### PR TITLE
Move logging setup code. Add runtime log levels

### DIFF
--- a/cmake/Root.cmake
+++ b/cmake/Root.cmake
@@ -27,6 +27,7 @@ set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 
 add_subdirectory(${SHARDS_DIR}/deps deps)
 
+add_subdirectory(${SHARDS_DIR}/src/log src/log)
 add_subdirectory(${SHARDS_DIR}/src/core src/core)
 add_subdirectory(${SHARDS_DIR}/src/mal src/mal)
 add_subdirectory(${SHARDS_DIR}/src/gfx src/gfx)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -105,6 +105,19 @@ if(NOT EMSCRIPTEN)
   else()
     target_compile_definitions(SDL2-static INTERFACE "SDL_MAIN_HANDLED=1")
   endif()
+else()
+  add_library(SDL2-static INTERFACE)
+  add_library(SDL2main INTERFACE)
+
+  # Use builtin SDL2 port
+  target_compile_options(SDL2-static INTERFACE
+    "SHELL:-s USE_SDL=2"
+  )
+  target_link_options(SDL2-static INTERFACE
+    "SHELL:-s MIN_WEBGL_VERSION=2"
+    "SHELL:-s MAX_WEBGL_VERSION=2"
+    "SHELL:-s USE_SDL=2"
+  )
 endif()
 
 sh_add_external_project(

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 target_link_libraries(shards-core-static
   spdlog magic_enum nameof linalg xxHash
   pdqsort utf8.h Taskflow stb nlohmann_json m3 ghc_filesystem
+  shards-logging
 )
 
 if(DESKTOP)

--- a/src/extra/CMakeLists.txt
+++ b/src/extra/CMakeLists.txt
@@ -27,19 +27,7 @@ else()
   add_library(shards-extra STATIC ${extra_SOURCES})
 endif()
 
-if(EMSCRIPTEN)
-  # Use builtin SDL2 port
-  target_compile_options(shards-extra PUBLIC
-    "SHELL:-s USE_SDL=2"
-  )
-  target_link_options(shards-extra PUBLIC
-    "SHELL:-s MIN_WEBGL_VERSION=2"
-    "SHELL:-s MAX_WEBGL_VERSION=2"
-    "SHELL:-s USE_SDL=2"
-  )
-else()
-  target_link_libraries(shards-extra SDL2-static)
-endif()
+target_link_libraries(shards-extra SDL2-static)
 
 target_link_libraries(shards-extra
   shards-core

--- a/src/gfx/CMakeLists.txt
+++ b/src/gfx/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(gfx
   tinygltf
   magic_enum nameof
   spdlog stb xxHash Boost::algorithm Boost::filesystem
+  shards-logging
 )
 target_precompile_headers(gfx PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp>")
 

--- a/src/gfx/egui/renderer.cpp
+++ b/src/gfx/egui/renderer.cpp
@@ -16,12 +16,16 @@
 #include <gfx/context.hpp>
 #include <gfx/window.hpp>
 #include <gfx/gfx_wgpu.hpp>
+#include <gfx/log.hpp>
 #include <spdlog/spdlog.h>
 #include <map>
 #include <vector>
 #include <memory>
 
 namespace gfx {
+
+static auto logger = getLogger();
+
 struct MeshPoolOps {
   size_t getCapacity(MeshPtr &item) const { return item->getNumVertices() * item->getFormat().getVertexSize(); }
   void init(MeshPtr &item) const { item = std::make_shared<Mesh>(); }
@@ -146,7 +150,7 @@ struct EguiRendererImpl {
 
   void processPendingTextureFrees() {
     for (auto &id : pendingTextureFrees) {
-      SPDLOG_INFO("textureFree {}", (uint64_t)id.id);
+      SPDLOG_LOGGER_INFO(logger, "textureFree {}", (uint64_t)id.id);
       textures.free(id);
     }
     pendingTextureFrees.clear();
@@ -162,7 +166,7 @@ void EguiRenderer::render(const egui::FullOutput &output, const gfx::DrawQueuePt
   auto &textureUpdates = output.textureUpdates;
   for (size_t i = 0; i < textureUpdates.numSets; i++) {
     auto &textureSet = textureUpdates.sets[i];
-    SPDLOG_INFO("textureSet {}", (uint64_t)textureSet.id);
+    SPDLOG_LOGGER_INFO(logger, "textureSet {}", (uint64_t)textureSet.id);
     impl->textures.set(textureSet);
   }
 

--- a/src/gfx/log.hpp
+++ b/src/gfx/log.hpp
@@ -1,0 +1,19 @@
+#ifndef DDE8DFC5_0F92_481A_AF98_812B4A76BE44
+#define DDE8DFC5_0F92_481A_AF98_812B4A76BE44
+
+#include <log/log.hpp>
+namespace gfx {
+
+inline shards::logging::Logger getLogger() {
+  auto logger = spdlog::get("GFX");
+  if (!logger) {
+    logger = std::make_shared<spdlog::logger>("GFX");
+    // Set default log level to warn to be less verbose
+    logger->set_level(spdlog::level::warn);
+    shards::logging::init(logger);
+  }
+  return logger;
+}
+} // namespace gfx
+
+#endif /* DDE8DFC5_0F92_481A_AF98_812B4A76BE44 */

--- a/src/gfx/renderer.cpp
+++ b/src/gfx/renderer.cpp
@@ -17,6 +17,7 @@
 #include "texture_placeholder.hpp"
 #include "view.hpp"
 #include "view_texture.hpp"
+#include "log.hpp"
 #include <algorithm>
 #include <magic_enum.hpp>
 #include <spdlog/spdlog.h>
@@ -31,6 +32,8 @@ using shader::TextureBindingLayoutBuilder;
 using shader::UniformBufferLayout;
 using shader::UniformBufferLayoutBuilder;
 using shader::UniformLayout;
+
+static auto logger = getLogger();
 
 PipelineStepPtr makeDrawablePipelineStep(RenderDrawablesStep &&step) { return std::make_shared<PipelineStep>(std::move(step)); }
 
@@ -989,7 +992,7 @@ struct RendererImpl final : public ContextData {
 
     wgslModuleDesc.chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
     wgpuShaderModuleWGSLDescriptorSetCode(wgslModuleDesc, generatorOutput.wgslSource.c_str());
-    spdlog::info("Generated WGSL:\n {}", generatorOutput.wgslSource);
+    SPDLOG_LOGGER_DEBUG(logger, "Generated WGSL:\n {}", generatorOutput.wgslSource);
 
     cachedPipeline.shaderModule = wgpuDeviceCreateShaderModule(context.wgpuDevice, &moduleDesc);
     assert(cachedPipeline.shaderModule);

--- a/src/gfx/tests/data.cpp
+++ b/src/gfx/tests/data.cpp
@@ -190,7 +190,7 @@ void TestData::storeFrame(const TestFrame &frame, const char *filePath) {
     return;
   }
 
-  spdlog::info("Writing frame data to {}", filePath);
+  SPDLOG_INFO("Writing frame data to {}", filePath);
   const std::vector<TestFrame::pixel_t> &pixels = frame.getPixels();
   stbi_write_png(filePath, size.x, size.y, 4, pixels.data(), sizeof(TestFrame::pixel_t) * size.x);
 

--- a/src/gfx/tests/sandbox.cpp
+++ b/src/gfx/tests/sandbox.cpp
@@ -232,7 +232,7 @@ struct App {
           static float fpsCounter = 0.0f;
           fpsCounter += deltaTime;
           if (fpsCounter >= 1.0f) {
-            spdlog::info("Average FPS: {:0.01f}", 1.0f / delaTimeMa.getAverage());
+            SPDLOG_INFO("Average FPS: {:0.01f}", 1.0f / delaTimeMa.getAverage());
             fpsCounter = 0.0f;
           }
         }

--- a/src/gfx/tests/test_shader.cpp
+++ b/src/gfx/tests/test_shader.cpp
@@ -140,7 +140,7 @@ TEST_CASE("Shader basic", "[Shader]") {
       blocks::makeCompoundBlock(blocks::WriteOutput("color", colorFieldType, "vec4<f32>(0.0, 1.0, 0.0, 1.0);")));
 
   GeneratorOutput output = generator.build(entryPoints);
-  spdlog::info(output.wgslSource);
+  SPDLOG_INFO(output.wgslSource);
 
   GeneratorOutput::dumpErrors(output);
   CHECK(output.errors.empty());
@@ -186,7 +186,7 @@ TEST_CASE("Shader globals & dependencies", "[Shader]") {
   entryPoints.back().dependencies.emplace_back("colorDefault", DependencyType::After);
 
   GeneratorOutput output = generator.build(entryPoints);
-  spdlog::info(output.wgslSource);
+  SPDLOG_INFO(output.wgslSource);
 
   GeneratorOutput::dumpErrors(output);
   CHECK(output.errors.empty());
@@ -220,7 +220,7 @@ TEST_CASE("Shader textures", "[Shader]") {
   entryPoints.emplace_back("interpolate", ProgrammableGraphicsStage::Vertex, blocks::DefaultInterpolation());
 
   GeneratorOutput output = generator.build(entryPoints);
-  spdlog::info(output.wgslSource);
+  SPDLOG_INFO(output.wgslSource);
 
   GeneratorOutput::dumpErrors(output);
   CHECK(output.errors.empty());

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(shards-logging log.cpp)
+target_include_directories(shards-logging PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+target_link_libraries(shards-logging spdlog SDL2-static magic_enum Boost::filesystem)
+
+if(DESKTOP)
+  target_compile_definitions(shards-logging PRIVATE SHARDS_LOG_FILE=1)
+endif()

--- a/src/log/log.cpp
+++ b/src/log/log.cpp
@@ -74,7 +74,7 @@ static void setupDefaultLogger() {
 #endif
 
   // Set default log level
-  spdlog::set_level(spdlog::level::info);
+  spdlog::set_level(spdlog::level::level_enum(SPDLOG_ACTIVE_LEVEL));
 
   // Init log level from environment variable
   initLogLevel(logger);

--- a/src/log/log.cpp
+++ b/src/log/log.cpp
@@ -1,0 +1,93 @@
+#include "log.hpp"
+#include <spdlog/spdlog.h>
+#include <vector>
+#include <SDL_stdinc.h>
+#include <magic_enum.hpp>
+#include <boost/filesystem.hpp>
+#include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#ifdef __ANDROID__
+#include <spdlog/sinks/android_sink.h>
+#endif
+
+namespace shards::logging {
+void init(Logger logger) {
+  initLogLevel(logger);
+  initSinks(logger);
+}
+
+void initLogLevel(Logger logger) {
+  std::string varName = fmt::format("LOG_{}", logger->name());
+  if (const char *val = SDL_getenv(varName.c_str())) {
+    auto enumVal = magic_enum::enum_cast<spdlog::level::level_enum>(val);
+    if (enumVal.has_value()) {
+      logger->set_level(enumVal.value());
+    }
+  }
+}
+
+void initSinks(Logger logger) { logger->sinks() = spdlog::default_logger()->sinks(); }
+
+Logger get(const std::string &name) {
+  auto logger = spdlog::get(name);
+  if (!logger) {
+    logger = std::make_shared<spdlog::logger>(name);
+    init(logger);
+    spdlog::register_logger(logger);
+  }
+  return logger;
+}
+
+void redirectAll(const std::vector<spdlog::sink_ptr> &sinks) {
+  spdlog::apply_all([&](Logger logger) { logger->sinks() = sinks; });
+}
+
+static void setupDefaultLogger() {
+  auto dist_sink = std::make_shared<spdlog::sinks::dist_sink_mt>();
+
+  auto sink1 = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+  dist_sink->add_sink(sink1);
+
+  // Setup log file
+#ifdef SHARDS_LOG_FILE
+  std::string logFilePath = boost::filesystem::absolute("shards.log").string();
+  auto sink2 = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logFilePath.c_str(), 1048576, 3, false);
+  dist_sink->add_sink(sink2);
+#endif
+
+  auto logger = std::make_shared<spdlog::logger>("shards", dist_sink);
+  logger->flush_on(spdlog::level::err);
+  spdlog::set_default_logger(logger);
+
+  // Setup android logcat output
+#ifdef __ANDROID__
+  auto android_sink = std::make_shared<spdlog::sinks::android_sink_mt>("shards");
+  logger->sinks().push_back(android_sink);
+#endif
+
+#ifdef __ANDROID
+  // Logcat already countains timestamps & log level
+  spdlog::set_pattern("[T-%t] [%s::%#] %v");
+#else
+  spdlog::set_pattern("%^[%l]%$ [%Y-%m-%d %T.%e] [T-%t] [%s::%#] %v");
+#endif
+
+  // Set default log level
+  spdlog::set_level(spdlog::level::info);
+
+  // Init log level from environment variable
+  initLogLevel(logger);
+
+  // Redirect all existing loggers to the default sink
+  redirectAll(logger->sinks());
+}
+
+void setupDefaultLoggerConditional() {
+  static bool initialized = false;
+  if (!initialized) {
+    initialized = true;
+    setupDefaultLogger();
+  }
+}
+} // namespace shards::logging

--- a/src/log/log.hpp
+++ b/src/log/log.hpp
@@ -1,0 +1,23 @@
+#ifndef E8296F1D_E25F_4AC4_AA7C_D680CA0D7ABF
+#define E8296F1D_E25F_4AC4_AA7C_D680CA0D7ABF
+
+#include <string>
+#include <spdlog/spdlog.h>
+#include <vector>
+
+namespace shards::logging {
+typedef std::shared_ptr<spdlog::logger> Logger;
+Logger get(const std::string &name);
+// Set default log level and redirect to main logger
+void init(Logger logger);
+// Redirects this logger to the same output as the default logger
+void initSinks(Logger logger);
+// Sets the log level for this logger based on the LOG_<name> environment variable if it is set
+void initLogLevel(Logger logger);
+void redirectAll(const std::vector<spdlog::sink_ptr> &sinks);
+
+// Setup the default logger if it's not setup already
+void setupDefaultLoggerConditional();
+} // namespace shards::logging
+
+#endif /* E8296F1D_E25F_4AC4_AA7C_D680CA0D7ABF */

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -21,6 +21,7 @@
 #include <ostream>
 #include <set>
 #include <thread>
+#include <log/log.hpp>
 
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -50,9 +51,6 @@ static StaticList<malBuiltIn *> handlers;
     return mal::boolean(DYNAMIC_CAST(type, *argsBegin)); \
   }
 
-namespace shards {
-extern void setupSpdLogConditional();
-}
 extern void shRegisterAllShards();
 
 #ifndef SH_CORE_ONLY
@@ -87,7 +85,7 @@ static std::map<malEnv *, std::shared_ptr<Observer>> observers;
 
 void installSHCore(const malEnvPtr &env, const char *exePath, const char *scriptPath) {
   // Setup logging first
-  shards::setupSpdLogConditional();
+  logging::setupDefaultLoggerConditional();
 
   std::shared_ptr<Observer> obs;
   setupObserver(obs, env);


### PR DESCRIPTION
- Move some of the logger setup code to a separate "module"
- Automatically grab runtime log level from a `LOG_<logger_name>=debug/trace/info/etc.` environment variable
- Examples:
  - `LOG_GFX=debug` debug output from graphics enabled
  - `LOG_shards=trace` trace logging from shards enabled
- The behavior of compiling out DEBUG/TRACE logs in release builds is still intact so trying to enabled them does nothing unless the log calls were outside of macros

Seems to close https://github.com/fragcolor-xyz/shards/issues/272 too