### PR TITLE
C++ shard parameter macros 

### DIFF
--- a/include/shards.hpp
+++ b/include/shards.hpp
@@ -553,7 +553,6 @@ struct Var : public SHVar {
   Var& operator=(const SHVar& other) { memcpy((void *)this, (void *)&other, sizeof(SHVar)); return *this; }
 
   bool isNone() const { return valueType == SHType::None; }
-  bool isSet() const { return !isNone(); }
 
   explicit operator bool() const {
     if (valueType != Bool) {

--- a/include/shards.hpp
+++ b/include/shards.hpp
@@ -550,6 +550,11 @@ struct Var : public SHVar {
 
   explicit Var(const SHVar &other) { memcpy((void *)this, (void *)&other, sizeof(SHVar)); }
 
+  Var& operator=(const SHVar& other) { memcpy((void *)this, (void *)&other, sizeof(SHVar)); return *this; }
+
+  bool isNone() const { return valueType == SHType::None; }
+  bool isSet() const { return !isNone(); }
+
   explicit operator bool() const {
     if (valueType != Bool) {
       throw InvalidVarTypeError("Invalid variable casting! expected Bool");
@@ -609,6 +614,14 @@ struct Var : public SHVar {
       return static_cast<double>(payload.intValue);
     } else {
       throw InvalidVarTypeError("Invalid variable casting! expected Float");
+    }
+  }
+
+  explicit operator const char *() const {
+    if (valueType == SHType::String || valueType == SHType::Path || valueType == SHType::ContextVar) {
+      return payload.stringValue;
+    } else {
+      throw InvalidVarTypeError("Invalid variable casting! expected String/Path/ContextVar");
     }
   }
 

--- a/src/core/params.hpp
+++ b/src/core/params.hpp
@@ -1,0 +1,138 @@
+#ifndef B0328A63_0B69_4191_94D5_38783B9F20C9
+#define B0328A63_0B69_4191_94D5_38783B9F20C9
+
+#include "stddef.h"
+#include <foundation.hpp>
+#include <type_traits>
+#include "shardwrapper.hpp"
+
+// Template helpers for setParam/getParam
+namespace shards {
+
+#define PARAM(_type, _name, _displayName, _help, _types)                                   \
+  static inline ParameterInfo _name##ParameterInfo = {_displayName, SHCCSTR(_help), _types}; \
+  _type _name;
+
+#define PARAM_VAR(_name, _displayName, _help, _types) PARAM(Var, _name, _displayName, _help, _types)
+#define PARAM_PARAMVAR(_name, _displayName, _help, _types) PARAM(ParamVar, _name, _displayName, _help, _types)
+
+struct IterableParam {
+  size_t offset;
+  const ParameterInfo *paramInfo;
+
+  void (*setParam)(void *varPtr, SHVar var){};
+  SHVar (*getParam)(void *varPtr){};
+  void (*warmup)(void *varPtr, SHContext *ctx){};
+  void (*cleanup)(void *varPtr){};
+
+  void *getVarPtr(void *obj) const { return (void *)(size_t(obj) + offset); }
+  template <typename T> T &get(void *obj) const { return *(T *)getVarPtr(obj); }
+
+  template <typename T> static IterableParam create(size_t offset, const ParameterInfo *paramInfo) {
+    return createWithVarInterface<T>(offset, paramInfo);
+  }
+
+  template <typename T> static IterableParam createWithVarInterface(size_t offset, const ParameterInfo *paramInfo) {
+    IterableParam result{
+        .offset = offset,
+        .paramInfo = paramInfo,
+        .setParam = [](void *varPtr, SHVar var) { *((T *)varPtr) = var; },
+        .getParam = [](void *varPtr) -> SHVar { return *((T *)varPtr); },
+    };
+
+    if constexpr (has_warmup<T>::value) {
+      result.warmup = [](void *varPtr, SHContext *ctx) { ((T *)varPtr)->warmup(ctx); };
+    } else {
+      result.warmup = [](void *, SHContext *) {};
+    }
+
+    if constexpr (has_warmup<T>::value) {
+      result.cleanup = [](void *varPtr) { ((T *)varPtr)->cleanup(); };
+    } else {
+      result.cleanup = [](void *) {};
+    }
+
+    return result;
+  }
+};
+
+// Usage:
+//  PARAM_IMPL(Shard,
+//    PARAM_IMPL_FOR(Param0),
+//    PARAM_IMPL_FOR(Param1),
+//    PARAM_IMPL_FOR(Param2))
+// Side effects:
+//  - typedefs Self to the current class
+//  - creates a static member named iterableParams
+#define PARAM_IMPL(_type, ...)                                          \
+  typedef _type Self;                                                   \
+  static const IterableParam *getIterableParams(size_t &outNumParams) { \
+    static IterableParam result[] = {__VA_ARGS__};                      \
+    outNumParams = std::extent<decltype(result)>::value;                \
+    return result;                                                      \
+  }                                                                     \
+  PARAM_PARAMS()                                                        \
+  PARAM_GET_SET()
+
+#define PARAM_IMPL_FOR(_name) IterableParam::create<decltype(_name)>(offsetof(Self, _name), &_name##ParameterInfo)
+
+// Implements parameters()
+#define PARAM_PARAMS()                                                           \
+  static SHParametersInfo parameters() {                                         \
+    static SHParametersInfo result = []() {                                      \
+      SHParametersInfo result{};                                                 \
+      size_t numParams;                                                          \
+      const IterableParam *params = getIterableParams(numParams);                \
+      arrayResize(result, numParams);                                            \
+      for (size_t i = 0; i < numParams; i++) {                                   \
+        result.elements[i] = *const_cast<ParameterInfo *>(params[i].paramInfo); \
+      }                                                                          \
+      return result;                                                             \
+    }();                                                                         \
+    return result;                                                               \
+  }
+
+// Implements setParam()/getParam()
+#define PARAM_GET_SET()                                             \
+  void setParam(int index, const SHVar &value) {                    \
+    size_t numParams;                                               \
+    const IterableParam *params = getIterableParams(numParams);     \
+    if (index < numParams) {                                        \
+      params[index].setParam(params[index].getVarPtr(this), value); \
+    } else {                                                        \
+      throw std::logic_error("Param index out of range");           \
+    }                                                               \
+  }                                                                 \
+  SHVar getParam(int index) {                                       \
+    size_t numParams;                                               \
+    const IterableParam *params = getIterableParams(numParams);     \
+    if (index < numParams) {                                        \
+      return params[index].getParam(params[index].getVarPtr(this)); \
+    } else {                                                        \
+      throw std::logic_error("Param index out of range");           \
+    }                                                               \
+  }
+
+// Implements warmup(ctx) for parameters
+// call from warmup manually with context
+#define PARAM_WARMUP(_ctx)                                      \
+  {                                                             \
+    size_t numParams;                                           \
+    const IterableParam *params = getIterableParams(numParams); \
+    for (size_t i = 0; i < numParams; i++)                      \
+      params[i].warmup(params[i].getVarPtr(this), _ctx);        \
+  }
+
+// implements cleanup() for parameters
+// call from cleanup manually
+#define PARAM_CLEANUP()                                         \
+  {                                                             \
+    size_t numParams;                                           \
+    const IterableParam *params = getIterableParams(numParams); \
+    for (size_t i = 0; i < numParams; i++)                      \
+      params[i].cleanup(params[i].getVarPtr(this));             \
+  }
+
+} // namespace shards
+
+#endif /* B0328A63_0B69_4191_94D5_38783B9F20C9 */

--- a/src/core/params.hpp
+++ b/src/core/params.hpp
@@ -13,11 +13,12 @@ namespace shards {
   static inline ParameterInfo _name##ParameterInfo = {_displayName, SHCCSTR(_help), _types}; \
   _type _name;
 
-#define PARAM_VAR(_name, _displayName, _help, _types) PARAM(Var, _name, _displayName, _help, _types)
-#define PARAM_PARAMVAR(_name, _displayName, _help, _types) PARAM(ParamVar, _name, _displayName, _help, _types)
+#define PARAM_VAR(_name, _displayName, _help, ...) PARAM(Var, _name, _displayName, _help, __VA_ARGS__)
+#define PARAM_PARAMVAR(_name, _displayName, _help, ...) PARAM(ParamVar, _name, _displayName, _help, __VA_ARGS__)
 
 struct IterableParam {
-  size_t offset;
+  // Return address of param inside shard
+  void *(*resolveParamInShard)(void *shardPtr);
   const ParameterInfo *paramInfo;
 
   void (*setParam)(void *varPtr, SHVar var){};
@@ -25,16 +26,16 @@ struct IterableParam {
   void (*warmup)(void *varPtr, SHContext *ctx){};
   void (*cleanup)(void *varPtr){};
 
-  void *getVarPtr(void *obj) const { return (void *)(size_t(obj) + offset); }
-  template <typename T> T &get(void *obj) const { return *(T *)getVarPtr(obj); }
+  template <typename T> T &get(void *obj) const { return *(T *)resolveParamInShard(obj); }
 
-  template <typename T> static IterableParam create(size_t offset, const ParameterInfo *paramInfo) {
-    return createWithVarInterface<T>(offset, paramInfo);
+  template <typename T> static IterableParam create(void *(*resolveParamInShard)(void *), const ParameterInfo *paramInfo) {
+    return createWithVarInterface<T>(resolveParamInShard, paramInfo);
   }
 
-  template <typename T> static IterableParam createWithVarInterface(size_t offset, const ParameterInfo *paramInfo) {
+  template <typename T>
+  static IterableParam createWithVarInterface(void *(*resolveParamInShard)(void *), const ParameterInfo *paramInfo) {
     IterableParam result{
-        .offset = offset,
+        .resolveParamInShard = resolveParamInShard,
         .paramInfo = paramInfo,
         .setParam = [](void *varPtr, SHVar var) { *((T *)varPtr) = var; },
         .getParam = [](void *varPtr) -> SHVar { return *((T *)varPtr); },
@@ -74,7 +75,8 @@ struct IterableParam {
   PARAM_PARAMS()                                                        \
   PARAM_GET_SET()
 
-#define PARAM_IMPL_FOR(_name) IterableParam::create<decltype(_name)>(offsetof(Self, _name), &_name##ParameterInfo)
+#define PARAM_IMPL_FOR(_name) \
+  IterableParam::create<decltype(_name)>([](void *obj) -> void * { return (void *)&((Self *)obj)->_name; }, &_name##ParameterInfo)
 
 // Implements parameters()
 #define PARAM_PARAMS()                                                          \
@@ -93,34 +95,34 @@ struct IterableParam {
   }
 
 // Implements setParam()/getParam()
-#define PARAM_GET_SET()                                             \
-  void setParam(int index, const SHVar &value) {                    \
-    size_t numParams;                                               \
-    const IterableParam *params = getIterableParams(numParams);     \
-    if (index < numParams) {                                        \
-      params[index].setParam(params[index].getVarPtr(this), value); \
-    } else {                                                        \
-      throw InvalidParameterIndex();                                \
-    }                                                               \
-  }                                                                 \
-  SHVar getParam(int index) {                                       \
-    size_t numParams;                                               \
-    const IterableParam *params = getIterableParams(numParams);     \
-    if (index < numParams) {                                        \
-      return params[index].getParam(params[index].getVarPtr(this)); \
-    } else {                                                        \
-      throw InvalidParameterIndex();                                \
-    }                                                               \
+#define PARAM_GET_SET()                                                       \
+  void setParam(int index, const SHVar &value) {                              \
+    size_t numParams;                                                         \
+    const IterableParam *params = getIterableParams(numParams);               \
+    if (index < numParams) {                                                  \
+      params[index].setParam(params[index].resolveParamInShard(this), value); \
+    } else {                                                                  \
+      throw InvalidParameterIndex();                                          \
+    }                                                                         \
+  }                                                                           \
+  SHVar getParam(int index) {                                                 \
+    size_t numParams;                                                         \
+    const IterableParam *params = getIterableParams(numParams);               \
+    if (index < numParams) {                                                  \
+      return params[index].getParam(params[index].resolveParamInShard(this)); \
+    } else {                                                                  \
+      throw InvalidParameterIndex();                                          \
+    }                                                                         \
   }
 
 // Implements warmup(ctx) for parameters
 // call from warmup manually with context
-#define PARAM_WARMUP(_ctx)                                      \
-  {                                                             \
-    size_t numParams;                                           \
-    const IterableParam *params = getIterableParams(numParams); \
-    for (size_t i = 0; i < numParams; i++)                      \
-      params[i].warmup(params[i].getVarPtr(this), _ctx);        \
+#define PARAM_WARMUP(_ctx)                                         \
+  {                                                                \
+    size_t numParams;                                              \
+    const IterableParam *params = getIterableParams(numParams);    \
+    for (size_t i = 0; i < numParams; i++)                         \
+      params[i].warmup(params[i].resolveParamInShard(this), _ctx); \
   }
 
 // implements cleanup() for parameters
@@ -130,7 +132,7 @@ struct IterableParam {
     size_t numParams;                                           \
     const IterableParam *params = getIterableParams(numParams); \
     for (size_t i = 0; i < numParams; i++)                      \
-      params[i].cleanup(params[i].getVarPtr(this));             \
+      params[i].cleanup(params[i].resolveParamInShard(this));   \
   }
 
 } // namespace shards

--- a/src/core/params.hpp
+++ b/src/core/params.hpp
@@ -131,8 +131,11 @@ struct IterableParam {
   {                                                             \
     size_t numParams;                                           \
     const IterableParam *params = getIterableParams(numParams); \
-    for (size_t i = 0; i < numParams; i++)                      \
+    for (size_t i = numParams - 1;; i--) {                      \
       params[i].cleanup(params[i].resolveParamInShard(this));   \
+      if (i == 0)                                               \
+        break;                                                  \
+    }                                                           \
   }
 
 } // namespace shards

--- a/src/core/params.hpp
+++ b/src/core/params.hpp
@@ -9,7 +9,7 @@
 // Template helpers for setParam/getParam
 namespace shards {
 
-#define PARAM(_type, _name, _displayName, _help, _types)                                   \
+#define PARAM(_type, _name, _displayName, _help, _types)                                     \
   static inline ParameterInfo _name##ParameterInfo = {_displayName, SHCCSTR(_help), _types}; \
   _type _name;
 
@@ -77,19 +77,19 @@ struct IterableParam {
 #define PARAM_IMPL_FOR(_name) IterableParam::create<decltype(_name)>(offsetof(Self, _name), &_name##ParameterInfo)
 
 // Implements parameters()
-#define PARAM_PARAMS()                                                           \
-  static SHParametersInfo parameters() {                                         \
-    static SHParametersInfo result = []() {                                      \
-      SHParametersInfo result{};                                                 \
-      size_t numParams;                                                          \
-      const IterableParam *params = getIterableParams(numParams);                \
-      arrayResize(result, numParams);                                            \
-      for (size_t i = 0; i < numParams; i++) {                                   \
+#define PARAM_PARAMS()                                                          \
+  static SHParametersInfo parameters() {                                        \
+    static SHParametersInfo result = []() {                                     \
+      SHParametersInfo result{};                                                \
+      size_t numParams;                                                         \
+      const IterableParam *params = getIterableParams(numParams);               \
+      arrayResize(result, numParams);                                           \
+      for (size_t i = 0; i < numParams; i++) {                                  \
         result.elements[i] = *const_cast<ParameterInfo *>(params[i].paramInfo); \
-      }                                                                          \
-      return result;                                                             \
-    }();                                                                         \
-    return result;                                                               \
+      }                                                                         \
+      return result;                                                            \
+    }();                                                                        \
+    return result;                                                              \
   }
 
 // Implements setParam()/getParam()
@@ -100,7 +100,7 @@ struct IterableParam {
     if (index < numParams) {                                        \
       params[index].setParam(params[index].getVarPtr(this), value); \
     } else {                                                        \
-      throw std::logic_error("Param index out of range");           \
+      throw InvalidParameterIndex();                                \
     }                                                               \
   }                                                                 \
   SHVar getParam(int index) {                                       \
@@ -109,7 +109,7 @@ struct IterableParam {
     if (index < numParams) {                                        \
       return params[index].getParam(params[index].getVarPtr(this)); \
     } else {                                                        \
-      throw std::logic_error("Param index out of range");           \
+      throw InvalidParameterIndex();                                \
     }                                                               \
   }
 

--- a/src/extra/gfx/gltf.cpp
+++ b/src/extra/gfx/gltf.cpp
@@ -73,7 +73,7 @@ struct GLTFShard {
         throw ComposeError("Path should be a string");
       _loadMode = LoadMemory;
       OVERRIDE_ACTIVATE(data, activateBytes);
-    } else if (_staticModelPath.isSet()) {
+    } else if (!_staticModelPath.isNone()) {
       _loadMode = LoadStaticFile;
       OVERRIDE_ACTIVATE(data, activateStatic);
     } else {
@@ -93,7 +93,7 @@ struct GLTFShard {
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
 
-    if (_staticModelPath.isSet()) {
+    if (!_staticModelPath.isNone()) {
       // Since loading from files is more of a debug funcitonality, try to load using the shards relative path
       std::string resolvedPath = gfx::resolveDataPath((const char *)_staticModelPath).string();
 

--- a/src/extra/gfx/mesh.cpp
+++ b/src/extra/gfx/mesh.cpp
@@ -2,6 +2,7 @@
 #include "buffer_vars.hpp"
 #include <gfx/geom.hpp>
 #include <gfx/mesh.hpp>
+#include <params.hpp>
 
 using namespace shards;
 namespace gfx {
@@ -22,39 +23,14 @@ struct MeshShard {
   static SHTypesInfo inputTypes() { return InputTable; }
   static SHTypesInfo outputTypes() { return Types::Mesh; }
 
-  static inline Parameters params{{"Layout", SHCCSTR("The names for each vertex attribute."), {VertexAttributeSeqType}},
-                                  {"WindingOrder", SHCCSTR("Front facing winding order for this mesh."), {Types::WindingOrder}}};
-
-  static SHParametersInfo parameters() { return params; }
-
-  std::vector<Var> _layout;
-  WindingOrder _windingOrder{WindingOrder::CCW};
+  PARAM_VAR(_layoutParam, "Layout", "The names for each vertex attribute.", {VertexAttributeSeqType});
+  PARAM_VAR(_windingOrderParam, "WindingOrder", "Front facing winding order for this mesh.", {Types::WindingOrder});
+  PARAM_IMPL(MeshShard, PARAM_IMPL_FOR(_layoutParam), PARAM_IMPL_FOR(_windingOrderParam));
 
   MeshPtr *_mesh = {};
 
-  void setParam(int index, const SHVar &value) {
-    switch (index) {
-    case 0:
-      _layout = std::vector<Var>(Var(value));
-      break;
-    case 1:
-      _windingOrder = WindingOrder(value.payload.enumValue);
-      break;
-    }
-  }
-
-  SHVar getParam(int index) {
-    switch (index) {
-    case 0:
-      return Var(_layout);
-    case 1:
-      return Var::Enum(_windingOrder, VendorId, Types::WindingOrderTypeId);
-    default:
-      return Var::Empty;
-    }
-  }
-
   void cleanup() {
+    PARAM_CLEANUP();
     if (_mesh) {
       Types::MeshObjectVar.Release(_mesh);
       _mesh = nullptr;
@@ -62,6 +38,7 @@ struct MeshShard {
   }
 
   void warmup(SHContext *context) {
+    PARAM_WARMUP(context);
     _mesh = Types::MeshObjectVar.New();
     MeshPtr mesh = (*_mesh) = std::make_shared<Mesh>();
   }
@@ -69,24 +46,25 @@ struct MeshShard {
   SHVar activate(SHContext *context, const SHVar &input) {
     MeshFormat meshFormat;
     meshFormat.primitiveType = PrimitiveType::TriangleList;
-    meshFormat.windingOrder = _windingOrder;
+    meshFormat.windingOrder = WindingOrder(_windingOrderParam.payload.enumValue);
 
     const SHTable &inputTable = input.payload.tableValue;
     SHVar *verticesVar = inputTable.api->tableAt(inputTable, InputVerticesTableKey);
     SHVar *indicesVar = inputTable.api->tableAt(inputTable, InputIndicesTableKey);
 
-    if (_layout.size() == 0) {
+    SHSeq &layoutSeq = _layoutParam.payload.seqValue;
+    if (layoutSeq.len == 0) {
       throw formatException("Layout must be set");
     }
 
     meshFormat.indexFormat = determineIndexFormat(*indicesVar);
     validateIndexFormat(meshFormat.indexFormat, *indicesVar);
 
-    determineVertexFormat(meshFormat.vertexAttributes, _layout.size(), *verticesVar);
+    determineVertexFormat(meshFormat.vertexAttributes, layoutSeq.len, *verticesVar);
 
     // Fill vertex attribute names from the Layout parameter
-    for (size_t i = 0; i < _layout.size(); i++) {
-      meshFormat.vertexAttributes[i].name = _layout[i].payload.stringValue;
+    for (size_t i = 0; i < layoutSeq.len; i++) {
+      meshFormat.vertexAttributes[i].name = layoutSeq.elements[i].payload.stringValue;
     }
 
     validateVertexFormat(meshFormat.vertexAttributes, *verticesVar);
@@ -140,37 +118,20 @@ struct BuiltinMeshShard {
   static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
   static SHTypesInfo outputTypes() { return Types::Mesh; }
 
-  Type _type = Type::Cube;
+  PARAM_VAR(_type, "Type", "The type of object to make.", {TypeType})
+  PARAM_IMPL(BuiltinMeshShard, PARAM_IMPL_FOR(_type));
 
-  static SHParametersInfo parameters() {
-    static Parameters params{{"Type", SHCCSTR("The type of object to make."), {TypeType}}};
-    return params;
+  BuiltinMeshShard() {
+    _type = Var::Enum(Type::Cube, SHTypeInfo(TypeType).enumeration.vendorId, SHTypeInfo(TypeType).enumeration.typeId);
   }
 
-  void setParam(int index, const SHVar &value) {
-    switch (index) {
-    case 0:
-      _type = Type(value.payload.enumValue);
-      break;
-    }
-  }
-
-  SHVar getParam(int index) {
-    switch (index) {
-    case 0:
-      return Var::Enum(_type, VendorId, TypeTypeId);
-      break;
-    default:
-      return Var::Empty;
-    }
-  }
-
-  void cleanup() {}
+  void warmup(SHContext *context) { PARAM_WARMUP(context); }
+  void cleanup() { PARAM_CLEANUP(); }
 
   SHVar activate(SHContext *context, const SHVar &input) {
     MeshPtr *meshVar = Types::MeshObjectVar.New();
 
-    switch (_type) {
+    switch (Type(_type.payload.enumValue)) {
     case Type::Cube: {
       geom::CubeGenerator gen;
       gen.generate();
@@ -191,6 +152,7 @@ struct BuiltinMeshShard {
     return Types::MeshObjectVar.Get(meshVar);
   }
 };
+
 void registerMeshShards() {
   REGISTER_SHARD("GFX.Mesh", MeshShard);
   REGISTER_SHARD("GFX.BuiltinMesh", BuiltinMeshShard);


### PR DESCRIPTION
Add a set of macros to define parameters quickly.

Usage:
```cpp
class ShardName {
  PARAM_VAR(_varName0, "DisplayName", "Help text", {Types});
  // = Var _varName0;

  PARAM_PARAMVAR(_varName1, "DisplayName", "Help text", {Type::VariableOf(Types)});
  // = ParamVar _varName1; 

  PARAM(ShardsVar, _varName2, "DisplayName", "Help text", {Types});
  // = ShardsVar _varName2;

  PARAM_IMPL(ShardName, PARAM_IMPL_FOR(_varName0), PARAM_IMPL_FOR(_varName1), PARAM_IMPL_FOR(_varName2));
  // implements parameters()/getParam()/setParam()
  // (and defines a static internal getIterableParams() that can be used to iterate over parameters)

  // Automatically calls warmup/cleanup for parameters that implement it (e.g. ParamVar/ShardsVar)
  void warmup(SHContext *context) { PARAM_WARMUP(context); }
  void cleanup() { PARAM_CLEANUP(); }
};
```


Also adding some additional functionality to Var to use alongside it:
- missing conversion to `const char*`
- check for `isNone` & `isSet` (it's inverse)