### PR TITLE
Add macros to override the activate function

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,6 +25,7 @@ extern crate lazy_static;
 extern crate compile_time_crc32;
 
 pub mod core;
+#[macro_use]
 pub mod shard;
 mod shardsc;
 #[macro_use]


### PR DESCRIPTION
Add two macros: `decl_override_activate` called during `compose`, and `impl_override_activate` that creates an `extern "C"` function that can be called from the C++ side.

Typical usage:

```rust
impl Shard for OverrideTest {
  fn hasCompose() -> bool {
    true
  }

  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
    match data.inputType.basicType {
      SHType_Float => decl_override_activate! {
        data.activate = OverrideTest::float_activate;
      },
      SHType_Int => decl_override_activate! {
        data.activate = OverrideTest::int_activate;
      },
      _ => (),
    }

    Ok(data.inputType)
  }

  fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
    Err("Invalid input type")
  }
}

impl OverrideTest {
  fn activateFloat(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
    Ok(*input)
  }

  fn activateInt(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
    Ok(*input)
  }

  impl_override_activate! {
    extern "C" fn float_activate() -> Var {
      OverrideTest::activateFloat()
    }
  }

  impl_override_activate! {
    extern "C" fn int_activate() -> Var {
      OverrideTest::activateInt()
    }
  }
}


```