### PR TITLE
Replace iterator math with std::distance

### DIFF
--- a/src/mal/Core.cpp
+++ b/src/mal/Core.cpp
@@ -472,11 +472,12 @@ BUILTIN("str") { return mal::string(printValues(argsBegin, argsEnd, "", false));
 
 BUILTIN("swap!") {
   CHECK_ARGS_AT_LEAST(2);
+
   ARG(malAtom, atom);
 
   malValuePtr op = *argsBegin++; // this gets checked in APPLY
 
-  malValueVec args(1 + argsEnd - argsBegin);
+  malValueVec args(1 + std::distance(argsBegin, argsEnd));
   args[0] = atom->deref();
   std::copy(argsBegin, argsEnd, args.begin() + 1);
 


### PR DESCRIPTION
Some C++ runtimes don't support (argsEnd - argsBegin) if argsBegin is the end iterator

std::distance works correctly in all cases
