### PR TITLE
ParamVar get returns a reference

### DIFF
--- a/rust/src/shards/browse.rs
+++ b/rust/src/shards/browse.rs
@@ -42,7 +42,7 @@ impl Shard for Browse {
     &INPUT_TYPES
   }
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    webbrowser::open(input.as_ref().try_into()?).map_err(|e| {
+    webbrowser::open(input.try_into()?).map_err(|e| {
       shlog!("{}", e);
       "Failed to browse."
     })?;

--- a/rust/src/shards/casting.rs
+++ b/rust/src/shards/casting.rs
@@ -64,11 +64,11 @@ impl Shard for ToBase58 {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let bytes: Result<&[u8], &str> = input.as_ref().try_into();
+    let bytes: Result<&[u8], &str> = input.try_into();
     if let Ok(bytes) = bytes {
       self.buffer = bs58::encode(bytes).into_string();
     } else {
-      let string: Result<&str, &str> = input.as_ref().try_into();
+      let string: Result<&str, &str> = input.try_into();
       if let Ok(string) = string {
         self.buffer = bs58::encode(string).into_string();
       }
@@ -108,7 +108,7 @@ impl Shard for FromBase58 {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let str_input: &str = input.as_ref().try_into()?;
+    let str_input: &str = input.try_into()?;
     self.output = bs58::decode(str_input).into_vec().map_err(|e| {
       shlog!("{}", e);
       "Failed to decode base58"
@@ -181,14 +181,14 @@ impl Shard for ToLEB128 {
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
     if self.signed {
-      let int_input: i64 = input.as_ref().try_into()?;
+      let int_input: i64 = input.try_into()?;
       self.output.clear();
       self
         .output
         .write_leb128(int_input)
         .map_err(|_| "Failed to convert int to leb128")?;
     } else {
-      let int_input: u64 = input.as_ref().try_into()?;
+      let int_input: u64 = input.try_into()?;
       self.output.clear();
       self
         .output
@@ -249,7 +249,7 @@ impl Shard for FromLEB128 {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let mut bytes: &[u8] = input.as_ref().try_into()?;
+    let mut bytes: &[u8] = input.try_into()?;
     if self.signed {
       let value: (i64, usize) = bytes
         .read_leb128()

--- a/rust/src/shards/chachapoly.rs
+++ b/rust/src/shards/chachapoly.rs
@@ -99,12 +99,12 @@ impl Shard for Encrypt {
     let key = self.key.get();
 
     // TODO cache me?
-    let key = if let Ok(key) = <&[u8]>::try_from(&key) {
+    let key = if let Ok(key) = <&[u8]>::try_from(key) {
       if key.len() != 32 {
         return Err("Invalid key length");
       }
       Key::from_slice(key)
-    } else if let Ok(key) = <&str>::try_from(&key) {
+    } else if let Ok(key) = <&str>::try_from(key) {
       if key.len() != 32 {
         return Err("Invalid key length");
       }
@@ -197,12 +197,12 @@ impl Shard for Decrypt {
     let key = self.key.get();
 
     // TODO cache me?
-    let key = if let Ok(key) = <&[u8]>::try_from(&key) {
+    let key = if let Ok(key) = <&[u8]>::try_from(key) {
       if key.len() != 32 {
         return Err("Invalid key length");
       }
       Key::from_slice(key)
-    } else if let Ok(key) = <&str>::try_from(&key) {
+    } else if let Ok(key) = <&str>::try_from(key) {
       if key.len() != 32 {
         return Err("Invalid key length");
       }

--- a/rust/src/shards/curve25519.rs
+++ b/rust/src/shards/curve25519.rs
@@ -50,14 +50,14 @@ lazy_static! {
 }
 
 fn get_key<T: Pair>(input: &Var) -> Result<T, &'static str> {
-  let key: Result<&[u8], &str> = input.as_ref().try_into();
+  let key: Result<&[u8], &str> = input.try_into();
   if let Ok(key) = key {
     T::from_seed_slice(key).map_err(|e| {
       shlog!("{:?}", e);
       "Failed to parse secret key"
     })
   } else {
-    let key: Result<&str, &str> = input.as_ref().try_into();
+    let key: Result<&str, &str> = input.try_into();
     if let Ok(key) = key {
       T::from_string(key, None).map_err(|e| {
         shlog!("{:?}", e);
@@ -127,7 +127,7 @@ macro_rules! add_signer {
       }
 
       fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-        let bytes: &[u8] = input.as_ref().try_into()?;
+        let bytes: &[u8] = input.try_into()?;
 
         let key = self.key.get();
         let key: $key_type::Pair = get_key(key)?;
@@ -244,7 +244,7 @@ macro_rules! add_priv_key {
       }
 
       fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-        let key: &str = input.as_ref().try_into()?;
+        let key: &str = input.try_into()?;
         let (_, seed) = $key_type::Pair::from_string_with_seed(key, None).map_err(|e| {
           shlog!("{:?}", e);
           "Failed to parse secret key mnemonic or string"

--- a/rust/src/shards/curve25519.rs
+++ b/rust/src/shards/curve25519.rs
@@ -49,7 +49,7 @@ lazy_static! {
     .into()];
 }
 
-fn get_key<T: Pair>(input: Var) -> Result<T, &'static str> {
+fn get_key<T: Pair>(input: &Var) -> Result<T, &'static str> {
   let key: Result<&[u8], &str> = input.as_ref().try_into();
   if let Ok(key) = key {
     T::from_seed_slice(key).map_err(|e| {
@@ -188,7 +188,7 @@ macro_rules! add_pub_key {
       }
 
       fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-        let key: $key_type::Pair = get_key(*input)?;
+        let key: $key_type::Pair = get_key(input)?;
         let key = key.public();
         let key: &[u8; $size] = key.as_array_ref();
         self.output = key[..].into();

--- a/rust/src/shards/ecdsa.rs
+++ b/rust/src/shards/ecdsa.rs
@@ -61,7 +61,7 @@ lazy_static! {
   ];
 }
 
-fn get_key(input: Var) -> Result<libsecp256k1::SecretKey, &'static str> {
+fn get_key(input: &Var) -> Result<libsecp256k1::SecretKey, &'static str> {
   let key: Result<&[u8], &str> = input.as_ref().try_into();
   if let Ok(key) = key {
     libsecp256k1::SecretKey::parse_slice(key).map_err(|e| {
@@ -208,7 +208,7 @@ impl Shard for ECDSAPubKey {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let key = get_key(*input)?;
+    let key = get_key(input)?;
     let key = libsecp256k1::PublicKey::from_secret_key(&key);
     if !self.compressed {
       let key: [u8; 65] = key.serialize();
@@ -267,7 +267,7 @@ impl Shard for ECDSAPrivKey {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let key = get_key(*input)?;
+    let key = get_key(input)?;
     let key: [u8; 32] = key.serialize();
     self.output = key[..].into();
     Ok(self.output.0)

--- a/rust/src/shards/ecdsa.rs
+++ b/rust/src/shards/ecdsa.rs
@@ -62,14 +62,14 @@ lazy_static! {
 }
 
 fn get_key(input: &Var) -> Result<libsecp256k1::SecretKey, &'static str> {
-  let key: Result<&[u8], &str> = input.as_ref().try_into();
+  let key: Result<&[u8], &str> = input.try_into();
   if let Ok(key) = key {
     libsecp256k1::SecretKey::parse_slice(key).map_err(|e| {
       shlog!("{}", e);
       "Failed to parse secret key"
     })
   } else {
-    let key: Result<&str, &str> = input.as_ref().try_into();
+    let key: Result<&str, &str> = input.try_into();
     if let Ok(key) = key {
       // use this to allow even mnemonics to work!
       let pair = ecdsa::Pair::from_string(key, None).map_err(|e| {
@@ -143,7 +143,7 @@ impl Shard for ECDSASign {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let bytes: &[u8] = input.as_ref().try_into()?;
+    let bytes: &[u8] = input.try_into()?;
 
     let key = self.key.get();
     let key = get_key(key)?;
@@ -333,10 +333,10 @@ impl Shard for ECDSARecover {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let bytes: &[u8] = input.as_ref().try_into()?;
+    let bytes: &[u8] = input.try_into()?;
 
     let signature = self.signature.get();
-    let x: &[u8] = signature.as_ref().try_into()?;
+    let x: &[u8] = signature.try_into()?;
     let sig = libsecp256k1::Signature::parse_overflowing_slice(&x[..64]).map_err(|e| {
       shlog!("{}", e);
       "Failed to parse signature"

--- a/rust/src/shards/eth.rs
+++ b/rust/src/shards/eth.rs
@@ -207,7 +207,7 @@ impl Shard for EncodeCall {
     // process abi, create contract if needed
     if let Some(current_abi) = &self.current_abi {
       // abi might change on the fly, so we need to check it
-      if self.abi.is_variable() && abi != current_abi.0 {
+      if self.abi.is_variable() && *abi != current_abi.0 {
         self.contract = serde_json::from_str(abi.as_ref().try_into()?).map_err(|e| {
           shlog!("{}", e);
           "Failed to parse abi json string"
@@ -344,7 +344,7 @@ impl Shard for DecodeCall {
     // process abi, create contract if needed
     if let Some(current_abi) = &self.current_abi {
       // abi might change on the fly, so we need to check it
-      if self.abi.is_variable() && abi != current_abi.0 {
+      if self.abi.is_variable() && *abi != current_abi.0 {
         self.contract = serde_json::from_str(abi.as_ref().try_into()?).map_err(|e| {
           shlog!("{}", e);
           "Failed to parse abi json string"

--- a/rust/src/shards/gui/containers/panels.rs
+++ b/rust/src/shards/gui/containers/panels.rs
@@ -160,7 +160,7 @@ macro_rules! impl_panel {
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
         if !self.contents.is_empty() {
-          let ui = util::get_current_parent(self.parents.get())?;
+          let ui = util::get_current_parent(*self.parents.get())?;
           let output = if let Some(ui) = ui {
             $egui_func(EguiId::new(self, 0)).show_inside(ui, |ui| {
               util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
@@ -168,7 +168,7 @@ macro_rules! impl_panel {
           } else {
             let gui_ctx = {
               let ctx_ptr: &mut EguiNativeContext =
-                Var::from_object_ptr_mut_ref(self.instance.get(), &EGUI_CTX_TYPE)?;
+                Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
               &*ctx_ptr
             };
             $egui_func(EguiId::new(self, 0)).show(gui_ctx, |ui| {
@@ -344,12 +344,12 @@ impl Shard for CentralPanel {
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
     let gui_ctx = {
       let ctx_ptr: &mut EguiNativeContext =
-        Var::from_object_ptr_mut_ref(self.instance.get(), &EGUI_CTX_TYPE)?;
+        Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
       &*ctx_ptr
     };
 
     if !self.contents.is_empty() {
-      let ui = util::get_current_parent(self.parents.get())?;
+      let ui = util::get_current_parent(*self.parents.get())?;
       let output = if let Some(ui) = ui {
         egui::CentralPanel::default().show_inside(ui, |ui| {
           util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)

--- a/rust/src/shards/gui/containers/window.rs
+++ b/rust/src/shards/gui/containers/window.rs
@@ -178,7 +178,7 @@ impl Shard for Window {
 
     let mut failed = false;
     if !self.contents.is_empty() {
-      let title: &str = self.title.get().as_ref().try_into()?;
+      let title: &str = self.title.get().try_into()?;
       egui::Window::new(title).show(gui_ctx, |ui| {
         if util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
           .is_err()

--- a/rust/src/shards/gui/containers/window.rs
+++ b/rust/src/shards/gui/containers/window.rs
@@ -172,7 +172,7 @@ impl Shard for Window {
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
     let gui_ctx = {
       let ctx_ptr: &mut EguiNativeContext =
-        Var::from_object_ptr_mut_ref(self.instance.get(), &EGUI_CTX_TYPE)?;
+        Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
       &*ctx_ptr
     };
 

--- a/rust/src/shards/gui/context.rs
+++ b/rust/src/shards/gui/context.rs
@@ -196,7 +196,7 @@ impl Shard for EguiContext {
     let raw_input = unsafe {
       let inputs = shardsc::gfx_getEguiWindowInputs(
         self.input_translator.as_mut_ptr() as *mut shardsc::gfx_EguiInputTranslator,
-        &self.main_window_globals.get(),
+        self.main_window_globals.get(),
       ) as *const egui_gfx::egui_Input;
       egui_gfx::translate_raw_input(&*inputs)
     };
@@ -228,7 +228,7 @@ impl Shard for EguiContext {
 
         let queue_var = self.queue.get();
         unsafe {
-          let queue = shardsc::gfx_getDrawQueueFromVar(&queue_var);
+          let queue = shardsc::gfx_getDrawQueueFromVar(queue_var);
           self.renderer.render(
             &gui_ctx,
             egui_output,

--- a/rust/src/shards/gui/util.rs
+++ b/rust/src/shards/gui/util.rs
@@ -18,7 +18,7 @@ pub(crate) fn activate_ui_contents<'a>(
 ) -> Result<Var, &'a str> {
   // pass the ui parent to the inner shards
   let var = parents.get();
-  let mut seq: Seq = var.as_ref().try_into()?;
+  let mut seq: Seq = var.try_into()?;
 
   unsafe {
     let var = Var::new_object_from_ptr(ui as *const _, &EGUI_UI_TYPE);

--- a/rust/src/shards/gui/widgets/button.rs
+++ b/rust/src/shards/gui/widgets/button.rs
@@ -158,7 +158,7 @@ impl Shard for Button {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
       let label: &str = self.label.get().as_ref().try_into()?;
       let mut button = egui::Button::new(label);
 

--- a/rust/src/shards/gui/widgets/button.rs
+++ b/rust/src/shards/gui/widgets/button.rs
@@ -159,12 +159,12 @@ impl Shard for Button {
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
     if let Some(ui) = util::get_current_parent(*self.parents.get())? {
-      let label: &str = self.label.get().as_ref().try_into()?;
+      let label: &str = self.label.get().try_into()?;
       let mut button = egui::Button::new(label);
 
       let wrap = self.wrap.get();
       if !wrap.is_none() {
-        let wrap: bool = wrap.as_ref().try_into()?;
+        let wrap: bool = wrap.try_into()?;
         button = button.wrap(wrap);
       }
 

--- a/rust/src/shards/gui/widgets/label.rs
+++ b/rust/src/shards/gui/widgets/label.rs
@@ -115,12 +115,12 @@ impl Shard for Label {
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
     if let Some(ui) = util::get_current_parent(*self.parents.get())? {
-      let text: &str = input.as_ref().try_into()?;
+      let text: &str = input.try_into()?;
       let mut label = egui::Label::new(text);
 
       let wrap = self.wrap.get();
       if !wrap.is_none() {
-        let wrap: bool = wrap.as_ref().try_into()?;
+        let wrap: bool = wrap.try_into()?;
         label = label.wrap(wrap);
       }
 

--- a/rust/src/shards/gui/widgets/label.rs
+++ b/rust/src/shards/gui/widgets/label.rs
@@ -114,7 +114,7 @@ impl Shard for Label {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
       let text: &str = input.as_ref().try_into()?;
       let mut label = egui::Label::new(text);
 

--- a/rust/src/shards/hash.rs
+++ b/rust/src/shards/hash.rs
@@ -78,11 +78,11 @@ macro_rules! add_hasher {
             }
           }
         } else {
-          let bytes: Result<&[u8], &str> = input.as_ref().try_into();
+          let bytes: Result<&[u8], &str> = input.try_into();
           if let Ok(bytes) = bytes {
             k.update(bytes);
           } else {
-            let string: Result<&str, &str> = input.as_ref().try_into();
+            let string: Result<&str, &str> = input.try_into();
             if let Ok(string) = string {
               let bytes = string.as_bytes();
               k.update(bytes);
@@ -168,11 +168,11 @@ macro_rules! add_hasher2 {
             }
           }
         } else {
-          let bytes: Result<&[u8], &str> = input.as_ref().try_into();
+          let bytes: Result<&[u8], &str> = input.try_into();
           if let Ok(bytes) = bytes {
             k.update(bytes);
           } else {
-            let string: Result<&str, &str> = input.as_ref().try_into();
+            let string: Result<&str, &str> = input.try_into();
             if let Ok(string) = string {
               let bytes = string.as_bytes();
               k.update(bytes);
@@ -246,11 +246,11 @@ macro_rules! add_hasher3 {
             }
           }
         } else {
-          let bytes: Result<&[u8], &str> = input.as_ref().try_into();
+          let bytes: Result<&[u8], &str> = input.try_into();
           if let Ok(bytes) = bytes {
             self.scratch.extend(bytes);
           } else {
-            let string: Result<&str, &str> = input.as_ref().try_into();
+            let string: Result<&str, &str> = input.try_into();
             if let Ok(string) = string {
               let bytes = string.as_bytes();
               self.scratch.extend(bytes);

--- a/rust/src/shards/http.rs
+++ b/rust/src/shards/http.rs
@@ -284,12 +284,12 @@ macro_rules! get_like {
     impl BlockingShard for $shard_name {
       fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
         let request = self.rb.url.get();
-        let request_string: &str = request.as_ref().try_into()?;
+        let request_string: &str = request.try_into()?;
         let mut request = self.rb.client.as_ref().unwrap().$call(request_string);
         request = request.timeout(Duration::from_secs(self.rb.timeout));
         let headers = self.rb.headers.get();
         if !headers.is_none() {
-          let headers_table: Table = headers.as_ref().try_into()?;
+          let headers_table: Table = headers.try_into()?;
           for (k, v) in headers_table.iter() {
             let key: &str = k.into();
             let hname: HeaderName = key
@@ -302,7 +302,7 @@ macro_rules! get_like {
         }
 
         if !input.is_none() {
-          let input_table: Table = input.as_ref().try_into()?;
+          let input_table: Table = input.try_into()?;
           for (k, v) in input_table.iter() {
             let key: &str = k.into();
             let value: &str = v.as_ref().try_into()?;
@@ -379,13 +379,13 @@ macro_rules! post_like {
     impl BlockingShard for $shard_name {
       fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
         let request = self.rb.url.get();
-        let request_string: &str = request.as_ref().try_into()?;
+        let request_string: &str = request.try_into()?;
         let mut request = self.rb.client.as_ref().unwrap().$call(request_string);
         request = request.timeout(Duration::from_secs(self.rb.timeout));
         let headers = self.rb.headers.get();
         if !input.is_none() {
           // .form ( kv table )
-          let input_table: Result<Table, &str> = input.as_ref().try_into();
+          let input_table: Result<Table, &str> = input.try_into();
           if let Ok(input_table) = input_table {
             for (k, v) in input_table.iter() {
               let key: &str = k.into();
@@ -396,14 +396,14 @@ macro_rules! post_like {
             request = request.header("content-type", "application/x-www-form-urlencoded");
           } else {
             // .body ( string )
-            let input_string: Result<&str, &str> = input.as_ref().try_into();
+            let input_string: Result<&str, &str> = input.try_into();
             if let Ok(input_string) = input_string {
               // default to this in this case but users can edit under
               request = request.header("content-type", "application/json");
               request = request.body(input_string);
             } else {
               // .body ( bytes )
-              let input_bytes: Result<&[u8], &str> = input.as_ref().try_into();
+              let input_bytes: Result<&[u8], &str> = input.try_into();
               if let Ok(input_bytes) = input_bytes {
                 request = request.body(input_bytes);
                 // default to this in this case but users can edit under

--- a/rust/src/shards/physics/forces.rs
+++ b/rust/src/shards/physics/forces.rs
@@ -142,7 +142,7 @@ impl Shard for Impulse {
     for rb in &rb.rigid_bodies {
       let rb = simulation.bodies.get_mut(*rb);
       if let Some(rb) = rb {
-        let (x, y, z) = input.as_ref().try_into()?;
+        let (x, y, z) = input.try_into()?;
         rb.apply_impulse(Vector3::new(x, y, z), true);
       } else {
         return Err("RigidBody not found in the simulation");

--- a/rust/src/shards/physics/forces.rs
+++ b/rust/src/shards/physics/forces.rs
@@ -132,11 +132,11 @@ impl Shard for Impulse {
   }
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
     let simulation = self.simulation.get();
-    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(simulation, &SIMULATION_TYPE)
+    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(*simulation, &SIMULATION_TYPE)
       .map_err(|_| "Physics simulation not found")?;
 
     let rb = self.rb.get();
-    let rb = Var::from_object_mut_ref::<RigidBody>(rb, &RIGIDBODY_TYPE)
+    let rb = Var::from_object_mut_ref::<RigidBody>(*rb, &RIGIDBODY_TYPE)
       .map_err(|_| "RigidBody not found")?;
 
     for rb in &rb.rigid_bodies {

--- a/rust/src/shards/physics/queries.rs
+++ b/rust/src/shards/physics/queries.rs
@@ -85,7 +85,7 @@ impl Shard for CastRay {
     self.output.clear();
 
     let simulation = self.simulation_var.get();
-    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(simulation, &SIMULATION_TYPE)
+    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(*simulation, &SIMULATION_TYPE)
       .map_err(|_| "Physics simulation not found.")?;
 
     let inputs: Seq = input.try_into().unwrap();

--- a/rust/src/shards/physics/rigidbody.rs
+++ b/rust/src/shards/physics/rigidbody.rs
@@ -144,7 +144,7 @@ impl RigidBody {
   fn _cleanup(&mut self) {
     if let Some(simulation) = self.simulation_var.try_get() {
       let simulation =
-        Var::from_object_ptr_mut_ref::<Simulation>(simulation, &SIMULATION_TYPE).unwrap();
+        Var::from_object_ptr_mut_ref::<Simulation>(*simulation, &SIMULATION_TYPE).unwrap();
       for rigid_body in &self.rigid_bodies {
         // this removes both RigidBodies and colliders attached.
         simulation.bodies.remove(
@@ -246,7 +246,7 @@ impl RigidBody {
       let rigid_body = {
         // Mut borrow - this is repeated a lot sadly - TODO figure out
         let simulation =
-          Var::from_object_ptr_mut_ref::<Simulation>(self.simulation_var.get(), &SIMULATION_TYPE)?;
+          Var::from_object_ptr_mut_ref::<Simulation>(*self.simulation_var.get(), &SIMULATION_TYPE)?;
         let rigid_body = Self::make_rigid_body(simulation, self.user_data, status, p, r)?;
         self.rigid_bodies.push(rigid_body);
         rigid_body
@@ -258,7 +258,7 @@ impl RigidBody {
         for shape in shapes {
           // Mut borrow - this is repeated a lot sadly - TODO figure out
           let simulation = Var::from_object_ptr_mut_ref::<Simulation>(
-            self.simulation_var.get(),
+            *self.simulation_var.get(),
             &SIMULATION_TYPE,
           )?;
           self.colliders.push(Self::make_collider(
@@ -271,11 +271,11 @@ impl RigidBody {
       } else {
         // Mut borrow - this is repeated a lot sadly - TODO figure out
         let simulation =
-          Var::from_object_ptr_mut_ref::<Simulation>(self.simulation_var.get(), &SIMULATION_TYPE)?;
+          Var::from_object_ptr_mut_ref::<Simulation>(*self.simulation_var.get(), &SIMULATION_TYPE)?;
         self.colliders.push(Self::make_collider(
           simulation,
           self.user_data,
-          shape,
+          *shape,
           rigid_body,
         )?);
       }
@@ -298,7 +298,7 @@ impl RigidBody {
         let rigid_body = {
           // Mut borrow - this is repeated a lot sadly - TODO figure out
           let simulation = Var::from_object_ptr_mut_ref::<Simulation>(
-            self.simulation_var.get(),
+            *self.simulation_var.get(),
             &SIMULATION_TYPE,
           )?;
           if r.is_seq() {
@@ -320,7 +320,7 @@ impl RigidBody {
           for shape in shapes {
             // Mut borrow - this is repeated a lot sadly - TODO figure out
             let simulation = Var::from_object_ptr_mut_ref::<Simulation>(
-              self.simulation_var.get(),
+              *self.simulation_var.get(),
               &SIMULATION_TYPE,
             )?;
             self.colliders.push(Self::make_collider(
@@ -333,13 +333,13 @@ impl RigidBody {
         } else {
           // Mut borrow - this is repeated a lot sadly - TODO figure out
           let simulation = Var::from_object_ptr_mut_ref::<Simulation>(
-            self.simulation_var.get(),
+            *self.simulation_var.get(),
             &SIMULATION_TYPE,
           )?;
           self.colliders.push(Self::make_collider(
             simulation,
             self.user_data,
-            shape,
+            *shape,
             rigid_body,
           )?);
         }
@@ -349,12 +349,12 @@ impl RigidBody {
   }
 
   fn _populate(&mut self, status: RigidBodyType) -> Result<(&[RigidBodyHandle], Var, Var), &str> {
-    let p = &self.position.get();
-    let r = &self.rotation.get();
+    let p = *self.position.get();
+    let r = *self.rotation.get();
     if p.is_seq() {
-      self.populate_multi(status, p, r)
+      self.populate_multi(status, &p, &r)
     } else {
-      self.populate_single(status, p, r)
+      self.populate_single(status, &p, &r)
     }
   }
 }
@@ -611,7 +611,7 @@ impl Shard for DynamicRigidBody {
     // after that will be driven by the physics engine so what we do is get the new matrix and output it
     let rbData = Rc::get_mut(&mut self.rb).unwrap();
     let sim_var = rbData.simulation_var.get();
-    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(sim_var, &SIMULATION_TYPE)?;
+    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(*sim_var, &SIMULATION_TYPE)?;
     let (rbs, _, _) = rbData._populate(RigidBodyType::Dynamic)?;
     if rbs.len() == 1 {
       let rb = simulation.bodies.get(rbs[0]).unwrap();
@@ -755,7 +755,7 @@ impl Shard for KinematicRigidBody {
     // it will also output a properly interpolated matrix
     let rbData = Rc::get_mut(&mut self.rb).unwrap();
     let sim_var = rbData.simulation_var.get();
-    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(sim_var, &SIMULATION_TYPE)?;
+    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(*sim_var, &SIMULATION_TYPE)?;
     let (rbs, p, r) = rbData._populate(RigidBodyType::KinematicPositionBased)?; // TODO KinematicVelocityBased as well
     if rbs.len() == 1 {
       let rb = simulation.bodies.get_mut(rbs[0]).unwrap();

--- a/rust/src/shards/physics/shapes.rs
+++ b/rust/src/shards/physics/shapes.rs
@@ -113,7 +113,7 @@ macro_rules! shape {
           if p.is_none() {
             Vector3::new(0.0, 0.0, 0.0)
           } else {
-            let (tx, ty, tz): (f32, f32, f32) = p.as_ref().try_into()?;
+            let (tx, ty, tz): (f32, f32, f32) = p.try_into()?;
             Vector3::new(tx, ty, tz)
           }
         };
@@ -122,7 +122,7 @@ macro_rules! shape {
           if r.is_none() {
             Isometry3::new(pos, Vector3::new(0.0, 0.0, 0.0))
           } else {
-            let quaternion: Result<(f32, f32, f32, f32), &str> = r.as_ref().try_into();
+            let quaternion: Result<(f32, f32, f32, f32), &str> = r.try_into();
             if let Ok(quaternion) = quaternion {
               let quaternion =
                 Quaternion::new(quaternion.3, quaternion.0, quaternion.1, quaternion.2);
@@ -188,7 +188,7 @@ impl BallShape {
   }
 
   fn make(&mut self) -> SharedShape {
-    let radius = self.radius.get().as_ref().try_into().unwrap();
+    let radius = self.radius.get().try_into().unwrap();
     SharedShape::ball(radius)
   }
 
@@ -259,7 +259,7 @@ impl CubeShape {
   }
 
   fn make(&mut self) -> SharedShape {
-    let (x, y, z) = self.half_extents.get().as_ref().try_into().unwrap();
+    let (x, y, z) = self.half_extents.get().try_into().unwrap();
     SharedShape::cuboid(x, y, z)
   }
 

--- a/rust/src/shards/substrate.rs
+++ b/rust/src/shards/substrate.rs
@@ -103,15 +103,15 @@ lazy_static! {
   static ref METADATA_TYPES: Vec<Type> = vec![*METADATA_TYPE];
 }
 
-fn get_key<T: Pair>(input: Var) -> Result<T, &'static str> {
-  let key: Result<&[u8], &str> = input.as_ref().try_into();
+fn get_key<T: Pair>(input: &Var) -> Result<T, &'static str> {
+  let key: Result<&[u8], &str> = input.try_into();
   if let Ok(key) = key {
     T::from_seed_slice(key).map_err(|e| {
       shlog!("{:?}", e);
       "Failed to parse secret key"
     })
   } else {
-    let key: Result<&str, &str> = input.as_ref().try_into();
+    let key: Result<&str, &str> = input.try_into();
     if let Ok(key) = key {
       T::from_string(key, None).map_err(|e| {
         shlog!("{:?}", e);
@@ -195,7 +195,7 @@ impl Shard for AccountId {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let bytes: &[u8] = input.as_ref().try_into()?;
+    let bytes: &[u8] = input.try_into()?;
     let prefix: u16 = self
       .version
       .try_into()
@@ -629,7 +629,7 @@ impl Shard for SHDecode {
   }
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
-    let bytes: &[u8] = input.as_ref().try_into()?;
+    let bytes: &[u8] = input.try_into()?;
     let types: Seq = self.types.0.try_into()?;
     let hints: Seq = self.hints.0.try_into()?;
     let mut offset = 0;

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -2766,9 +2766,9 @@ impl ParamVar {
     }
   }
 
-  pub fn get(&self) -> Var {
+  pub fn get(&self) -> &Var {
     assert_ne!(self.pointee, std::ptr::null_mut());
-    unsafe { *self.pointee }
+    unsafe { &*self.pointee }
   }
 
   pub fn get_mut(&mut self) -> &mut Var {
@@ -2776,12 +2776,11 @@ impl ParamVar {
     unsafe { &mut *self.pointee }
   }
 
-  pub fn try_get(&self) -> Option<Var> {
+  pub fn try_get(&self) -> Option<&Var> {
     if self.pointee.is_null() {
       None
     } else {
-      let v = unsafe { *self.pointee };
-      Some(v)
+      Some(unsafe { &*self.pointee })
     }
   }
 


### PR DESCRIPTION
`ParamVar::get()` now returns a `&Var` instead of `Var` which created a copy.

This should make it a bit more efficient since a lot of time we get it in order to convert it into another value:
```rust
let text: &str = self.label.get().as_ref().try_into()?;
// can be simplified to
let text: &str = self.label.get().try_into()?;
```

In the other cases where we do need to get a `Var` we can make an explicit copy by dereferencing:
```rust
let simulation: Var = *self.simulation.get();
```