### PR TITLE
UI Context stack & 4 character constants

### DIFF
--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Clean workspace
         if: ${{ github.event.inputs.clean-workspace == 'true' || inputs.clean-workspace == 'true' }}
         run: |
-            rm -rf $GITHUB_WORKSPACE
-            mkdir $GITHUB_WORKSPACE
+          rm -rf $GITHUB_WORKSPACE
+          mkdir $GITHUB_WORKSPACE
       - name: Checkout shards
         uses: actions/checkout@v3
         with:
@@ -84,6 +84,9 @@ jobs:
 
           echo "Running UI"
           build/shards src/tests/ui.edn
+
+          echo "Running UI (nested)"
+          build/shards src/tests/ui-nested.edn
 
           echo "Running egui demo"
           build/shards src/tests/egui-demo.edn

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -43,6 +43,14 @@ use crate::types::Var;
 use std::convert::TryInto;
 use std::ffi::CString;
 
+pub const fn fourCharacterCode(val: [u8; 4]) -> i32 {
+  let unsigned_val = ((val[0] as u32) << 24 & 0xff000000)
+    | ((val[1] as u32) << 16 & 0x00ff0000)
+    | ((val[2] as u32) << 8 & 0x0000ff00)
+    | ((val[3] as u32) & 0x000000ff);
+  unsigned_val as i32
+}
+
 pub trait IntoVar {
   fn into_var(self) -> Var;
 }

