### PR TITLE
Update egui to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,10 +51,11 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
+ "cfg-if",
  "getrandom 0.2.7",
  "once_cell",
  "version_check",
@@ -848,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb095a8b9feb9b7ff8f00b6776dffcef059538a3f4a91238e03c900e9c9ad9a2"
+checksum = "fc9fcd393c3daaaf5909008a1d948319d538b79c51871e4df0993260260a94e4"
 dependencies = [
  "ahash",
  "epaint",
@@ -876,9 +877,9 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "emath"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c223f58c7e38abe1770f367b969f1b3fbd4704b67666bcb65dbb1adb0980ba72"
+checksum = "9542a40106fdba943a055f418d1746a050e1a903a049b030c2b097d4686a33cf"
 
 [[package]]
 name = "encoding_rs"
@@ -910,9 +911,9 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "epaint"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c29567088888e8ac3e8f61bbb2ddc820207ebb8d69eefde5bcefa06d65e4e89"
+checksum = "5ba04741be7f6602b1a1b28f1082cce45948a7032961c52814f8946b28493300"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,7 +41,7 @@ parity-scale-codec = { version = "2.3.1", default-features = false, optional = t
 chrono = { version = "0.4", optional = true }
 
 chacha20poly1305 = { version = "0.9.0", optional = true }
-egui = { version = "0.18.1", optional = true }
+egui = { version = "0.19.0", optional = true }
 egui-gfx = { path = "../src/gfx/egui", optional = true }
 half = { version = "2.0.0" }
 

--- a/rust/src/shards/gui/widgets/image.rs
+++ b/rust/src/shards/gui/widgets/image.rs
@@ -160,12 +160,12 @@ impl Shard for Image {
 impl Image {
   fn activateImage(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
     if let Some(ui) = util::get_current_parent(*self.parents.get())? {
-      let image: &SHImage = input.try_into()?;
-      let ptr = image.data;
+      let shimage: &SHImage = input.try_into()?;
+      let ptr = shimage.data;
       let texture = if ptr != self.prev_ptr {
-        let image: egui::ColorImage = image.into();
+        let image: egui::ColorImage = shimage.into();
         self.prev_ptr = ptr;
-        self.texture.insert(ui.ctx().load_texture("example", image, Default::default())) // FIXME name
+        self.texture.insert(ui.ctx().load_texture(format!("UI.Image: {:p}", shimage.data), image, Default::default()))
       } else {
         self.texture.as_ref().unwrap()
       };

--- a/rust/src/shards/gui/widgets/image.rs
+++ b/rust/src/shards/gui/widgets/image.rs
@@ -165,7 +165,7 @@ impl Image {
       let texture = if ptr != self.prev_ptr {
         let image: egui::ColorImage = image.into();
         self.prev_ptr = ptr;
-        self.texture.insert(ui.ctx().load_texture("example", image))
+        self.texture.insert(ui.ctx().load_texture("example", image, Default::default())) // FIXME name
       } else {
         self.texture.as_ref().unwrap()
       };

--- a/rust/src/shards/gui/widgets/image_button.rs
+++ b/rust/src/shards/gui/widgets/image_button.rs
@@ -229,7 +229,7 @@ impl Shard for ImageButton {
         let image: &SHImage = input.try_into().unwrap();
         let image: egui::ColorImage = image.into();
 
-        ui.ctx().load_texture("example", image) // FIXME name
+        ui.ctx().load_texture("example", image, Default::default()) // FIXME name
       });
 
       let scale: (f32, f32) = self.scale.get().try_into()?;

--- a/rust/src/shards/gui/widgets/image_button.rs
+++ b/rust/src/shards/gui/widgets/image_button.rs
@@ -226,10 +226,10 @@ impl Shard for ImageButton {
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
     if let Some(ui) = util::get_current_parent(*self.parents.get())? {
       let texture = &*self.texture.get_or_insert_with(|| {
-        let image: &SHImage = input.try_into().unwrap();
-        let image: egui::ColorImage = image.into();
+        let shimage: &SHImage = input.try_into().unwrap();
+        let image: egui::ColorImage = shimage.into();
 
-        ui.ctx().load_texture("example", image, Default::default()) // FIXME name
+        ui.ctx().load_texture(format!("UI.ImageButton: {:p}", shimage.data), image, Default::default())
       });
 
       let scale: (f32, f32) = self.scale.get().try_into()?;

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -2173,9 +2173,13 @@ impl TryFrom<&Var> for &str {
     if var.valueType != SHType_String
       && var.valueType != SHType_Path
       && var.valueType != SHType_ContextVar
+      && var.valueType != SHType_None
     {
       Err("Expected None, String, Path or ContextVar variable, but casting failed.")
     } else {
+      if var.valueType == SHType_None {
+        return Ok("");
+      }
       unsafe {
         let cstr = CStr::from_ptr(
           var.payload.__bindgen_anon_1.__bindgen_anon_2.stringValue as *mut std::os::raw::c_char,

--- a/src/gfx/egui/Cargo.toml
+++ b/src/gfx/egui/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-egui = { version = "0.18.1" }
-epaint = {version = "0.18.1"}
+egui = { version = "0.19.0" }
+epaint = {version = "0.19.0"}
 lazy_static = "1.4.0"
 
 [build-dependencies]

--- a/src/gfx/egui/src/color_test.rs
+++ b/src/gfx/egui/src/color_test.rs
@@ -329,6 +329,7 @@ impl TextureManager {
                     size: [width, height],
                     pixels,
                 },
+                Default::default(),
             )
         })
     }

--- a/src/gfx/egui/src/input.rs
+++ b/src/gfx/egui/src/input.rs
@@ -237,6 +237,7 @@ pub fn translate_raw_input(input: &egui_Input) -> Result<egui::RawInput, Transla
         screen_rect: Some(input.screenRect.into()),
         pixels_per_point: Some(input.pixelsPerPoint),
         max_texture_side: None,
+        has_focus: true, // FIXME
     })
 }
 


### PR DESCRIPTION
Implement `TextBuffer` trait directly on `Var`.
Remove workaround that was using the `VarTextBuffer` enum.
Fix code following egui update.