### PR TITLE
Use boost source archive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,6 +82,3 @@
 [submodule "deps/imgui"]
 	path = deps/imgui
 	url = https://github.com/ocornut/imgui.git
-[submodule "deps/boost"]
-	path = deps/boost
-	url = https://github.com/chainblocks/boost.git

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -35,7 +35,14 @@ if(NOT EMSCRIPTEN)
   set_property(GLOBAL PROPERTY OPENSSL_SOURCE_DIR ${libressl_SOURCE_DIR})
 endif()
 
-add_subdirectory(boost)
+message(STATUS "Fetching boost")
+FetchContent_Declare(
+  boost
+  URL      https://github.com/chainblocks/boost/releases/download/boost-f74a225c09/output.7z
+  URL_HASH SHA256=EB73BDD6B5B78C6A09A8F45B50AE8FAF5C44A6C741487313E978F0AF3073DA7A
+)
+FetchContent_MakeAvailable(boost)
+message(STATUS "boost_SOURCE_DIR=${boost_SOURCE_DIR}")
 
 if(NOT EMSCRIPTEN)
   if(EXTERNAL_BUILD_TYPE MATCHES "Debug")


### PR DESCRIPTION
Bundled boost into a source archive that doesn't contain tests/docs/unused modules (9.62 MB)

Check the dep branch for the build/package script.
Pushing a tag to that repo wil automatically create a release that can be linked to inside FetchContent_Declare
https://github.com/chainblocks/boost/commit/e11da3be380e29c5021912816e293c73127960f3