--- a/rust/src/shards/gui/containers/area.rs
+++ b/rust/src/shards/gui/containers/area.rs
@@ -217,11 +217,7 @@ impl Shard for Area {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    let gui_ctx = {
-      let ctx_ptr: &mut EguiNativeContext =
-        Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
-      &*ctx_ptr
-    };
+    let gui_ctx = util::get_current_context(&self.instance)?;
 
     let mut failed = false;
     if !self.contents.is_empty() {

--- a/rust/src/shards/gui/containers/panels.rs
+++ b/rust/src/shards/gui/containers/panels.rs
@@ -200,11 +200,7 @@ macro_rules! impl_panel {
             })
             .inner?;
         } else {
-          let gui_ctx = {
-            let ctx_ptr: &mut EguiNativeContext =
-              Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
-            &*ctx_ptr
-          };
+          let gui_ctx = util::get_current_context(&self.instance)?;
           $egui_func(EguiId::new(self, 0))
             .show(gui_ctx, |ui| {
               util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
@@ -397,11 +393,7 @@ impl Shard for CentralPanel {
       return Ok(*input);
     }
 
-    let gui_ctx = {
-      let ctx_ptr: &mut EguiNativeContext =
-        Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
-      &*ctx_ptr
-    };
+    let gui_ctx = util::get_current_context(&self.instance)?;
 
     if let Some(ui) = util::get_current_parent(*self.parents.get())? {
       egui::CentralPanel::default()

--- a/rust/src/shards/gui/containers/window.rs
+++ b/rust/src/shards/gui/containers/window.rs
@@ -244,11 +244,7 @@ impl Shard for Window {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    let gui_ctx = {
-      let ctx_ptr: &mut EguiNativeContext =
-        Var::from_object_ptr_mut_ref(*self.instance.get(), &EGUI_CTX_TYPE)?;
-      &*ctx_ptr
-    };
+    let gui_ctx = util::get_current_context(&self.instance)?;
 
     let mut failed = false;
     if !self.contents.is_empty() {

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -4,6 +4,7 @@
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::shardsc;
+use crate::fourCharacterCode;
 use crate::types::common_type;
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
@@ -32,11 +33,11 @@ static STRING_OR_SHARDS_OR_NONE_TYPES_SLICE: &[Type] = &[
   common_type::none,
 ];
 
-static EGUI_UI_TYPE: Type = Type::object(FRAG_CC, 1701279061); // 'eguU'
+static EGUI_UI_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"eguU"));
 static EGUI_UI_SLICE: &[Type] = &[EGUI_UI_TYPE];
 static EGUI_UI_SEQ_TYPE: Type = Type::seq(EGUI_UI_SLICE);
 
-static EGUI_CTX_TYPE: Type = Type::object(FRAG_CC, 1701279043); // 'eguC'
+static EGUI_CTX_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"eguC"));
 static EGUI_CTX_SLICE: &[Type] = &[EGUI_CTX_TYPE];
 static EGUI_CTX_VAR: Type = Type::context_variable(EGUI_CTX_SLICE);
 static EGUI_CTX_VAR_TYPES: &[Type] = &[EGUI_CTX_VAR];
@@ -90,7 +91,6 @@ mod layouts;
 mod menus;
 mod reset;
 mod widgets;
-
 mod util;
 
 pub fn registerShards() {

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -2,9 +2,9 @@
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
 use crate::core::registerShard;
+use crate::fourCharacterCode;
 use crate::shard::Shard;
 use crate::shardsc;
-use crate::fourCharacterCode;
 use crate::types::common_type;
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
@@ -39,8 +39,7 @@ static EGUI_UI_SEQ_TYPE: Type = Type::seq(EGUI_UI_SLICE);
 
 static EGUI_CTX_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"eguC"));
 static EGUI_CTX_SLICE: &[Type] = &[EGUI_CTX_TYPE];
-static EGUI_CTX_VAR: Type = Type::context_variable(EGUI_CTX_SLICE);
-static EGUI_CTX_VAR_TYPES: &[Type] = &[EGUI_CTX_VAR];
+static EGUI_CTX_SEQ_TYPE: Type = Type::seq(EGUI_CTX_SLICE);
 
 lazy_static! {
   static ref GFX_GLOBALS_TYPE: Type = unsafe { *shardsc::gfx_getMainWindowGlobalsType() };
@@ -90,8 +89,8 @@ mod context;
 mod layouts;
 mod menus;
 mod reset;
-mod widgets;
 mod util;
+mod widgets;
 
 pub fn registerShards() {
   containers::registerShards();

--- a/rust/src/shards/gui/util.rs
+++ b/rust/src/shards/gui/util.rs
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
+use crate::shards::gui::EGUI_CTX_TYPE;
 use crate::shards::gui::EGUI_UI_SEQ_TYPE;
 use crate::shards::gui::EGUI_UI_TYPE;
 use crate::types::Context;
@@ -9,36 +10,65 @@ use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::Seq;
 use crate::types::ShardsVar;
+use crate::types::Type;
 use crate::types::Var;
 use crate::types::WireState;
+
+pub(crate) fn update_seq<F>(seq_var: &mut ParamVar, inner: F) -> Result<(), &'static str>
+where
+  F: FnOnce(&mut Seq),
+{
+  let var = seq_var.get();
+  let mut seq: Seq = var.try_into()?;
+  inner(&mut seq);
+  seq_var.set(seq.as_ref().into());
+
+  Ok(())
+}
+
+pub(crate) fn with_object_stack_var<'a, T, F, R>(
+  stack_var: &mut ParamVar,
+  object: &T,
+  object_type: &Type,
+  inner: F,
+) -> Result<R, &'static str>
+where
+  F: FnOnce() -> Result<R, &'static str>,
+{
+  // push
+  unsafe {
+    let var = Var::new_object_from_ptr(object as *const _, object_type);
+    update_seq(stack_var, |seq| {
+      seq.push(var);
+    })?;
+  }
+
+  let result = inner();
+
+  // pop
+  update_seq(stack_var, |seq| {
+    seq.pop();
+  })?;
+
+  result
+}
 
 pub(crate) fn activate_ui_contents<'a>(
   context: &Context,
   input: &Var,
   ui: &mut egui::Ui,
-  parents: &mut ParamVar,
+  parents_stack_var: &mut ParamVar,
   contents: &mut ShardsVar,
 ) -> Result<Var, &'a str> {
-  // pass the ui parent to the inner shards
-  let var = parents.get();
-  let mut seq: Seq = var.try_into()?;
-
-  unsafe {
-    let var = Var::new_object_from_ptr(ui as *const _, &EGUI_UI_TYPE);
-    seq.push(var);
-    parents.set(seq.as_ref().into());
-  }
-
   let mut output = Var::default();
-  let state = contents.activate(context, input, &mut output);
 
-  // restore the previous ui parent
-  seq.pop();
-  parents.set(seq.as_ref().into());
-
-  if state == WireState::Error {
-    return Err("Failed to activate contents");
-  }
+  with_object_stack_var(parents_stack_var, ui, &EGUI_UI_TYPE, || {
+    let wire_state = contents.activate(context, input, &mut output);
+    if wire_state == WireState::Error {
+      return Err("Failed to activate contents");
+    }
+    Ok(())
+  })?;
 
   Ok(output)
 }
