### PR TITLE
Rust shards enum

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -8,6 +8,7 @@ use crate::shard::Shard;
 use crate::shardsc::SHBool;
 use crate::shardsc::SHContext;
 use crate::shardsc::SHCore;
+use crate::shardsc::SHEnumInfo;
 use crate::shardsc::SHOptionalString;
 use crate::shardsc::SHString;
 use crate::shardsc::SHStrings;
@@ -376,6 +377,12 @@ pub fn releaseVariable(var: &SHVar) {
   unsafe {
     let v = var as *const SHVar as *mut SHVar;
     (*Core).releaseVariable.unwrap()(v);
+  }
+}
+
+pub fn registerEnumType(vendorId: i32, typeId: i32, info: SHEnumInfo) {
+  unsafe {
+    (*Core).registerEnumType.unwrap()(vendorId, typeId, info);
   }
 }
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -845,6 +845,18 @@ impl Type {
     }
   }
 
+  pub const fn enumeration(vendorId: i32, typeId: i32) -> Type {
+    Type {
+      basicType: SHType_Enum,
+      details: SHTypeInfo_Details {
+        enumeration: SHTypeInfo_Details_Enum { vendorId, typeId },
+      },
+      fixedSize: 0,
+      innerType: SHType_None,
+      recursiveSelf: false,
+    }
+  }
+
   pub const fn object(vendorId: i32, typeId: i32) -> Type {
     Type {
       basicType: SHType_Object,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3197,6 +3197,36 @@ macro_rules! __impl_shenuminfo {
   };
 }
 
+#[macro_export]
+macro_rules! shenum_types {
+  (
+    $SHEnumInfo:ident,
+    const $SHEnumCC:ident = $value:expr;
+    static ref $SHEnumEnumInfo:ident;
+    static ref $SHEnum_TYPE:ident: Type;
+    static ref $SHEnum_TYPES:ident: Vec<Type>;
+    static ref $SEQ_OF_SHEnum:ident: Type;
+    static ref $SEQ_OF_SHEnum_TYPES:ident: Vec<Type>;
+
+    $($t:tt)*
+  ) => {
+    const $SHEnumCC: i32 = $value;
+
+    lazy_static! {
+      static ref $SHEnumEnumInfo: $SHEnumInfo = $SHEnumInfo::new();
+      static ref $SHEnum_TYPE: Type = Type::enumeration(FRAG_CC, $SHEnumCC);
+      static ref $SHEnum_TYPES: Vec<Type> = vec![*$SHEnum_TYPE];
+      static ref $SEQ_OF_SHEnum: Type = Type::seq(&$SHEnum_TYPES);
+      static ref $SEQ_OF_SHEnum_TYPES: Vec<Type> = vec![*$SEQ_OF_SHEnum];
+    }
+
+    shenum_types! {
+      $($t)*
+    }
+  };
+  () => {};
+}
+
 // Strings / SHStrings
 
 #[derive(Clone)]

--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -144,7 +144,6 @@ void setSharedVariable(const char *name, const SHVar &value);
 void unsetSharedVariable(const char *name);
 SHVar getSharedVariable(const char *name);
 SHWireState suspend(SHContext *context, double seconds);
-void registerEnumType(int32_t vendorId, int32_t enumId, SHEnumInfo info);
 
 Shard *createShard(std::string_view name);
 void registerCoreShards();


### PR DESCRIPTION
Add support for declaring shards enum in rust.

There are two macros: `shenum!`  and `shenum_types`. The first one is very similar to what `bitflags!` was doing, except it doesn't generate operators for now. The second one declares the various `Type` that are required if we want to use the enum as input/output or parameter type.

Fixes #366.