### PR TITLE
Refactor Shards error propagation

### DIFF
--- a/include/common_types.hpp
+++ b/include/common_types.hpp
@@ -34,7 +34,7 @@ enum class BasicTypes {
   Bytes,
   String,
   Image,
-  Audio
+  Audio,
 };
 
 struct CoreInfo {

--- a/include/dllshard.hpp
+++ b/include/dllshard.hpp
@@ -135,7 +135,7 @@ public:
   }
 
   static SHWireState runShards2(Shards shards, SHContext *context, const SHVar &input, SHVar &output) {
-    return sCore._core->runShards(shards, context, &input, &output);
+    return sCore._core->runShards2(shards, context, &input, &output);
   }
 
   static void log(const char *msg) { sCore._core->log(msg); }

--- a/include/ops.hpp
+++ b/include/ops.hpp
@@ -13,9 +13,10 @@
 inline std::string type2Name(SHType type) {
   std::string name = "";
   switch (type) {
+  case SHType::Error:
   case EndOfBlittableTypes:
     // this should never happen
-    throw shards::SHException("EndOfBlittableTypes is an invalid type");
+    throw shards::SHException("EndOfBlittableTypes and Error are invalid types");
   case None:
     name = "None";
     break;
@@ -136,6 +137,7 @@ ALWAYS_INLINE inline bool operator==(const SHVar &a, const SHVar &b) {
   case None:
   case SHType::Any:
   case EndOfBlittableTypes:
+  case SHType::Error:
     return true;
   case Object:
     return a.payload.objectVendorId == b.payload.objectVendorId && a.payload.objectTypeId == b.payload.objectTypeId &&

--- a/include/ops.hpp
+++ b/include/ops.hpp
@@ -13,7 +13,6 @@
 inline std::string type2Name(SHType type) {
   std::string name = "";
   switch (type) {
-  case SHType::Error:
   case EndOfBlittableTypes:
     // this should never happen
     throw shards::SHException("EndOfBlittableTypes and Error are invalid types");
@@ -137,7 +136,6 @@ ALWAYS_INLINE inline bool operator==(const SHVar &a, const SHVar &b) {
   case None:
   case SHType::Any:
   case EndOfBlittableTypes:
-  case SHType::Error:
     return true;
   case Object:
     return a.payload.objectVendorId == b.payload.objectVendorId && a.payload.objectTypeId == b.payload.objectTypeId &&

--- a/include/shards.h
+++ b/include/shards.h
@@ -315,8 +315,10 @@ struct SHError {
 #endif
 };
 
+#define SH_ERROR_NONE (0)
+
 #ifdef __cplusplus
-constexpr const SHError SHError::Success = {0, nullptr};
+constexpr const SHError SHError::Success = {SH_ERROR_NONE, nullptr};
 #endif
 
 // table interface

--- a/include/shards.h
+++ b/include/shards.h
@@ -309,7 +309,15 @@ struct SHAudio {
 struct SHError {
   uint8_t code; // 0 if no error, 1 if error so far
   SHString message;
+
+#ifdef __cplusplus
+  static const SHError Success;
+#endif
 };
+
+#ifdef __cplusplus
+constexpr const SHError SHError::Success = {0, nullptr};
+#endif
 
 // table interface
 typedef void(__cdecl *SHTableGetIterator)(struct SHTable table, SHTableIterator *outIter);

--- a/include/shards.h
+++ b/include/shards.h
@@ -302,6 +302,7 @@ struct SHAudio {
 };
 
 struct SHError {
+  uint32_t code; // 0 if no error
   SHString message;
   // TODO might need to add more
 };
@@ -437,6 +438,11 @@ struct SHTypeInfo {
   // inside the seqTypes or so)
   // Should not be considered when hashing this type
   SHBool recursiveSelf;
+};
+
+struct SHShardComposeResult {
+  struct SHError error;
+  struct SHTypeInfo result;
 };
 
 // if outData is NULL will just give you a valid outLen
@@ -695,10 +701,10 @@ typedef SHExposedTypesInfo(__cdecl *SHExposedVariablesProc)(struct Shard *);
 typedef SHExposedTypesInfo(__cdecl *SHRequiredVariablesProc)(struct Shard *);
 
 typedef SHParametersInfo(__cdecl *SHParametersProc)(struct Shard *);
-typedef void(__cdecl *SHSetParamProc)(struct Shard *, int, const struct SHVar *);
+typedef struct SHError(__cdecl *SHSetParamProc)(struct Shard *, int, const struct SHVar *);
 typedef struct SHVar(__cdecl *SHGetParamProc)(struct Shard *, int);
 
-typedef struct SHTypeInfo(__cdecl *SHComposeProc)(struct Shard *, struct SHInstanceData data);
+typedef struct SHShardComposeResult(__cdecl *SHComposeProc)(struct Shard *, struct SHInstanceData data);
 
 typedef void(__cdecl *SHComposedProc)(struct Shard *, const struct SHWire *wire, const struct SHComposeResult *data);
 
@@ -706,9 +712,9 @@ typedef void(__cdecl *SHComposedProc)(struct Shard *, const struct SHWire *wire,
 typedef struct SHVar(__cdecl *SHActivateProc)(struct Shard *, struct SHContext *, const struct SHVar *);
 
 // Generally when stop() is called
-typedef void(__cdecl *SHCleanupProc)(struct Shard *);
+typedef struct SHError(__cdecl *SHCleanupProc)(struct Shard *);
 
-typedef void(__cdecl *SHWarmupProc)(struct Shard *, struct SHContext *);
+typedef struct SHError(__cdecl *SHWarmupProc)(struct Shard *, struct SHContext *);
 
 typedef void(__cdecl *SHNextFrameProc)(struct Shard *, struct SHContext *);
 

--- a/include/shards.h
+++ b/include/shards.h
@@ -28,6 +28,9 @@ enum SHType : uint8_t {
   Color,    // A vector of 4 uint8
   ShardRef, // a shard, useful for future introspection shards!
 
+  Error = 49, // This is rather internal, but it's used to signal errors, actual high level wires should not have to deal with
+              // such type
+
   EndOfBlittableTypes = 50, // anything below this is not blittable (ish)
 
   Bytes, // pointer + size
@@ -41,7 +44,7 @@ enum SHType : uint8_t {
   Object,
   Array, // Notice: of just bilttable types/WIP!
   Set,
-  Audio
+  Audio,
 };
 
 enum SHWireState : uint8_t {
@@ -296,6 +299,11 @@ struct SHAudio {
   uint16_t nsamples;
   uint16_t channels;
   float *samples;
+};
+
+struct SHError {
+  SHString message;
+  // TODO might need to add more
 };
 
 // table interface
@@ -588,6 +596,8 @@ struct SHVarPayload {
     };
 
     SHPayloadArray arrayValue;
+
+    struct SHError errorValue;
   };
 } __attribute__((aligned(16)));
 

--- a/include/shards.hpp
+++ b/include/shards.hpp
@@ -888,6 +888,14 @@ struct Var : public SHVar {
     return res;
   }
 
+  static Var Error(const char *message, uint32_t code = 1) {
+    Var res{};
+    res.valueType = SHType::Error;
+    res.payload.errorValue.message = message;
+    res.payload.errorValue.code = code;
+    return res;
+  }
+
   uint32_t colorToInt() {
     if (valueType != Color) {
       throw InvalidVarTypeError("Invalid variable casting! expected Color");

--- a/include/shards.hpp
+++ b/include/shards.hpp
@@ -888,14 +888,6 @@ struct Var : public SHVar {
     return res;
   }
 
-  static Var Error(const char *message, uint32_t code = 1) {
-    Var res{};
-    res.valueType = SHType::Error;
-    res.payload.errorValue.message = message;
-    res.payload.errorValue.code = code;
-    return res;
-  }
-
   uint32_t colorToInt() {
     if (valueType != Color) {
       throw InvalidVarTypeError("Invalid variable casting! expected Color");
@@ -1089,6 +1081,8 @@ public:
 private:
   std::shared_ptr<SHWire> _wire;
 };
+
+void abortWire(struct SHContext *context, std::string_view errorText);
 } // namespace shards
 
 inline SHVar *begin(SHVar &a) {

--- a/include/shardwrapper.hpp
+++ b/include/shardwrapper.hpp
@@ -157,14 +157,14 @@ template <class T> struct ShardWrapper {
       result->setParam = static_cast<SHSetParamProc>([](Shard *b, int i, const SHVar *v) {
         try {
           reinterpret_cast<ShardWrapper<T> *>(b)->shard.setParam(i, *v);
-          return SHError{0};
+          return SHError::Success;
         } catch (const std::exception &e) {
           reinterpret_cast<ShardWrapper<T> *>(b)->lastError.assign(e.what());
           return SHError{1, reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str()};
         }
       });
     } else {
-      result->setParam = static_cast<SHSetParamProc>([](Shard *b, int i, const SHVar *v) { return SHError{0}; });
+      result->setParam = static_cast<SHSetParamProc>([](Shard *b, int i, const SHVar *v) { return SHError::Success; });
     }
 
     // getParam
@@ -179,7 +179,7 @@ template <class T> struct ShardWrapper {
     if constexpr (has_compose<T>::value) {
       result->compose = static_cast<SHComposeProc>([](Shard *b, SHInstanceData data) {
         try {
-          return SHShardComposeResult{SHError{0}, reinterpret_cast<ShardWrapper<T> *>(b)->shard.compose(data)};
+          return SHShardComposeResult{SHError::Success, reinterpret_cast<ShardWrapper<T> *>(b)->shard.compose(data)};
         } catch (std::exception &e) {
           reinterpret_cast<ShardWrapper<T> *>(b)->lastError.assign(e.what());
           return SHShardComposeResult{SHError{1, reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str()}, SHTypeInfo{}};
@@ -205,7 +205,7 @@ template <class T> struct ShardWrapper {
       result->warmup = static_cast<SHWarmupProc>([](Shard *b, SHContext *ctx) {
         try {
           reinterpret_cast<ShardWrapper<T> *>(b)->shard.warmup(ctx);
-          return SHError{0};
+          return SHError::Success;
         } catch (const std::exception &e) {
           reinterpret_cast<ShardWrapper<T> *>(b)->lastError.assign(e.what());
           return SHError{1, reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str()};
@@ -243,14 +243,14 @@ template <class T> struct ShardWrapper {
       result->cleanup = static_cast<SHCleanupProc>([](Shard *b) {
         try {
           reinterpret_cast<ShardWrapper<T> *>(b)->shard.cleanup();
-          return SHError{0};
+          return SHError::Success;
         } catch (const std::exception &e) {
           reinterpret_cast<ShardWrapper<T> *>(b)->lastError.assign(e.what());
           return SHError{1, reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str()};
         }
       });
     } else {
-      result->cleanup = static_cast<SHCleanupProc>([](Shard *b) { return SHError{0}; });
+      result->cleanup = static_cast<SHCleanupProc>([](Shard *b) { return SHError::Success; });
     }
 
     // mutate

--- a/include/shardwrapper.hpp
+++ b/include/shardwrapper.hpp
@@ -229,7 +229,12 @@ template <class T> struct ShardWrapper {
     static_assert(has_activate<T>::value, "Shards must have an \"activate\" method.");
     if constexpr (has_activate<T>::value) {
       result->activate = static_cast<SHActivateProc>([](Shard *b, SHContext *ctx, const SHVar *v) {
-        return reinterpret_cast<ShardWrapper<T> *>(b)->shard.activate(ctx, *v);
+        try {
+          return reinterpret_cast<ShardWrapper<T> *>(b)->shard.activate(ctx, *v);
+        } catch (const std::exception &e) {
+          reinterpret_cast<ShardWrapper<T> *>(b)->lastError.assign(e.what());
+          return SHVar(shards::Var::Error(reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str()));
+        }
       });
     }
 

--- a/include/shardwrapper.hpp
+++ b/include/shardwrapper.hpp
@@ -233,7 +233,8 @@ template <class T> struct ShardWrapper {
           return reinterpret_cast<ShardWrapper<T> *>(b)->shard.activate(ctx, *v);
         } catch (const std::exception &e) {
           reinterpret_cast<ShardWrapper<T> *>(b)->lastError.assign(e.what());
-          return SHVar(shards::Var::Error(reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str()));
+          shards::abortWire(ctx, reinterpret_cast<ShardWrapper<T> *>(b)->lastError.c_str());
+          return SHVar{};
         }
       });
     }

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -433,7 +433,11 @@ private:
   void destroy() {
     for (auto it = _shardsArray.rbegin(); it != _shardsArray.rend(); ++it) {
       auto blk = *it;
-      blk->cleanup(blk);
+      auto errors = blk->cleanup(blk);
+      if (errors.code != 0) {
+        auto msg = "TShardsVar: Error during blocks cleanup: " + std::string(errors.message);
+        SH_CORE::log(msg.c_str());
+      }
       blk->destroy(blk);
     }
     _shardsArray.clear();
@@ -450,13 +454,10 @@ public:
   void cleanup() {
     for (auto it = _shardsArray.rbegin(); it != _shardsArray.rend(); ++it) {
       auto blk = *it;
-      try {
-        blk->cleanup(blk);
-      } catch (const std::exception &e) {
-        std::string msg = "Shard cleanup error, failed shard: " + std::string(blk->name(blk)) + ", error: " + e.what();
-        SH_CORE::log(msg.c_str());
-      } catch (...) {
-        std::string msg = "Shard cleanup generic error, failed shard: " + std::string(blk->name(blk));
+
+      auto errors = blk->cleanup(blk);
+      if (errors.code != 0) {
+        auto msg = "TShardsVar: Error during blocks cleanup: " + std::string(errors.message);
         SH_CORE::log(msg.c_str());
       }
     }

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -465,8 +465,12 @@ public:
 
   void warmup(SHContext *context) {
     for (auto &blk : _shardsArray) {
-      if (blk->warmup)
-        blk->warmup(blk, context);
+      if (blk->warmup) {
+        auto errors = blk->warmup(blk, context);
+        if (errors.code != 0) {
+          throw WarmupError(errors.message);
+        }
+      }
     }
   }
 

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -434,7 +434,7 @@ private:
     for (auto it = _shardsArray.rbegin(); it != _shardsArray.rend(); ++it) {
       auto blk = *it;
       auto errors = blk->cleanup(blk);
-      if (errors.code != 0) {
+      if (errors.code != SH_ERROR_NONE) {
         auto msg = "TShardsVar: Error during blocks cleanup: " + std::string(errors.message);
         SH_CORE::log(msg.c_str());
       }
@@ -456,7 +456,7 @@ public:
       auto blk = *it;
 
       auto errors = blk->cleanup(blk);
-      if (errors.code != 0) {
+      if (errors.code != SH_ERROR_NONE) {
         auto msg = "TShardsVar: Error during blocks cleanup: " + std::string(errors.message);
         SH_CORE::log(msg.c_str());
       }
@@ -467,7 +467,7 @@ public:
     for (auto &blk : _shardsArray) {
       if (blk->warmup) {
         auto errors = blk->warmup(blk, context);
-        if (errors.code != 0) {
+        if (errors.code != SH_ERROR_NONE) {
           throw WarmupError(errors.message);
         }
       }

--- a/rust/src/shard.rs
+++ b/rust/src/shard.rs
@@ -204,10 +204,7 @@ unsafe extern "C" fn shard_destroy<T: Shard>(arg1: *mut CShard) {
 unsafe extern "C" fn shard_warmup<T: Shard>(arg1: *mut CShard, arg2: *mut SHContext) -> SHError {
   let blk = arg1 as *mut ShardWrapper<T>;
   match (*blk).shard.warmup(&(*arg2)) {
-    Ok(_) => SHError {
-      message: core::ptr::null(),
-      code: 0,
-    },
+    Ok(_) => SHError::default(),
     Err(error) => {
       (*blk).error = Some(CString::new(error).expect("CString::new failed"));
       SHError {
@@ -248,10 +245,7 @@ unsafe extern "C" fn shard_mutate<T: Shard>(arg1: *mut CShard, arg2: SHTable) {
 unsafe extern "C" fn shard_cleanup<T: Shard>(arg1: *mut CShard) -> SHError {
   let blk = arg1 as *mut ShardWrapper<T>;
   match (*blk).shard.cleanup() {
-    Ok(_) => SHError {
-      message: core::ptr::null(),
-      code: 0,
-    },
+    Ok(_) => SHError::default(),
     Err(error) => {
       (*blk).error = Some(CString::new(error).expect("CString::new failed"));
       SHError {
@@ -287,10 +281,7 @@ unsafe extern "C" fn shard_compose<T: Shard>(
   let blk = arg1 as *mut ShardWrapper<T>;
   match (*blk).shard.compose(&data) {
     Ok(output) => SHShardComposeResult {
-      error: SHError {
-        message: core::ptr::null(),
-        code: 0,
-      },
+      error: SHError::default(),
       result: output,
     },
     Err(error) => {
@@ -344,10 +335,7 @@ unsafe extern "C" fn shard_setParam<T: Shard>(
 ) -> SHError {
   let blk = arg1 as *mut ShardWrapper<T>;
   match (*blk).shard.setParam(arg2, &*arg3) {
-    Ok(_) => SHError {
-      message: core::ptr::null(),
-      code: 0,
-    },
+    Ok(_) => SHError::default(),
     Err(error) => {
       (*blk).error = Some(CString::new(error).expect("CString::new failed"));
       SHError {

--- a/rust/src/shards/casting.rs
+++ b/rust/src/shards/casting.rs
@@ -161,9 +161,9 @@ impl Shard for ToLEB128 {
     Some(&LEB_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.signed = value.try_into().unwrap(),
+      0 => Ok(self.signed = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -230,9 +230,9 @@ impl Shard for FromLEB128 {
     Some(&LEB_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.signed = value.try_into().unwrap(),
+      0 => Ok(self.signed = value.try_into()?),
       _ => unreachable!(),
     }
   }

--- a/rust/src/shards/chachapoly.rs
+++ b/rust/src/shards/chachapoly.rs
@@ -67,9 +67,9 @@ impl Shard for Encrypt {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.key.set_param(value),
+      0 => Ok(self.key.set_param(value)),
       _ => unreachable!(),
     }
   }
@@ -86,8 +86,9 @@ impl Shard for Encrypt {
     Ok(())
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.key.cleanup();
+    Ok(())
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
@@ -166,9 +167,9 @@ impl Shard for Decrypt {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.key.set_param(value),
+      0 => Ok(self.key.set_param(value)),
       _ => unreachable!(),
     }
   }
@@ -185,8 +186,9 @@ impl Shard for Decrypt {
     Ok(())
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.key.cleanup();
+    Ok(())
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {

--- a/rust/src/shards/csv.rs
+++ b/rust/src/shards/csv.rs
@@ -99,10 +99,10 @@ impl Shard for CSVRead {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.no_header = value.try_into().unwrap(),
-      1 => self.separator = value.try_into().unwrap(),
+      0 => Ok(self.no_header = value.try_into()?),
+      1 => Ok(self.separator = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -195,10 +195,10 @@ impl Shard for CSVWrite {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.no_header = value.try_into().unwrap(),
-      1 => self.separator = value.try_into().unwrap(),
+      0 => Ok(self.no_header = value.try_into().unwrap()),
+      1 => Ok(self.separator = value.try_into().unwrap()),
       _ => unreachable!(),
     }
   }

--- a/rust/src/shards/curve25519.rs
+++ b/rust/src/shards/curve25519.rs
@@ -104,9 +104,9 @@ macro_rules! add_signer {
         Some(&PARAMETERS)
       }
 
-      fn setParam(&mut self, index: i32, value: &Var) {
+      fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
         match index {
-          0 => self.key.set_param(value),
+          0 => Ok(self.key.set_param(value)),
           _ => unreachable!(),
         }
       }
@@ -123,8 +123,9 @@ macro_rules! add_signer {
         Ok(())
       }
 
-      fn cleanup(&mut self) {
+      fn cleanup(&mut self) -> Result<(), &str> {
         self.key.cleanup();
+        Ok(())
       }
 
       fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {

--- a/rust/src/shards/ecdsa.rs
+++ b/rust/src/shards/ecdsa.rs
@@ -119,9 +119,9 @@ impl Shard for ECDSASign {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.key.set_param(value),
+      0 => Ok(self.key.set_param(value)),
       _ => unreachable!(),
     }
   }
@@ -138,8 +138,9 @@ impl Shard for ECDSASign {
     Ok(())
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.key.cleanup();
+    Ok(())
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
@@ -193,9 +194,9 @@ impl Shard for ECDSAPubKey {
     Some(&PK_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.compressed = value.try_into().unwrap(),
+      0 => Ok(self.compressed = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -252,9 +253,9 @@ impl Shard for ECDSAPrivKey {
     Some(&PK_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.compressed = value.try_into().unwrap(),
+      0 => Ok(self.compressed = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -306,10 +307,10 @@ impl Shard for ECDSARecover {
     Some(&SIG_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.signature.set_param(value),
-      1 => self.compressed = value.try_into().unwrap(),
+      0 => Ok(self.signature.set_param(value)),
+      1 => Ok(self.compressed = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -327,8 +328,9 @@ impl Shard for ECDSARecover {
     Ok(())
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.signature.cleanup();
+    Ok(())
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {

--- a/rust/src/shards/eth.rs
+++ b/rust/src/shards/eth.rs
@@ -172,10 +172,10 @@ impl Shard for EncodeCall {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.abi.set_param(value),
-      1 => self.call_name.set_param(value),
+      0 => Ok(self.abi.set_param(value)),
+      1 => Ok(self.call_name.set_param(value)),
       _ => unreachable!(),
     }
   }
@@ -194,9 +194,10 @@ impl Shard for EncodeCall {
     Ok(())
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.abi.cleanup();
     self.call_name.cleanup();
+    Ok(())
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
@@ -306,11 +307,11 @@ impl Shard for DecodeCall {
     Some(&DECODE_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.abi.set_param(value),
-      1 => self.call_name.set_param(value),
-      2 => self.is_input = value.try_into().unwrap(),
+      0 => Ok(self.abi.set_param(value)),
+      1 => Ok(self.call_name.set_param(value)),
+      2 => Ok(self.is_input = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -330,9 +331,10 @@ impl Shard for DecodeCall {
     Ok(())
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.abi.cleanup();
     self.call_name.cleanup();
+    Ok(())
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {

--- a/rust/src/shards/http.rs
+++ b/rust/src/shards/http.rs
@@ -258,8 +258,9 @@ macro_rules! get_like {
         self.rb._parameters()
       }
 
-      fn setParam(&mut self, index: i32, value: &Var) {
+      fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
         self.rb._setParam(index, value);
+        Ok(())
       }
 
       fn getParam(&mut self, index: i32) -> Var {
@@ -270,8 +271,9 @@ macro_rules! get_like {
         self.rb._warmup(context)
       }
 
-      fn cleanup(&mut self) {
+      fn cleanup(&mut self) -> Result<(), &str> {
         self.rb._cleanup();
+        Ok(())
       }
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
@@ -351,8 +353,9 @@ macro_rules! post_like {
         self.rb._parameters()
       }
 
-      fn setParam(&mut self, index: i32, value: &Var) {
+      fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
         self.rb._setParam(index, value);
+        Ok(())
       }
 
       fn getParam(&mut self, index: i32) -> Var {
@@ -363,8 +366,9 @@ macro_rules! post_like {
         self.rb._warmup(context)
       }
 
-      fn cleanup(&mut self) {
+      fn cleanup(&mut self) -> Result<(), &str> {
         self.rb._cleanup();
+        Ok(())
       }
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {

--- a/rust/src/shards/physics/forces.rs
+++ b/rust/src/shards/physics/forces.rs
@@ -79,11 +79,13 @@ impl Shard for Impulse {
   fn parameters(&mut self) -> Option<&Parameters> {
     Some(&PARAMETERS)
   }
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
       0 => {
         if !value.is_none() {
-          self.rb.set_name(value.try_into().unwrap())
+          Ok(self.rb.set_name(value.try_into()?))
+        } else {
+          Ok(())
         }
       }
       _ => unreachable!(),
@@ -117,9 +119,10 @@ impl Shard for Impulse {
     }
     Some(&self.reqs)
   }
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.rb.cleanup();
     self.simulation.cleanup();
+    Ok(())
   }
   fn warmup(&mut self, context: &Context) -> Result<(), &str> {
     self.rb.warmup(context);

--- a/rust/src/shards/physics/queries.rs
+++ b/rust/src/shards/physics/queries.rs
@@ -73,8 +73,9 @@ impl Shard for CastRay {
   fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
     Some(&EXPOSED_SIMULATION)
   }
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.simulation_var.cleanup();
+    Ok(())
   }
   fn warmup(&mut self, context: &Context) -> Result<(), &str> {
     self.simulation_var.warmup(context);

--- a/rust/src/shards/physics/rigidbody.rs
+++ b/rust/src/shards/physics/rigidbody.rs
@@ -396,12 +396,18 @@ impl Shard for StaticRigidBody {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 | 1 | 2 => Rc::get_mut(&mut self.rb).unwrap()._set_param(index, value),
+      0 | 1 | 2 => Ok(
+        Rc::get_mut(&mut self.rb)
+          .map(|x| x._set_param(index, value))
+          .ok_or_else(|| "Failed to set Rc param")?,
+      ),
       3 => {
         if !value.is_none() {
-          self.self_obj.set_name(value.try_into().unwrap())
+          Ok(self.self_obj.set_name(value.try_into()?))
+        } else {
+          Ok(())
         }
       }
       _ => unreachable!(),
@@ -442,9 +448,10 @@ impl Shard for StaticRigidBody {
     }
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.self_obj.cleanup();
-    Rc::get_mut(&mut self.rb).unwrap()._cleanup();
+    Rc::get_mut(&mut self.rb).map(|x| x._cleanup());
+    Ok(())
   }
 
   fn warmup(&mut self, context: &Context) -> Result<(), &str> {
@@ -523,12 +530,18 @@ impl Shard for DynamicRigidBody {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 | 1 | 2 => Rc::get_mut(&mut self.rb).unwrap()._set_param(index, value),
+      0 | 1 | 2 => Ok(
+        Rc::get_mut(&mut self.rb)
+          .map(|x| x._set_param(index, value))
+          .ok_or_else(|| "Failed to set Rc param")?,
+      ),
       3 => {
         if !value.is_none() {
-          self.self_obj.set_name(value.try_into().unwrap())
+          Ok(self.self_obj.set_name(value.try_into()?))
+        } else {
+          Ok(())
         }
       }
       _ => unreachable!(),
@@ -569,9 +582,10 @@ impl Shard for DynamicRigidBody {
     }
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.self_obj.cleanup();
-    Rc::get_mut(&mut self.rb).unwrap()._cleanup();
+    Rc::get_mut(&mut self.rb).map(|x| x._cleanup());
+    Ok(())
   }
 
   fn warmup(&mut self, context: &Context) -> Result<(), &str> {
@@ -660,12 +674,18 @@ impl Shard for KinematicRigidBody {
     Some(&PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 | 1 | 2 => Rc::get_mut(&mut self.rb).unwrap()._set_param(index, value),
+      0 | 1 | 2 => Ok(
+        Rc::get_mut(&mut self.rb)
+          .map(|x| x._set_param(index, value))
+          .ok_or_else(|| "Failed to set Rc param")?,
+      ),
       3 => {
         if !value.is_none() {
-          self.self_obj.set_name(value.try_into().unwrap())
+          Ok(self.self_obj.set_name(value.try_into()?))
+        } else {
+          Ok(())
         }
       }
       _ => unreachable!(),
@@ -706,9 +726,10 @@ impl Shard for KinematicRigidBody {
     }
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.self_obj.cleanup();
-    Rc::get_mut(&mut self.rb).unwrap()._cleanup();
+    Rc::get_mut(&mut self.rb).map(|x| x._cleanup());
+    Ok(())
   }
 
   fn warmup(&mut self, context: &Context) -> Result<(), &str> {

--- a/rust/src/shards/physics/shapes.rs
+++ b/rust/src/shards/physics/shapes.rs
@@ -73,11 +73,11 @@ macro_rules! shape {
         self._parameters()
       }
 
-      fn setParam(&mut self, index: i32, value: &Var) {
+      fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
         match index {
-          0 => self.position.set_param(value),
-          1 => self.rotation.set_param(value),
-          _ => self._set_param(index, value),
+          0 => Ok(self.position.set_param(value)),
+          1 => Ok(self.rotation.set_param(value)),
+          _ => Ok(self._set_param(index, value)),
         }
       }
 
@@ -89,11 +89,12 @@ macro_rules! shape {
         }
       }
 
-      fn cleanup(&mut self) {
+      fn cleanup(&mut self) -> Result<(), &str> {
         self.bs.shape = None;
         self.position.cleanup();
         self.rotation.cleanup();
         self._cleanup();
+        Ok(())
       }
 
       fn warmup(&mut self, context: &Context) -> Result<(), &str> {

--- a/rust/src/shards/physics/simulation.rs
+++ b/rust/src/shards/physics/simulation.rs
@@ -83,11 +83,12 @@ impl Shard for Simulation {
     Some(&SIMULATION_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
       0 => {
-        let (x, y, z) = value.try_into().unwrap();
+        let (x, y, z) = value.try_into()?;
         self.gravity = Vector3::new(x, y, z);
+        Ok(())
       }
       _ => unreachable!(),
     }
@@ -103,8 +104,9 @@ impl Shard for Simulation {
     Some(&EXPOSED_SIMULATION)
   }
 
-  fn cleanup(&mut self) {
+  fn cleanup(&mut self) -> Result<(), &str> {
     self.self_obj.cleanup();
+    Ok(())
   }
 
   fn warmup(&mut self, context: &Context) -> Result<(), &str> {

--- a/rust/src/shards/substrate.rs
+++ b/rust/src/shards/substrate.rs
@@ -174,10 +174,10 @@ impl Shard for AccountId {
     Some(&ID_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.is_ecdsa = value.try_into().unwrap(),
-      1 => self.version = value.try_into().unwrap(),
+      0 => Ok(self.is_ecdsa = value.try_into()?),
+      1 => Ok(self.version = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -317,9 +317,9 @@ impl Shard for SHStorageMap {
     Some(&STORAGE_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.pre_hashed = value.try_into().unwrap(),
+      0 => Ok(self.pre_hashed = value.try_into()?),
       _ => unreachable!(),
     }
   }
@@ -519,9 +519,9 @@ impl Shard for SHEncode {
     Some(&ENCODE_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.hints = value.into(),
+      0 => Ok(self.hints = value.into()),
       _ => unreachable!(),
     }
   }
@@ -606,11 +606,11 @@ impl Shard for SHDecode {
     Some(&DECODE_PARAMETERS)
   }
 
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => self.types = value.into(),
-      1 => self.hints = value.into(),
-      2 => self.version = value.try_into().expect("A valid integer var"),
+      0 => Ok(self.types = value.into()),
+      1 => Ok(self.hints = value.into()),
+      2 => Ok(self.version = value.try_into()?),
       _ => unreachable!(),
     }
   }

--- a/rust/src/shards/svg.rs
+++ b/rust/src/shards/svg.rs
@@ -84,11 +84,9 @@ impl Shard for ToImage {
   fn parameters(&mut self) -> Option<&Parameters> {
     Some(&PARAMETERS)
   }
-  fn setParam(&mut self, index: i32, value: &Var) {
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => {
-        self.size = value.try_into().unwrap();
-      }
+      0 => Ok(self.size = value.try_into()?),
       _ => unreachable!(),
     }
   }

--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -436,9 +436,6 @@ struct Globals {
   std::string RootPath;
   std::string ExePath;
 
-  std::exception_ptr StopWireEx;
-  std::exception_ptr RestartWireEx;
-
   std::unordered_map<uint32_t, SHOptionalString> *CompressedStrings{nullptr};
 
   SHTableInterface TableInterface{

--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -414,13 +414,6 @@ using SHMap = std::unordered_map<std::string, OwnedVar, std::hash<std::string>, 
                                  boost::alignment::aligned_allocator<std::pair<const std::string, OwnedVar>, 16>>;
 using SHMapIt = SHMap::iterator;
 
-struct StopWireException : public SHException {
-  StopWireException() : SHException("The wire has been stopped") {}
-};
-struct RestartWireException : public SHException {
-  RestartWireException() : SHException("The wire has been restarted") {}
-};
-
 struct Globals {
   // sporadically used, don't abuse. And don't use in real time code.
   std::mutex GlobalMutex;

--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -125,17 +125,17 @@ SHString getString(uint32_t crc);
 void setString(uint32_t crc, SHString str);
 [[nodiscard]] SHComposeResult composeWire(const Shards wire, SHValidationCallback callback, void *userData, SHInstanceData data);
 // caller does not handle return
-SHWireState activateShards(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output);
+SHWireState activateShards(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept;
 // caller handles return
-SHWireState activateShards2(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output);
+SHWireState activateShards2(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept;
 // caller does not handle return
-SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output);
+SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept;
 // caller handles return
-SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output);
+SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept;
 // caller does not handle return
-SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash);
+SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash) noexcept;
 // caller handles return
-SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash);
+SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash) noexcept;
 SHVar *referenceGlobalVariable(SHContext *ctx, const char *name);
 SHVar *referenceVariable(SHContext *ctx, const char *name);
 void releaseVariable(SHVar *variable);

--- a/src/core/ops_internal.cpp
+++ b/src/core/ops_internal.cpp
@@ -10,9 +10,6 @@ std::ostream &operator<<(std::ostream &os, const SHVar &var) {
   switch (var.valueType) {
   case SHType::EndOfBlittableTypes:
     break;
-  case SHType::Error:
-    os << "Error, Code: " << var.payload.errorValue.code << " Message: " << var.payload.errorValue.message;
-    break;
   case SHType::None:
     os << "None";
     break;

--- a/src/core/ops_internal.cpp
+++ b/src/core/ops_internal.cpp
@@ -11,7 +11,7 @@ std::ostream &operator<<(std::ostream &os, const SHVar &var) {
   case SHType::EndOfBlittableTypes:
     break;
   case SHType::Error:
-    os << "Error: " << var.payload.errorValue.message;
+    os << "Error, Code: " << var.payload.errorValue.code << " Message: " << var.payload.errorValue.message;
     break;
   case SHType::None:
     os << "None";

--- a/src/core/ops_internal.cpp
+++ b/src/core/ops_internal.cpp
@@ -10,6 +10,9 @@ std::ostream &operator<<(std::ostream &os, const SHVar &var) {
   switch (var.valueType) {
   case SHType::EndOfBlittableTypes:
     break;
+  case SHType::Error:
+    os << "Error: " << var.payload.errorValue.message;
+    break;
   case SHType::None:
     os << "None";
     break;

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -2620,6 +2620,7 @@ void Serialization::varFree(SHVar &output) {
   switch (output.valueType) {
   case SHType::None:
   case SHType::EndOfBlittableTypes:
+  case SHType::Error:
   case SHType::Any:
   case SHType::Enum:
   case SHType::Bool:

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -727,7 +727,7 @@ ALWAYS_INLINE SHWireState shardsActivation(T &shards, SHContext *context, const 
     outHash->valueType = SHType::Int2;
     outHash->payload.int2Value[0] = int64_t(digest.low64);
     outHash->payload.int2Value[1] = int64_t(digest.high64);
-    SHLOG_TRACE("Hashing digested {}", *outHash);
+    SHLOG_TRACE("Hash digested {}", *outHash);
   });
 
   // store initial input

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -1086,7 +1086,7 @@ void validateConnection(ValidationContext &ctx) {
     // this ensures e.g. SetVariable exposedVars have right type from the actual
     // input type (previousOutput)!
     auto composeResult = ctx.bottom->compose(ctx.bottom, data);
-    if (composeResult.error.code != 0) {
+    if (composeResult.error.code != SH_ERROR_NONE) {
       SHLOG_ERROR("Error composing shard: %s", composeResult.error.message);
       throw ComposeError(composeResult.error.message);
     }

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -809,27 +809,27 @@ ALWAYS_INLINE SHWireState shardsActivation(T &shards, SHContext *context, const 
   return SHWireState::Continue;
 }
 
-SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output) {
+SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept {
   return shardsActivation<Shards, false, false>(shards, context, wireInput, output);
 }
 
-SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output) {
+SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept {
   return shardsActivation<Shards, true, false>(shards, context, wireInput, output);
 }
 
-SHWireState activateShards(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output) {
+SHWireState activateShards(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept {
   return shardsActivation<SHSeq, false, false>(shards, context, wireInput, output);
 }
 
-SHWireState activateShards2(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output) {
+SHWireState activateShards2(SHSeq shards, SHContext *context, const SHVar &wireInput, SHVar &output) noexcept {
   return shardsActivation<SHSeq, true, false>(shards, context, wireInput, output);
 }
 
-SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash) {
+SHWireState activateShards(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash) noexcept {
   return shardsActivation<Shards, false, true>(shards, context, wireInput, output, &outHash);
 }
 
-SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash) {
+SHWireState activateShards2(Shards shards, SHContext *context, const SHVar &wireInput, SHVar &output, SHVar &outHash) noexcept {
   return shardsActivation<Shards, true, true>(shards, context, wireInput, output, &outHash);
 }
 
@@ -3026,51 +3026,19 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
   };
 
   result->runShards = [](Shards shards, SHContext *context, const SHVar *input, SHVar *output) noexcept {
-    try {
-      return shards::activateShards(shards, context, *input, *output);
-    } catch (const std::exception &e) {
-      context->cancelFlow(e.what());
-      return SHWireState::Stop;
-    } catch (...) {
-      context->cancelFlow("foreign exception failure during runShards");
-      return SHWireState::Stop;
-    }
+    return shards::activateShards(shards, context, *input, *output);
   };
 
   result->runShards2 = [](Shards shards, SHContext *context, const SHVar *input, SHVar *output) noexcept {
-    try {
-      return shards::activateShards2(shards, context, *input, *output);
-    } catch (const std::exception &e) {
-      context->cancelFlow(e.what());
-      return SHWireState::Stop;
-    } catch (...) {
-      context->cancelFlow("foreign exception failure during runShards");
-      return SHWireState::Stop;
-    }
+    return shards::activateShards2(shards, context, *input, *output);
   };
 
   result->runShardsHashed = [](Shards shards, SHContext *context, const SHVar *input, SHVar *output, SHVar *outHash) noexcept {
-    try {
-      return shards::activateShards(shards, context, *input, *output, *outHash);
-    } catch (const std::exception &e) {
-      context->cancelFlow(e.what());
-      return SHWireState::Stop;
-    } catch (...) {
-      context->cancelFlow("foreign exception failure during runShards");
-      return SHWireState::Stop;
-    }
+    return shards::activateShards(shards, context, *input, *output, *outHash);
   };
 
   result->runShardsHashed2 = [](Shards shards, SHContext *context, const SHVar *input, SHVar *output, SHVar *outHash) noexcept {
-    try {
-      return shards::activateShards2(shards, context, *input, *output, *outHash);
-    } catch (const std::exception &e) {
-      context->cancelFlow(e.what());
-      return SHWireState::Stop;
-    } catch (...) {
-      context->cancelFlow("foreign exception failure during runShards");
-      return SHWireState::Stop;
-    }
+    return shards::activateShards2(shards, context, *input, *output, *outHash);
   };
 
   result->getWireInfo = [](SHWireRef wireref) noexcept {

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -1115,7 +1115,12 @@ void validateConnection(ValidationContext &ctx) {
 
     // this ensures e.g. SetVariable exposedVars have right type from the actual
     // input type (previousOutput)!
-    ctx.previousOutputType = ctx.bottom->compose(ctx.bottom, data);
+    auto composeResult = ctx.bottom->compose(ctx.bottom, data);
+    if (composeResult.error.code != 0) {
+      SHLOG_ERROR("Error composing shard: %s", composeResult.error.message);
+      throw ComposeError(composeResult.error.message);
+    }
+    ctx.previousOutputType = composeResult.result;
 
     if (externalCtx.externalFailure) {
       if (externalCtx.warning) {

--- a/src/core/runtime.hpp
+++ b/src/core/runtime.hpp
@@ -838,6 +838,7 @@ struct Serialization {
     switch (output.valueType) {
     case SHType::None:
     case SHType::EndOfBlittableTypes:
+    case SHType::Error: // this is not a valid type we want to serialize...
     case SHType::Any:
       break;
     case SHType::Enum:
@@ -1185,6 +1186,7 @@ struct Serialization {
     switch (input.valueType) {
     case SHType::None:
     case SHType::EndOfBlittableTypes:
+    case SHType::Error: // this is not a valid type we want to serialize...
     case SHType::Any:
       break;
     case SHType::Enum:

--- a/src/core/runtime.hpp
+++ b/src/core/runtime.hpp
@@ -178,14 +178,6 @@ FLATTEN ALWAYS_INLINE inline SHVar activateShard(Shard *blk, SHContext *context,
     auto shard = reinterpret_cast<shards::ShardWrapper<Const> *>(blk);
     return shard->shard._value;
   }
-  case CoreIs: {
-    auto shard = reinterpret_cast<shards::IsRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case CoreIsNot: {
-    auto shard = reinterpret_cast<shards::IsNotRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
   case CoreAnd: {
     auto shard = reinterpret_cast<shards::AndRuntime *>(blk);
     return shard->core.activate(context, input);
@@ -198,26 +190,6 @@ FLATTEN ALWAYS_INLINE inline SHVar activateShard(Shard *blk, SHContext *context,
     auto shard = reinterpret_cast<shards::NotRuntime *>(blk);
     return shard->core.activate(context, input);
   }
-  case CoreIsMore: {
-    auto shard = reinterpret_cast<shards::IsMoreRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case CoreIsLess: {
-    auto shard = reinterpret_cast<shards::IsLessRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case CoreIsMoreEqual: {
-    auto shard = reinterpret_cast<shards::IsMoreEqualRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case CoreIsLessEqual: {
-    auto shard = reinterpret_cast<shards::IsLessEqualRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case CoreSleep: {
-    auto shard = reinterpret_cast<shards::ShardWrapper<Pause> *>(blk);
-    return shard->shard.activate(context, input);
-  }
   case CoreInput: {
     auto shard = reinterpret_cast<shards::ShardWrapper<Input> *>(blk);
     return shard->shard.activate(context, input);
@@ -225,18 +197,6 @@ FLATTEN ALWAYS_INLINE inline SHVar activateShard(Shard *blk, SHContext *context,
   case CorePush: {
     auto shard = reinterpret_cast<shards::PushRuntime *>(blk);
     return shard->core.activate(context, input);
-  }
-  case CoreForRange: {
-    auto shard = reinterpret_cast<shards::ShardWrapper<ForRangeShard> *>(blk);
-    return shard->shard.activate(context, input);
-  }
-  case CoreRepeat: {
-    auto shard = reinterpret_cast<shards::RepeatRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case CoreOnce: {
-    auto shard = reinterpret_cast<shards::ShardWrapper<Once> *>(blk);
-    return shard->shard.activate(context, input);
   }
   case CoreGet: {
     auto shard = reinterpret_cast<shards::GetRuntime *>(blk);
@@ -261,176 +221,6 @@ FLATTEN ALWAYS_INLINE inline SHVar activateShard(Shard *blk, SHContext *context,
   case CoreSwap: {
     auto shard = reinterpret_cast<shards::SwapRuntime *>(blk);
     return shard->core.activate(context, input);
-  }
-  case MathAdd: {
-    auto shard = reinterpret_cast<shards::Math::AddRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathSubtract: {
-    auto shard = reinterpret_cast<shards::Math::SubtractRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathMultiply: {
-    auto shard = reinterpret_cast<shards::Math::MultiplyRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathDivide: {
-    auto shard = reinterpret_cast<shards::Math::DivideRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathXor: {
-    auto shard = reinterpret_cast<shards::Math::XorRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathAnd: {
-    auto shard = reinterpret_cast<shards::Math::AndRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathOr: {
-    auto shard = reinterpret_cast<shards::Math::OrRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathMod: {
-    auto shard = reinterpret_cast<shards::Math::ModRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathLShift: {
-    auto shard = reinterpret_cast<shards::Math::LShiftRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathRShift: {
-    auto shard = reinterpret_cast<shards::Math::RShiftRuntime *>(blk);
-    return shard->core.activate(context, input);
-  }
-  case MathAbs: {
-    auto shard = reinterpret_cast<shards::Math::AbsRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathFastSqrt: {
-    auto shard = reinterpret_cast<shards::Math::FastSqrtRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathFastInvSqrt: {
-    auto shard = reinterpret_cast<shards::Math::FastInvSqrtRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-#if 0
-  case MathExp: {
-    auto shard = reinterpret_cast<shards::Math::ExpRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathExp2: {
-    auto shard = reinterpret_cast<shards::Math::Exp2Runtime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathExpm1: {
-    auto shard = reinterpret_cast<shards::Math::Expm1Runtime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathLog: {
-    auto shard = reinterpret_cast<shards::Math::LogRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathLog10: {
-    auto shard = reinterpret_cast<shards::Math::Log10Runtime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathLog2: {
-    auto shard = reinterpret_cast<shards::Math::Log2Runtime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathLog1p: {
-    auto shard = reinterpret_cast<shards::Math::Log1pRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathSqrt: {
-    auto shard = reinterpret_cast<shards::Math::SqrtRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathCbrt: {
-    auto shard = reinterpret_cast<shards::Math::CbrtRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathSin: {
-    auto shard = reinterpret_cast<shards::Math::SinRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathCos: {
-    auto shard = reinterpret_cast<shards::Math::CosRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathTan: {
-    auto shard = reinterpret_cast<shards::Math::TanRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathAsin: {
-    auto shard = reinterpret_cast<shards::Math::AsinRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathAcos: {
-    auto shard = reinterpret_cast<shards::Math::AcosRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathAtan: {
-    auto shard = reinterpret_cast<shards::Math::AtanRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathSinh: {
-    auto shard = reinterpret_cast<shards::Math::SinhRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathCosh: {
-    auto shard = reinterpret_cast<shards::Math::CoshRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathTanh: {
-    auto shard = reinterpret_cast<shards::Math::TanhRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathAsinh: {
-    auto shard = reinterpret_cast<shards::Math::AsinhRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathAcosh: {
-    auto shard = reinterpret_cast<shards::Math::AcoshRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathAtanh: {
-    auto shard = reinterpret_cast<shards::Math::AtanhRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathErf: {
-    auto shard = reinterpret_cast<shards::Math::ErfRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathErfc: {
-    auto shard = reinterpret_cast<shards::Math::ErfcRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathTGamma: {
-    auto shard = reinterpret_cast<shards::Math::TGammaRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathLGamma: {
-    auto shard = reinterpret_cast<shards::Math::LGammaRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-#endif
-  case MathCeil: {
-    auto shard = reinterpret_cast<shards::Math::CeilRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathFloor: {
-    auto shard = reinterpret_cast<shards::Math::FloorRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathTrunc: {
-    auto shard = reinterpret_cast<shards::Math::TruncRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
-  }
-  case MathRound: {
-    auto shard = reinterpret_cast<shards::Math::RoundRuntime *>(blk);
-    return shard->core.activateSingle(context, input);
   }
   default: {
     // NotInline

--- a/src/core/runtime.hpp
+++ b/src/core/runtime.hpp
@@ -55,9 +55,6 @@ using SHTimeDiff = decltype(SHClock::now() - SHDuration(0.0));
   if (_suspend_state != SHWireState::Continue)                \
   return shards::Var::Empty
 
-#define SH_STOP() std::rethrow_exception(shards::GetGlobals().StopWireEx);
-#define SH_RESTART() std::rethrow_exception(shards::GetGlobals().RestartWireEx);
-
 struct SHContext {
   SHContext(
 #ifndef __EMSCRIPTEN__

--- a/src/core/runtime.hpp
+++ b/src/core/runtime.hpp
@@ -111,14 +111,8 @@ struct SHContext {
   }
 
   void cancelFlow(std::string_view message) {
-    state = SHWireState::Stop;
+    state = SHWireState::Error;
     errorMessage = message;
-    hasError = true;
-  }
-
-  void resetCancelFlow() {
-    state = SHWireState::Continue;
-    hasError = false;
   }
 
   constexpr void rebaseFlow() { state = SHWireState::Rebase; }
@@ -131,7 +125,7 @@ struct SHContext {
 
   constexpr bool shouldStop() const { return state == SHWireState::Stop; }
 
-  constexpr bool failed() const { return hasError; }
+  constexpr bool failed() const { return state == SHWireState::Error; }
 
   constexpr const std::string &getErrorMessage() { return errorMessage; }
 
@@ -148,7 +142,6 @@ private:
   // Used when flow is stopped/restart/return
   // to store the previous result
   SHVar flowStorage{};
-  bool hasError{false};
   std::string errorMessage;
   mutable std::vector<const Shard *> nextFrameShards;
 };
@@ -628,7 +621,6 @@ struct Serialization {
     switch (output.valueType) {
     case SHType::None:
     case SHType::EndOfBlittableTypes:
-    case SHType::Error: // this is not a valid type we want to serialize...
     case SHType::Any:
       break;
     case SHType::Enum:
@@ -976,7 +968,6 @@ struct Serialization {
     switch (input.valueType) {
     case SHType::None:
     case SHType::EndOfBlittableTypes:
-    case SHType::Error: // this is not a valid type we want to serialize...
     case SHType::Any:
       break;
     case SHType::Enum:

--- a/src/core/shards/core.hpp
+++ b/src/core/shards/core.hpp
@@ -386,7 +386,7 @@ struct OnCleanup {
         error = _context->getErrorMessage();
       }
       // we need to reset the state or only the first shard will run
-      _context->resetCancelFlow();
+      _context->continueFlow();
       _context->onCleanup = true; // this is kind of a hack
       _shards.activate(_context, shards::Var(error), output);
       // restore the terminal state

--- a/src/core/shards/flow.cpp
+++ b/src/core/shards/flow.cpp
@@ -476,7 +476,7 @@ struct Maybe : public BaseSubFlow {
           if (!_silent) {
             SHLOG_WARNING("Maybe shard Ignored an error: {}", ex.what());
           }
-          context->resetCancelFlow();
+          context->continueFlow();
           if (_elseBlks)
             _elseBlks.activate(context, input, output);
         } else {

--- a/src/core/shards/genetic.hpp
+++ b/src/core/shards/genetic.hpp
@@ -744,7 +744,11 @@ struct Mutant {
         if (mut.valueType == ShardRef) {
           auto blk = mut.payload.shardValue;
           if (blk->compose) {
-            auto res = blk->compose(blk, dataCopy);
+            auto res0 = blk->compose(blk, dataCopy);
+            if (res0.error.code != 0) {
+              throw ComposeError(res0.error.message);
+            }
+            auto res = res0.result;
             if (res != ptype) {
               throw SHException("Expected same type as input in parameter "
                                 "mutation wire's output.");
@@ -1072,7 +1076,11 @@ struct DShard {
     }
     // and compose finally
     if (_wrapped->compose) {
-      return _wrapped->compose(_wrapped, data);
+      auto res = _wrapped->compose(_wrapped, data);
+      if (res.error.code != 0) {
+        throw SHException("Failed to compose a wrapped DShard.");
+      }
+      return res.result;
     } else {
       // need to return something valid following runtime validation
       auto outputTypes = _wrapped->outputTypes(_wrapped);

--- a/src/core/shards/genetic.hpp
+++ b/src/core/shards/genetic.hpp
@@ -745,7 +745,7 @@ struct Mutant {
           auto blk = mut.payload.shardValue;
           if (blk->compose) {
             auto res0 = blk->compose(blk, dataCopy);
-            if (res0.error.code != 0) {
+            if (res0.error.code != SH_ERROR_NONE) {
               throw ComposeError(res0.error.message);
             }
             auto res = res0.result;

--- a/src/core/shards/json.cpp
+++ b/src/core/shards/json.cpp
@@ -61,6 +61,7 @@ void to_json(json &j, const SHVar &var) {
   switch (var.valueType) {
   case SHType::Any:
   case SHType::EndOfBlittableTypes:
+  case SHType::Error: // this is not a valid type we want to serialize...
   case SHType::None: {
     j = json{{"type", valType}};
     break;
@@ -281,6 +282,7 @@ void from_json(const json &j, SHVar &var) {
   switch (valType.value()) {
   case SHType::Any:
   case SHType::EndOfBlittableTypes:
+  case SHType::Error: // this is not a valid type we want to serialize...
   case SHType::None: {
     var = {};
     var.valueType = valType.value();

--- a/src/core/shards/json.cpp
+++ b/src/core/shards/json.cpp
@@ -61,7 +61,6 @@ void to_json(json &j, const SHVar &var) {
   switch (var.valueType) {
   case SHType::Any:
   case SHType::EndOfBlittableTypes:
-  case SHType::Error: // this is not a valid type we want to serialize...
   case SHType::None: {
     j = json{{"type", valType}};
     break;
@@ -282,7 +281,6 @@ void from_json(const json &j, SHVar &var) {
   switch (valType.value()) {
   case SHType::Any:
   case SHType::EndOfBlittableTypes:
-  case SHType::Error: // this is not a valid type we want to serialize...
   case SHType::None: {
     var = {};
     var.valueType = valType.value();

--- a/src/core/shards/seqs.cpp
+++ b/src/core/shards/seqs.cpp
@@ -24,6 +24,7 @@ struct Flatten {
     case None:
     case SHType::Any:
     case EndOfBlittableTypes:
+    case SHType::Error: // this is not a valid type we want to serialize...
       // Nothing
       break;
     case SHType::Wire:
@@ -91,6 +92,7 @@ struct Flatten {
     case None:
     case SHType::Any:
     case EndOfBlittableTypes:
+    case SHType::Error: // this is not a valid type we want to serialize...
       // Nothing
       break;
     case SHType::Wire:

--- a/src/core/shards/seqs.cpp
+++ b/src/core/shards/seqs.cpp
@@ -24,7 +24,6 @@ struct Flatten {
     case None:
     case SHType::Any:
     case EndOfBlittableTypes:
-    case SHType::Error: // this is not a valid type we want to serialize...
       // Nothing
       break;
     case SHType::Wire:
@@ -92,7 +91,6 @@ struct Flatten {
     case None:
     case SHType::Any:
     case EndOfBlittableTypes:
-    case SHType::Error: // this is not a valid type we want to serialize...
       // Nothing
       break;
     case SHType::Wire:

--- a/src/core/shards_macros.hpp
+++ b/src/core/shards_macros.hpp
@@ -223,7 +223,12 @@
 
 #define RUNTIME_SHARD_activate(_name_)                                                                      \
   result->activate = static_cast<SHActivateProc>([](Shard *shard, SHContext *context, const SHVar *input) { \
-    return reinterpret_cast<_name_##Runtime *>(shard)->core.activate(context, *input);                      \
+    try {                                                                                                   \
+      return reinterpret_cast<_name_##Runtime *>(shard)->core.activate(context, *input);                    \
+    } catch (std::exception & e) {                                                                          \
+      reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(e.what());                               \
+      return SHVar(shards::Var::Error(reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()));      \
+    }                                                                                                       \
   });
 
 #define RUNTIME_SHARD_cleanup(_name_)                                                   \

--- a/src/core/shards_macros.hpp
+++ b/src/core/shards_macros.hpp
@@ -6,74 +6,76 @@
 #ifndef SH_CORE_SHARDS_MACROS
 #define SH_CORE_SHARDS_MACROS
 
-#define RUNTIME_SHARD(_namespace_, _name_)                                                                                  \
-  struct _name_##Runtime {                                                                                                  \
-    Shard header;                                                                                                           \
-    _name_ core;                                                                                                            \
-    std::string lastError;                                                                                                  \
-  };                                                                                                                        \
-  __cdecl Shard *createShard##_name_() {                                                                                    \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                          \
-    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                               \
-      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                   \
-    });                                                                                                                     \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
-      auto blk = (_name_##Runtime *)shard;                                                                                  \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
-    });                                                                                                                     \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
-    result->compose = nullptr;                                                                                              \
-    result->warmup = nullptr;                                                                                               \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
-    result->nextFrame = nullptr;                                                                                            \
-    result->mutate = nullptr;                                                                                               \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
+#define RUNTIME_SHARD(_namespace_, _name_)                                                                               \
+  struct _name_##Runtime {                                                                                               \
+    Shard header;                                                                                                        \
+    _name_ core;                                                                                                         \
+    std::string lastError;                                                                                               \
+  };                                                                                                                     \
+  __cdecl Shard *createShard##_name_() {                                                                                 \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                       \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                            \
+      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                \
+    });                                                                                                                  \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
+      auto blk = (_name_##Runtime *)shard;                                                                               \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+    });                                                                                                                  \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->setParam =                                                                                                   \
+        static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
+    result->compose = nullptr;                                                                                           \
+    result->warmup = nullptr;                                                                                            \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
+    result->nextFrame = nullptr;                                                                                         \
+    result->mutate = nullptr;                                                                                            \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError::Success; });
 
-#define RUNTIME_CORE_SHARD(_name_)                                                                                          \
-  struct _name_##Runtime {                                                                                                  \
-    Shard header;                                                                                                           \
-    _name_ core;                                                                                                            \
-    std::string lastError;                                                                                                  \
-  };                                                                                                                        \
-  __cdecl Shard *createShard##_name_() {                                                                                    \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                           \
-    result->hash = static_cast<SHHashProc>(                                                                                 \
-        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });           \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
-      auto blk = (_name_##Runtime *)shard;                                                                                  \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
-    });                                                                                                                     \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
-    result->compose = nullptr;                                                                                              \
-    result->warmup = nullptr;                                                                                               \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
-    result->nextFrame = nullptr;                                                                                            \
-    result->mutate = nullptr;                                                                                               \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
+#define RUNTIME_CORE_SHARD(_name_)                                                                                       \
+  struct _name_##Runtime {                                                                                               \
+    Shard header;                                                                                                        \
+    _name_ core;                                                                                                         \
+    std::string lastError;                                                                                               \
+  };                                                                                                                     \
+  __cdecl Shard *createShard##_name_() {                                                                                 \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                        \
+    result->hash = static_cast<SHHashProc>(                                                                              \
+        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });        \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
+      auto blk = (_name_##Runtime *)shard;                                                                               \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+    });                                                                                                                  \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->setParam =                                                                                                   \
+        static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
+    result->compose = nullptr;                                                                                           \
+    result->warmup = nullptr;                                                                                            \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
+    result->nextFrame = nullptr;                                                                                         \
+    result->mutate = nullptr;                                                                                            \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError::Success; });
 
 #define RUNTIME_SHARD_TYPE(_namespace_, _name_) \
   struct _name_##Runtime {                      \
@@ -81,35 +83,36 @@
     _name_ core;                                \
     std::string lastError;                      \
   };
-#define RUNTIME_SHARD_FACTORY(_namespace_, _name_)                                                                          \
-  __cdecl Shard *createShard##_name_() {                                                                                    \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                          \
-    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                               \
-      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                   \
-    });                                                                                                                     \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
-      auto blk = (_name_##Runtime *)shard;                                                                                  \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
-    });                                                                                                                     \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
-    result->compose = nullptr;                                                                                              \
-    result->warmup = nullptr;                                                                                               \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
-    result->nextFrame = nullptr;                                                                                            \
-    result->mutate = nullptr;                                                                                               \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
+#define RUNTIME_SHARD_FACTORY(_namespace_, _name_)                                                                       \
+  __cdecl Shard *createShard##_name_() {                                                                                 \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                       \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                            \
+      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                \
+    });                                                                                                                  \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
+      auto blk = (_name_##Runtime *)shard;                                                                               \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+    });                                                                                                                  \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->setParam =                                                                                                   \
+        static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
+    result->compose = nullptr;                                                                                           \
+    result->warmup = nullptr;                                                                                            \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
+    result->nextFrame = nullptr;                                                                                         \
+    result->mutate = nullptr;                                                                                            \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError::Success; });
 
 #define RUNTIME_CORE_SHARD_TYPE(_name_) \
   struct _name_##Runtime {              \
@@ -117,34 +120,35 @@
     _name_ core;                        \
     std::string lastError;              \
   };
-#define RUNTIME_CORE_SHARD_FACTORY(_name_)                                                                                  \
-  __cdecl Shard *createShard##_name_() {                                                                                    \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                           \
-    result->hash = static_cast<SHHashProc>(                                                                                 \
-        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });           \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
-      auto blk = (_name_##Runtime *)shard;                                                                                  \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
-    });                                                                                                                     \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
-    result->compose = nullptr;                                                                                              \
-    result->warmup = nullptr;                                                                                               \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
-    result->nextFrame = nullptr;                                                                                            \
-    result->mutate = nullptr;                                                                                               \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
+#define RUNTIME_CORE_SHARD_FACTORY(_name_)                                                                               \
+  __cdecl Shard *createShard##_name_() {                                                                                 \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                        \
+    result->hash = static_cast<SHHashProc>(                                                                              \
+        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });        \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
+      auto blk = (_name_##Runtime *)shard;                                                                               \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+    });                                                                                                                  \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->setParam =                                                                                                   \
+        static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
+    result->compose = nullptr;                                                                                           \
+    result->warmup = nullptr;                                                                                            \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
+    result->nextFrame = nullptr;                                                                                         \
+    result->mutate = nullptr;                                                                                            \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError::Success; });
 
 // Those get nicely inlined fully so only 1 indirection will happen at the root
 // of the call if the shard is all inline
@@ -190,7 +194,7 @@
   result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { \
     try {                                                                                          \
       reinterpret_cast<_name_##Runtime *>(shard)->core.setParam(index, *value);                    \
-      return SHError{0};                                                                           \
+      return SHError::Success;                                                                     \
     } catch (std::exception & ex) {                                                                \
       reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(ex.what());                     \
       return SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()};            \
@@ -203,7 +207,7 @@
 #define RUNTIME_SHARD_compose(_name_)                                                                                       \
   result->compose = static_cast<SHComposeProc>([](Shard *shard, SHInstanceData data) {                                      \
     try {                                                                                                                   \
-      return SHShardComposeResult{SHError{0}, reinterpret_cast<_name_##Runtime *>(shard)->core.compose(data)};              \
+      return SHShardComposeResult{SHError::Success, reinterpret_cast<_name_##Runtime *>(shard)->core.compose(data)};        \
     } catch (std::exception & e) {                                                                                          \
       reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(e.what());                                               \
       return SHShardComposeResult{SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()}, SHTypeInfo{}}; \
@@ -214,7 +218,7 @@
   result->warmup = static_cast<SHWarmupProc>([](Shard *shard, SHContext *ctx) {         \
     try {                                                                               \
       reinterpret_cast<_name_##Runtime *>(shard)->core.warmup(ctx);                     \
-      return SHError{0};                                                                \
+      return SHError::Success;                                                          \
     } catch (std::exception & ex) {                                                     \
       reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(ex.what());          \
       return SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()}; \
@@ -235,7 +239,7 @@
   result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) {                       \
     try {                                                                               \
       reinterpret_cast<_name_##Runtime *>(shard)->core.cleanup();                       \
-      return SHError{0};                                                                \
+      return SHError::Success;                                                          \
     } catch (std::exception & ex) {                                                     \
       reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(ex.what());          \
       return SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()}; \

--- a/src/core/shards_macros.hpp
+++ b/src/core/shards_macros.hpp
@@ -6,141 +6,145 @@
 #ifndef SH_CORE_SHARDS_MACROS
 #define SH_CORE_SHARDS_MACROS
 
-#define RUNTIME_SHARD(_namespace_, _name_)                                                                               \
-  struct _name_##Runtime {                                                                                               \
-    Shard header;                                                                                                        \
-    _name_ core;                                                                                                         \
-  };                                                                                                                     \
-  __cdecl Shard *createShard##_name_() {                                                                                 \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                       \
-    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                            \
-      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                \
-    });                                                                                                                  \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
-      auto blk = (_name_##Runtime *)shard;                                                                               \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
-    });                                                                                                                  \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) {});                  \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->compose = nullptr;                                                                                           \
-    result->warmup = nullptr;                                                                                            \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
-    result->nextFrame = nullptr;                                                                                         \
-    result->mutate = nullptr;                                                                                            \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) {});
+#define RUNTIME_SHARD(_namespace_, _name_)                                                                                  \
+  struct _name_##Runtime {                                                                                                  \
+    Shard header;                                                                                                           \
+    _name_ core;                                                                                                            \
+    std::string lastError;                                                                                                  \
+  };                                                                                                                        \
+  __cdecl Shard *createShard##_name_() {                                                                                    \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                          \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                               \
+      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                   \
+    });                                                                                                                     \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
+      auto blk = (_name_##Runtime *)shard;                                                                                  \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
+    });                                                                                                                     \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
+    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
+    result->compose = nullptr;                                                                                              \
+    result->warmup = nullptr;                                                                                               \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
+    result->nextFrame = nullptr;                                                                                            \
+    result->mutate = nullptr;                                                                                               \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
 
-#define RUNTIME_CORE_SHARD(_name_)                                                                                       \
-  struct _name_##Runtime {                                                                                               \
-    Shard header;                                                                                                        \
-    _name_ core;                                                                                                         \
-  };                                                                                                                     \
-  __cdecl Shard *createShard##_name_() {                                                                                 \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                        \
-    result->hash = static_cast<SHHashProc>(                                                                              \
-        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });        \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
-      auto blk = (_name_##Runtime *)shard;                                                                               \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
-    });                                                                                                                  \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) {});                  \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->compose = nullptr;                                                                                           \
-    result->warmup = nullptr;                                                                                            \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
-    result->nextFrame = nullptr;                                                                                         \
-    result->mutate = nullptr;                                                                                            \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) {});
+#define RUNTIME_CORE_SHARD(_name_)                                                                                          \
+  struct _name_##Runtime {                                                                                                  \
+    Shard header;                                                                                                           \
+    _name_ core;                                                                                                            \
+    std::string lastError;                                                                                                  \
+  };                                                                                                                        \
+  __cdecl Shard *createShard##_name_() {                                                                                    \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                           \
+    result->hash = static_cast<SHHashProc>(                                                                                 \
+        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });           \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
+      auto blk = (_name_##Runtime *)shard;                                                                                  \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
+    });                                                                                                                     \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
+    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
+    result->compose = nullptr;                                                                                              \
+    result->warmup = nullptr;                                                                                               \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
+    result->nextFrame = nullptr;                                                                                            \
+    result->mutate = nullptr;                                                                                               \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
 
 #define RUNTIME_SHARD_TYPE(_namespace_, _name_) \
   struct _name_##Runtime {                      \
     Shard header;                               \
     _name_ core;                                \
+    std::string lastError;                      \
   };
-#define RUNTIME_SHARD_FACTORY(_namespace_, _name_)                                                                       \
-  __cdecl Shard *createShard##_name_() {                                                                                 \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                       \
-    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                            \
-      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                \
-    });                                                                                                                  \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
-      auto blk = (_name_##Runtime *)shard;                                                                               \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
-    });                                                                                                                  \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) {});                  \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->compose = nullptr;                                                                                           \
-    result->warmup = nullptr;                                                                                            \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
-    result->nextFrame = nullptr;                                                                                         \
-    result->mutate = nullptr;                                                                                            \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) {});
+#define RUNTIME_SHARD_FACTORY(_namespace_, _name_)                                                                          \
+  __cdecl Shard *createShard##_name_() {                                                                                    \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                          \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                               \
+      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                   \
+    });                                                                                                                     \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
+      auto blk = (_name_##Runtime *)shard;                                                                                  \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
+    });                                                                                                                     \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
+    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
+    result->compose = nullptr;                                                                                              \
+    result->warmup = nullptr;                                                                                               \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
+    result->nextFrame = nullptr;                                                                                            \
+    result->mutate = nullptr;                                                                                               \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
 
 #define RUNTIME_CORE_SHARD_TYPE(_name_) \
   struct _name_##Runtime {              \
     Shard header;                       \
     _name_ core;                        \
+    std::string lastError;              \
   };
-#define RUNTIME_CORE_SHARD_FACTORY(_name_)                                                                               \
-  __cdecl Shard *createShard##_name_() {                                                                                 \
-    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                        \
-    result->hash = static_cast<SHHashProc>(                                                                              \
-        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });        \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
-    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
-    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
-      auto blk = (_name_##Runtime *)shard;                                                                               \
-      blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
-    });                                                                                                                  \
-    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
-    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
-    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
-    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
-    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) {});                  \
-    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->compose = nullptr;                                                                                           \
-    result->warmup = nullptr;                                                                                            \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
-    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
-    result->nextFrame = nullptr;                                                                                         \
-    result->mutate = nullptr;                                                                                            \
-    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) {});
+#define RUNTIME_CORE_SHARD_FACTORY(_name_)                                                                                  \
+  __cdecl Shard *createShard##_name_() {                                                                                    \
+    Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                                \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                           \
+    result->hash = static_cast<SHHashProc>(                                                                                 \
+        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });           \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                                \
+    result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                          \
+    result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                         \
+      auto blk = (_name_##Runtime *)shard;                                                                                  \
+      blk->_name_##Runtime::~_name_##Runtime();                                                                             \
+      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                   \
+    });                                                                                                                     \
+    result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                         \
+    result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                       \
+    result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });      \
+    result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });    \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                    \
+    result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError{0}; }); \
+    result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                        \
+    result->compose = nullptr;                                                                                              \
+    result->warmup = nullptr;                                                                                               \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                           \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                          \
+    result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });            \
+    result->nextFrame = nullptr;                                                                                            \
+    result->mutate = nullptr;                                                                                               \
+    result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { return SHError{0}; });
 
 // Those get nicely inlined fully so only 1 indirection will happen at the root
 // of the call if the shard is all inline
@@ -184,27 +188,54 @@
       static_cast<SHParametersProc>([](Shard *shard) { return reinterpret_cast<_name_##Runtime *>(shard)->core.parameters(); });
 #define RUNTIME_SHARD_setParam(_name_)                                                             \
   result->setParam = static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { \
-    reinterpret_cast<_name_##Runtime *>(shard)->core.setParam(index, *value);                      \
+    try {                                                                                          \
+      reinterpret_cast<_name_##Runtime *>(shard)->core.setParam(index, *value);                    \
+      return SHError{0};                                                                           \
+    } catch (std::exception & ex) {                                                                \
+      reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(ex.what());                     \
+      return SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()};            \
+    }                                                                                              \
   });
 #define RUNTIME_SHARD_getParam(_name_)            \
   result->getParam = static_cast<SHGetParamProc>( \
       [](Shard *shard, int index) { return reinterpret_cast<_name_##Runtime *>(shard)->core.getParam(index); });
 
-#define RUNTIME_SHARD_compose(_name_)           \
-  result->compose = static_cast<SHComposeProc>( \
-      [](Shard *shard, SHInstanceData data) { return reinterpret_cast<_name_##Runtime *>(shard)->core.compose(data); });
+#define RUNTIME_SHARD_compose(_name_)                                                                                       \
+  result->compose = static_cast<SHComposeProc>([](Shard *shard, SHInstanceData data) {                                      \
+    try {                                                                                                                   \
+      return SHShardComposeResult{SHError{0}, reinterpret_cast<_name_##Runtime *>(shard)->core.compose(data)};              \
+    } catch (std::exception & e) {                                                                                          \
+      reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(e.what());                                               \
+      return SHShardComposeResult{SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()}, SHTypeInfo{}}; \
+    }                                                                                                                       \
+  });
 
-#define RUNTIME_SHARD_warmup(_name_)          \
-  result->warmup = static_cast<SHWarmupProc>( \
-      [](Shard *shard, SHContext *ctx) { reinterpret_cast<_name_##Runtime *>(shard)->core.warmup(ctx); });
+#define RUNTIME_SHARD_warmup(_name_)                                                    \
+  result->warmup = static_cast<SHWarmupProc>([](Shard *shard, SHContext *ctx) {         \
+    try {                                                                               \
+      reinterpret_cast<_name_##Runtime *>(shard)->core.warmup(ctx);                     \
+      return SHError{0};                                                                \
+    } catch (std::exception & ex) {                                                     \
+      reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(ex.what());          \
+      return SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()}; \
+    }                                                                                   \
+  });
 
 #define RUNTIME_SHARD_activate(_name_)                                                                      \
   result->activate = static_cast<SHActivateProc>([](Shard *shard, SHContext *context, const SHVar *input) { \
     return reinterpret_cast<_name_##Runtime *>(shard)->core.activate(context, *input);                      \
   });
 
-#define RUNTIME_SHARD_cleanup(_name_) \
-  result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) { reinterpret_cast<_name_##Runtime *>(shard)->core.cleanup(); });
+#define RUNTIME_SHARD_cleanup(_name_)                                                   \
+  result->cleanup = static_cast<SHCleanupProc>([](Shard *shard) {                       \
+    try {                                                                               \
+      reinterpret_cast<_name_##Runtime *>(shard)->core.cleanup();                       \
+      return SHError{0};                                                                \
+    } catch (std::exception & ex) {                                                     \
+      reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(ex.what());          \
+      return SHError{1, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()}; \
+    }                                                                                   \
+  });
 
 #define RUNTIME_SHARD_mutate(_name_)          \
   result->mutate = static_cast<SHMutateProc>( \

--- a/src/core/shards_macros.hpp
+++ b/src/core/shards_macros.hpp
@@ -227,7 +227,8 @@
       return reinterpret_cast<_name_##Runtime *>(shard)->core.activate(context, *input);                    \
     } catch (std::exception & e) {                                                                          \
       reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(e.what());                               \
-      return SHVar(shards::Var::Error(reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str()));      \
+      shards::abortWire(context, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str());            \
+      return SHVar{};                                                                                       \
     }                                                                                                       \
   });
 

--- a/src/core/shards_macros.hpp
+++ b/src/core/shards_macros.hpp
@@ -226,8 +226,7 @@
     try {                                                                                                   \
       return reinterpret_cast<_name_##Runtime *>(shard)->core.activate(context, *input);                    \
     } catch (std::exception & e) {                                                                          \
-      reinterpret_cast<_name_##Runtime *>(shard)->lastError.assign(e.what());                               \
-      shards::abortWire(context, reinterpret_cast<_name_##Runtime *>(shard)->lastError.c_str());            \
+      shards::abortWire(context, e.what());                                                                 \
       return SHVar{};                                                                                       \
     }                                                                                                       \
   });

--- a/src/extra/audio.cpp
+++ b/src/extra/audio.cpp
@@ -333,7 +333,8 @@ struct Device {
     }
 
     if (stopped) {
-      SH_STOP();
+      context->stopFlow(Var::Empty);
+      return Var::Empty;
     }
 
     return input;
@@ -787,7 +788,8 @@ struct ReadFile {
         _done = false;
         _progress = 0;
       } else {
-        SH_STOP();
+        context->stopFlow(Var::Empty);
+        return Var::Empty;
       }
     }
 

--- a/src/extra/gfx/material_utils.hpp
+++ b/src/extra/gfx/material_utils.hpp
@@ -57,7 +57,7 @@ inline bool tryVarToParam(const SHVar &var, ParamVariant &outVariant) {
   try {
     varToParam(var, outVariant);
     return true;
-  } catch (std::exception& e) {
+  } catch (std::exception &e) {
     spdlog::error("{}", e.what());
     return false;
   }

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -748,8 +748,7 @@ SHType keywordToType(malKeyword *typeKeyword) {
 malValuePtr typeToKeyword(SHType type) {
   switch (type) {
   case SHType::EndOfBlittableTypes:
-  case SHType::Error:
-    return mal::keyword(":Error");
+    return mal::keyword(":EndOfBlittableTypes");
   case SHType::None:
     return mal::keyword(":None");
   case SHType::Any:

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -748,6 +748,8 @@ SHType keywordToType(malKeyword *typeKeyword) {
 malValuePtr typeToKeyword(SHType type) {
   switch (type) {
   case SHType::EndOfBlittableTypes:
+  case SHType::Error:
+    return mal::keyword(":Error");
   case SHType::None:
     return mal::keyword(":None");
   case SHType::Any:

--- a/src/tests/test_runtime.cpp
+++ b/src/tests/test_runtime.cpp
@@ -59,6 +59,7 @@ struct Reader {
 
 TEST_CASE("SHType-type2Name", "[ops]") {
   REQUIRE_THROWS(type2Name(SHType::EndOfBlittableTypes));
+  REQUIRE_THROWS(type2Name(SHType::Error));
   REQUIRE(type2Name(SHType::None) == "None");
   REQUIRE(type2Name(SHType::Any) == "Any");
   REQUIRE(type2Name(SHType::Object) == "Object");

--- a/src/tests/test_runtime.cpp
+++ b/src/tests/test_runtime.cpp
@@ -59,7 +59,6 @@ struct Reader {
 
 TEST_CASE("SHType-type2Name", "[ops]") {
   REQUIRE_THROWS(type2Name(SHType::EndOfBlittableTypes));
-  REQUIRE_THROWS(type2Name(SHType::Error));
   REQUIRE(type2Name(SHType::None) == "None");
   REQUIRE(type2Name(SHType::Any) == "Any");
   REQUIRE(type2Name(SHType::Object) == "Object");

--- a/src/tests/test_runtime.cpp
+++ b/src/tests/test_runtime.cpp
@@ -1150,9 +1150,9 @@ TEST_CASE("HashedActivations") {
   } catch (...) {
   }
   SHLOG_INFO("hash: {} - output: {}", hash, output);
-  REQUIRE(hash.payload.int2Value[0] == 6312058842062295303ll);
-  REQUIRE(hash.payload.int2Value[1] == -1718237385683811710ll);
-  REQUIRE(output == input);
+  REQUIRE(hash.payload.int2Value[0] == 4867318254273060702ll);
+  REQUIRE(hash.payload.int2Value[1] == -743121074487371807ll);
+  REQUIRE(output == Var::Empty);
 }
 
 #include "number_types.hpp"


### PR DESCRIPTION
aka remove some exceptions...

This is the first part of the refactor, eventually we want to remove exceptions **totally** from `activation` calls.
But for now we just wrap activations in a nice landing pad that translates into an Error value type.