@@ -58,9 +88,30 @@ pub(crate) fn expose_contents_variables(exposing: &mut ExposedTypes, contents: &
   }
 }
 
-pub(crate) fn get_current_parent<'a>(parents: Var) -> Result<Option<&'a mut egui::Ui>, &'a str> {
-  let seq: Seq = parents.try_into()?;
+pub(crate) fn get_current_context<'a>(
+  context_stack_var: &ParamVar,
+) -> Result<&'a mut egui::Context, &'a str> {
+  let seq: Seq = context_stack_var.get().try_into()?;
   if !seq.is_empty() {
+    Ok(Var::from_object_ptr_mut_ref(
+      seq[seq.len() - 1],
+      &EGUI_CTX_TYPE,
+    )?)
+  } else {
+    Err("Failed to get context, stack is empty")
+  }
+}
+
+pub(crate) fn get_current_parent<'a>(
+  parents_stack_var: Var,
+) -> Result<Option<&'a mut egui::Ui>, &'a str> {
+  let seq: Seq = parents_stack_var.try_into()?;
+  if !seq.is_empty() {
+    let var = seq[seq.len() - 1];
+    if var.is_none() {
+      return Ok(None);
+    }
+
     Ok(Some(Var::from_object_ptr_mut_ref(
       seq[seq.len() - 1],
       &EGUI_UI_TYPE,
@@ -70,10 +121,10 @@ pub(crate) fn get_current_parent<'a>(parents: Var) -> Result<Option<&'a mut egui
   }
 }
 
-pub(crate) fn require_parents(requiring: &mut ExposedTypes, parents: &ParamVar) {
+pub(crate) fn require_parents(requiring: &mut ExposedTypes, parents_stack_var: &ParamVar) {
   let exp_info = ExposedInfo {
     exposedType: EGUI_UI_SEQ_TYPE,
-    name: parents.get_name(),
+    name: parents_stack_var.get_name(),
     help: cstr!("The parent UI objects.").into(),
     ..ExposedInfo::default()
   };

--- a/rust/src/shards/gui/widgets/image.rs
+++ b/rust/src/shards/gui/widgets/image.rs
@@ -2,6 +2,7 @@
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
 use super::Image;
+use crate::fourCharacterCode;
 use crate::shard::Shard;
 use crate::shards::gui::util;
 use crate::shards::gui::widgets::FLOAT2_VAR_SLICE;
@@ -25,7 +26,7 @@ use crate::types::Types;
 use crate::types::Var;
 use crate::types::FRAG_CC;
 
-const TextureCC: i32 = 1952807007; // 'tex_'
+const TextureCC: i32 = fourCharacterCode(*b"tex_");
 
 lazy_static! {
   static ref TEXTURE_TYPE: Type = Type::object(FRAG_CC, TextureCC);

--- a/rust/src/shards/physics/mod.rs
+++ b/rust/src/shards/physics/mod.rs
@@ -4,6 +4,7 @@
 extern crate crossbeam;
 extern crate rapier3d;
 
+use crate::fourCharacterCode;
 use crate::shardsc::SHTypeInfo_Details_Object;
 use crate::shardsc::SHType_Float4;
 use crate::shardsc::SHType_None;
@@ -31,8 +32,8 @@ lazy_static! {
   static ref SIMULATION_TYPE: Type = {
     let mut t = common_type::object;
     t.details.object = SHTypeInfo_Details_Object {
-      vendorId: FRAG_CC, // 'frag'
-      typeId: 0x70687973, // 'phys'
+      vendorId: FRAG_CC,
+      typeId: fourCharacterCode(*b"phys"),
     };
     t
   };
@@ -48,8 +49,8 @@ lazy_static! {
   static ref SHAPE_TYPE: Type = {
     let mut t = common_type::object;
     t.details.object = SHTypeInfo_Details_Object {
-      vendorId: FRAG_CC, // 'frag'
-      typeId: 0x70687953, // 'phyS'
+      vendorId: FRAG_CC,
+      typeId: fourCharacterCode(*b"phyS"),
     };
     t
   };
@@ -62,8 +63,8 @@ lazy_static! {
   static ref RIGIDBODY_TYPE: Type = {
     let mut t = common_type::object;
     t.details.object = SHTypeInfo_Details_Object {
-      vendorId: FRAG_CC, // 'frag'
-      typeId: 0x70687952, // 'phyR'
+      vendorId: FRAG_CC,
+      typeId: fourCharacterCode(*b"phyR"),
     };
     t
   };

--- a/rust/src/shards/substrate.rs
+++ b/rust/src/shards/substrate.rs
@@ -3,6 +3,7 @@
 
 use crate::core::log;
 use crate::core::registerShard;
+use crate::fourCharacterCode;
 use crate::shard::Shard;
 use crate::shardsc::SHTypeInfo_Details_Object;
 use crate::shardsc::SHType_Bool;
@@ -92,8 +93,8 @@ lazy_static! {
   static ref METADATA_TYPE: Type = {
     let mut t = common_type::object;
     t.details.object = SHTypeInfo_Details_Object {
-      vendorId: FRAG_CC, // 'frag'
-      typeId: 0x7375624D, // 'subM'
+      vendorId: FRAG_CC,
+      typeId: fourCharacterCode(*b"subM"),
     };
     t
   };

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -4,6 +4,7 @@
 use crate::core::cloneVar;
 use crate::core::destroyVar;
 use crate::core::Core;
+use crate::fourCharacterCode;
 use crate::shardsc::SHBool;
 use crate::shardsc::SHColor;
 use crate::shardsc::SHComposeResult;
@@ -4145,7 +4146,7 @@ impl PartialEq for Type {
   }
 }
 
-pub const FRAG_CC: i32 = 0x66726167; // 'frag'
+pub const FRAG_CC: i32 = fourCharacterCode(*b"frag");
 
 pub static INT_TYPES_SLICE: &[Type] = &[common_type::int];
 pub static INT_OR_NONE_TYPES_SLICE: &[Type] = &[common_type::int, common_type::none];
@@ -4208,8 +4209,8 @@ lazy_static! {
   pub static ref ENUM_TYPE: Type = {
     let mut t = common_type::enumeration;
     t.details.enumeration = SHTypeInfo_Details_Enum {
-      vendorId: FRAG_CC, // 'frag'
-      typeId: 0x74797065, // 'type'
+      vendorId: FRAG_CC,
+      typeId: fourCharacterCode(*b"type"),
     };
     t
   };

--- a/src/tests/ui-nested.edn
+++ b/src/tests/ui-nested.edn
@@ -1,0 +1,34 @@
+(defloop main-wire
+  (GFX.MainWindow
+   :Contents
+   (->
+    (Setup
+     (GFX.DrawQueue) >= .ui-draw-queue-1
+     (GFX.DrawQueue) >= .ui-draw-queue-2
+     (GFX.UIPass .ui-draw-queue-1) >> .render-steps
+     (GFX.UIPass .ui-draw-queue-2) >> .render-steps)
+    .ui-draw-queue-1 (GFX.ClearQueue)
+    .ui-draw-queue-2 (GFX.ClearQueue)
+
+    (UI
+     .ui-draw-queue-1
+     (UI.CentralPanel
+      (->
+       "This is UI 1 " (UI.Label)
+       (UI.Window :Title "Window" :Contents
+                  (->
+                   "This is UI 1" (UI.Label)
+                   (UI
+                    .ui-draw-queue-2
+                    (->
+                     (UI.CentralPanel
+                      (->
+                       "This is UI 2 (nested)" (UI.Label)
+                       (UI.Window :Title "Window" :Contents
+                                  (->
+                                   "This is UI 2 (nested)" (UI.Label))))))))))))
+
+    (GFX.Render :Steps .render-steps))))
+(defmesh root)
+(schedule root main-wire)
+(run root 0.01 200)


### PR DESCRIPTION
Makes the egui context exposed variable a stack.
This way we can have claymore UI host user scripts containing it's own UI.
Additionally I want to make some additional things available within the new `Context` struct, mainly to be able to map a region inside egui back into window coordinates