### PR TITLE
Allow to use a context variable to set the port of `Http.Server`

### DIFF
--- a/docs/details/blocks/Http/Server.md
+++ b/docs/details/blocks/Http/Server.md
@@ -1,0 +1,2 @@
+The `:Port` is only set once, even if given a variable and that variable is changed during the execution of the loop.
+Having a variable is useful if the port to use is the result of a previous computation, otherwise a constant `int` can directly be used.

--- a/docs/samples/blocks/Http/Server/1.edn
+++ b/docs/samples/blocks/Http/Server/1.edn
@@ -1,0 +1,21 @@
+(def headers-self {"Cross-Origin-Opener-Policy" "same-origin"
+                   "Cross-Origin-Embedder-Policy" "require-corp"})
+(def headers-embed {"X-Frame-Options" ""
+                    "Access-Control-Allow-Origin" "*"})
+(def headers headers-self)
+(defloop handler
+  (Http.Read) = .request
+  (Take "target") >= .target (Log "target")
+
+  ; filter out query params
+  (Regex.Search #"(.*)\?") >= .matches
+  (Count .matches) (When (Is 2) (-> .matches (Take 1) > .target))
+
+  .target ;;(Log "target")
+  (Match
+   ["/" (-> "/index.html" (Http.SendFile headers))
+    nil (-> .target (Http.SendFile headers))]))
+
+(Http.Server
+ :Port 7070
+ :Handler handler)


### PR DESCRIPTION
Make the `:Port`parameter of `Http.Server` accept a context variable.

The rationale is that the port could be computed from previous blocks or that it could be part of a "retry" pattern with a list of possible ports. This will be useful in the Unity plugin to recover from a crashed server (where the socket might not have been released properly) or if two instances of Unity with the plugin are used from the same machine.

```clj
7070 = .port
(Http.Server :Port .port :Handler handler)
```

Documentation has a note to indicate that the port is only set once when the server initializes and if the variable is modified afterwards, the server is not affected.