### PR TITLE
UI code editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1039,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1726,21 @@ checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
+
+[[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "liquid"
@@ -2476,6 +2510,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time 0.3.14",
+ "xml-rs",
+]
+
+[[package]]
 name = "png"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +2994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3257,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sp-core",
+ "syntect",
  "tiny-keccak",
  "tiny-skia",
  "tract-onnx",
@@ -3526,6 +3581,29 @@ dependencies = [
  "quote 1.0.20",
  "syn 1.0.98",
  "unicode-xid 0.2.3",
+]
+
+[[package]]
+name = "syntect"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
+dependencies = [
+ "bincode",
+ "bitflags",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -4412,6 +4490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,6 +4506,15 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/docs/samples/shards/UI/CodeEditor/1.edn
+++ b/docs/samples/shards/UI/CodeEditor/1.edn
@@ -1,0 +1,30 @@
+(defloop main-wire
+  (GFX.MainWindow
+   :Contents
+   (->
+    (Setup
+     (GFX.DrawQueue) >= .ui-draw-queue
+     (GFX.UIPass .ui-draw-queue) >> .render-steps)
+    .ui-draw-queue (GFX.ClearQueue)
+
+    (UI
+     .ui-draw-queue
+     (->
+      (Setup "" >= .code)
+      (UI.TopPanel
+       :Contents
+       (UI.MenuBar
+        :Contents
+        (UI.Menu
+         "Edit"
+         (UI.Button
+          "Clear"
+          (-> "" > .code (UI.CloseMenu))))))
+      (UI.CentralPanel
+       :Contents
+       (UI.CodeEditor .code "Rust"))))
+
+    (GFX.Render :Steps .render-steps))))
+(defmesh root)
+(schedule root main-wire)
+(run root 0.1 10)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,6 +43,7 @@ chrono = { version = "0.4", optional = true }
 chacha20poly1305 = { version = "0.9.0", optional = true }
 egui = { version = "0.19.0", optional = true }
 egui-gfx = { path = "../src/gfx/egui", optional = true }
+syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"], optional = true }
 half = { version = "2.0.0" }
 tract-onnx = { version = "0.17.7", optional = true }
 
@@ -86,7 +87,7 @@ shards = ["reqwest",
           "egui",
           "egui-gfx",
           "tract-onnx"]
-code_editor = []
+code_editor = ["syntect"]
 dllshard = ["dlopen"]
 scripting = []
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -86,6 +86,7 @@ shards = ["reqwest",
           "chrono",
           "egui",
           "egui-gfx",
+          "code_editor",
           "tract-onnx"]
 code_editor = ["syntect"]
 dllshard = ["dlopen"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -86,6 +86,7 @@ shards = ["reqwest",
           "egui",
           "egui-gfx",
           "tract-onnx"]
+code_editor = []
 dllshard = ["dlopen"]
 scripting = []
 

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
+use crate::core::cloneVar;
 use crate::core::registerShard;
 use crate::fourCharacterCode;
 use crate::shard::Shard;
@@ -10,9 +11,11 @@ use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::ShardsVar;
 use crate::types::Type;
+use crate::types::Var;
 use crate::types::FRAG_CC;
 use egui::Context as EguiNativeContext;
 use std::ffi::c_void;
+use std::ffi::CStr;
 
 static ANY_VAR_SLICE: &[Type] = &[common_type::any, common_type::any_var];
 static BOOL_OR_NONE_SLICE: &[Type] = &[common_type::bool, common_type::none];
@@ -98,6 +101,118 @@ mod menus;
 mod reset;
 mod util;
 mod widgets;
+
+struct MutableVar<'a>(&'a mut Var);
+struct ImmutableVar<'a>(&'a Var);
+
+impl egui::TextBuffer for ImmutableVar<'_> {
+  fn is_mutable(&self) -> bool {
+    false
+  }
+
+  fn as_str(&self) -> &str {
+    (self.0).try_into().unwrap()
+  }
+
+  fn insert_text(&mut self, _text: &str, _char_index: usize) -> usize {
+    0usize
+  }
+
+  fn delete_char_range(&mut self, _char_range: std::ops::Range<usize>) {}
+}
+
+impl egui::TextBuffer for MutableVar<'_> {
+  fn is_mutable(&self) -> bool {
+    true
+  }
+
+  fn as_str(&self) -> &str {
+    self.0.as_ref().try_into().unwrap()
+  }
+
+  fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
+    let byte_idx = if !self.0.is_string() {
+      0usize
+    } else {
+      self.byte_index_from_char_index(char_index)
+    };
+
+    let text_len = text.len();
+    let (current_len, current_cap) = unsafe {
+      (
+        self.0.payload.__bindgen_anon_1.__bindgen_anon_2.stringLen as usize,
+        self
+          .0
+          .payload
+          .__bindgen_anon_1
+          .__bindgen_anon_2
+          .stringCapacity as usize,
+      )
+    };
+
+    if current_cap == 0usize {
+      // new string
+      let tmp = Var::ephemeral_string(text);
+      cloneVar(self.0, &tmp);
+    } else if (current_cap - current_len) >= text_len {
+      // text can fit within existing capacity
+      unsafe {
+        let base_ptr =
+          self.0.payload.__bindgen_anon_1.__bindgen_anon_2.stringValue as *mut std::os::raw::c_char;
+        // move the rest of the string to the end
+        std::ptr::copy(
+          base_ptr.add(byte_idx),
+          base_ptr.add(byte_idx).add(text_len),
+          current_len - byte_idx,
+        );
+        // insert the new text
+        let bytes = text.as_ptr() as *const std::os::raw::c_char;
+        std::ptr::copy_nonoverlapping(bytes, base_ptr.add(byte_idx), text_len);
+        // update the length
+        let new_len = current_len + text_len;
+        self.0.payload.__bindgen_anon_1.__bindgen_anon_2.stringLen = new_len as u32;
+        // fixup null-terminator
+        *base_ptr.add(new_len) = 0;
+      }
+    } else {
+      let mut str = String::from(self.as_str());
+      str.insert_str(byte_idx, text);
+      let tmp = Var::ephemeral_string(str.as_str());
+      cloneVar(self.0, &tmp);
+    }
+
+    text.chars().count()
+  }
+
+  fn delete_char_range(&mut self, char_range: std::ops::Range<usize>) {
+    assert!(char_range.start <= char_range.end);
+
+    let byte_start = self.byte_index_from_char_index(char_range.start);
+    let byte_end = self.byte_index_from_char_index(char_range.end);
+
+    if byte_start == byte_end {
+      // nothing to do
+      return;
+    }
+
+    unsafe {
+      let current_len = self.0.payload.__bindgen_anon_1.__bindgen_anon_2.stringLen as usize;
+      let base_ptr =
+        self.0.payload.__bindgen_anon_1.__bindgen_anon_2.stringValue as *mut std::os::raw::c_char;
+      // move rest of the text at the deletion location
+      std::ptr::copy(
+        base_ptr.add(byte_end),
+        base_ptr.add(byte_start),
+        current_len - byte_end,
+      );
+      // update the length
+      let new_len = current_len - byte_end + byte_start;
+      self.0.payload.__bindgen_anon_1.__bindgen_anon_2.stringLen = new_len as u32;
+      // fixup null-terminator
+      *base_ptr.add(new_len) = 0;
+    }
+  }
+}
 
 pub fn registerShards() {
   containers::registerShards();

--- a/rust/src/shards/gui/widgets/code_editor/mod.rs
+++ b/rust/src/shards/gui/widgets/code_editor/mod.rs
@@ -239,12 +239,12 @@ impl Shard for CodeEditor {
       };
       let code_editor = egui::TextEdit::multiline(text)
         .code_editor()
-        .desired_rows(10)
         .desired_width(f32::INFINITY)
         .layouter(&mut layouter);
       let response = egui::ScrollArea::vertical()
         .id_source(id_source)
-        .show(ui, |ui| ui.add(code_editor))
+        .show(ui, |ui| ui.centered_and_justified(|ui| ui.add(code_editor)))
+        .inner
         .inner;
 
       if response.changed() || response.lost_focus() {

--- a/rust/src/shards/gui/widgets/code_editor/syntax_highlighting.rs
+++ b/rust/src/shards/gui/widgets/code_editor/syntax_highlighting.rs
@@ -1,0 +1,175 @@
+/* SPDX-License-Identifier: BSD-3-Clause AND MIT */
+/* Copyright (c) 2022 Fragcolor Pte. Ltd. */
+/* Copyright (c) 2018-2021 Emil Ernerfeldt <emil.ernerfeldt@gmail.com> */
+
+// Code partially extracted from egui_demo_lib
+// https://github.com/emilk/egui/blob/master/crates/egui_demo_lib/src/syntax_highlighting.rs
+
+use egui::epaint::text::layout;
+use egui::text::LayoutJob;
+use syntect::highlighting::Theme;
+use syntect::highlighting::ThemeSet;
+use syntect::parsing::SyntaxSet;
+
+/// Memoized Code highlighting
+pub(crate) fn highlight(
+  ctx: &egui::Context,
+  theme: &CodeTheme,
+  code: &str,
+  language: &str,
+) -> LayoutJob {
+  impl egui::util::cache::ComputerMut<(&CodeTheme, &str, &str), LayoutJob> for Highlighter {
+    fn compute(&mut self, (theme, code, language): (&CodeTheme, &str, &str)) -> LayoutJob {
+      self.highlight(theme, code, language)
+    }
+  }
+
+  type HighlightCache<'a> = egui::util::cache::FrameCache<LayoutJob, Highlighter>;
+
+  let mut memory = ctx.memory();
+  let highlight_cache = memory.caches.cache::<HighlightCache<'_>>();
+  highlight_cache.get((theme, code, language))
+}
+
+#[derive(Hash)]
+pub(crate) struct CodeTheme {
+  dark_mode: bool,
+  syntect_theme: SyntectTheme,
+}
+
+impl Default for CodeTheme {
+  fn default() -> Self {
+    Self::dark()
+  }
+}
+
+impl CodeTheme {
+  pub fn dark() -> Self {
+    Self {
+      dark_mode: true,
+      syntect_theme: SyntectTheme::Base16MochaDark,
+    }
+  }
+
+  pub fn light() -> Self {
+    Self {
+      dark_mode: false,
+      syntect_theme: SyntectTheme::SolarizedLight,
+    }
+  }
+}
+
+struct Highlighter {
+  syntaxes: SyntaxSet,
+  themes: ThemeSet,
+}
+
+impl Default for Highlighter {
+  fn default() -> Self {
+    Self {
+      syntaxes: SyntaxSet::load_defaults_newlines(),
+      themes: ThemeSet::load_defaults(),
+    }
+  }
+}
+
+impl Highlighter {
+  fn highlight(&self, theme: &CodeTheme, text: &str, language: &str) -> LayoutJob {
+    self
+      .highlight_impl(theme, text, language)
+      .unwrap_or_else(|| {
+        LayoutJob::simple(
+          text.into(),
+          egui::FontId::monospace(14.0),
+          if theme.dark_mode {
+            egui::Color32::LIGHT_GRAY
+          } else {
+            egui::Color32::DARK_GRAY
+          },
+          f32::INFINITY,
+        )
+      })
+  }
+
+  fn highlight_impl(&self, theme: &CodeTheme, text: &str, language: &str) -> Option<LayoutJob> {
+    use syntect::easy::HighlightLines;
+    use syntect::highlighting::FontStyle;
+    use syntect::util::LinesWithEndings;
+
+    let syntax = self
+      .syntaxes
+      .find_syntax_by_name(language)
+      .or_else(|| self.syntaxes.find_syntax_by_extension(language))?;
+
+    let theme = theme.syntect_theme.syntect_key_name();
+    let mut h = HighlightLines::new(syntax, &self.themes.themes[theme]);
+
+    use egui::text::{LayoutSection, TextFormat};
+
+    let mut job = LayoutJob {
+      text: text.into(),
+      ..Default::default()
+    };
+
+    for line in LinesWithEndings::from(text) {
+      for (style, range) in h.highlight_line(line, &self.syntaxes).ok()? {
+        let fg = style.foreground;
+        let text_color = egui::Color32::from_rgb(fg.r, fg.g, fg.b);
+        let italics = style.font_style.contains(FontStyle::ITALIC);
+        let underline = style.font_style.contains(FontStyle::ITALIC);
+        let underline = if underline {
+          egui::Stroke::new(1.0, text_color)
+        } else {
+          egui::Stroke::none()
+        };
+        job.sections.push(LayoutSection {
+          leading_space: 0.0,
+          byte_range: as_byte_range(text, range),
+          format: TextFormat {
+            font_id: egui::FontId::monospace(14.0),
+            color: text_color,
+            italics,
+            underline,
+            ..Default::default()
+          },
+        });
+      }
+    }
+
+    Some(job)
+  }
+}
+
+#[derive(Hash)]
+enum SyntectTheme {
+  Base16EightiesDark,
+  Base16MochaDark,
+  Base16OceanDark,
+  Base16OceanLight,
+  InspiredGitHub,
+  SolarizedDark,
+  SolarizedLight,
+}
+
+impl SyntectTheme {
+  fn syntect_key_name(&self) -> &'static str {
+    match self {
+      Self::Base16EightiesDark => "base16-eighties.dark",
+      Self::Base16MochaDark => "base16-mocha.dark",
+      Self::Base16OceanDark => "base16-ocean.dark",
+      Self::Base16OceanLight => "base16-ocean.light",
+      Self::InspiredGitHub => "InspiredGitHub",
+      Self::SolarizedDark => "Solarized (dark)",
+      Self::SolarizedLight => "Solarized (light)",
+    }
+  }
+}
+
+fn as_byte_range(whole: &str, range: &str) -> std::ops::Range<usize> {
+  let whole_start = whole.as_ptr() as usize;
+  let range_start = range.as_ptr() as usize;
+  assert!(whole_start <= range_start);
+  assert!(range_start + range.len() <= whole_start + whole.len());
+  let offset = range_start - whole_start;
+  offset..(offset + range.len())
+}

--- a/rust/src/shards/gui/widgets/mod.rs
+++ b/rust/src/shards/gui/widgets/mod.rs
@@ -34,6 +34,7 @@ struct CodeEditor {
   parents: ParamVar,
   requiring: ExposedTypes,
   variable: ParamVar,
+  language: ParamVar,
   exposing: ExposedTypes,
   should_expose: bool,
   mutable_text: bool,

--- a/rust/src/shards/gui/widgets/mod.rs
+++ b/rust/src/shards/gui/widgets/mod.rs
@@ -29,6 +29,7 @@ struct Checkbox {
   should_expose: bool,
 }
 
+#[cfg(feature = "code_editor")]
 struct CodeEditor {
   parents: ParamVar,
   requiring: ExposedTypes,
@@ -193,6 +194,7 @@ decl_ui_slider!(Int4Slider, [i32; 4]);
 
 mod button;
 mod checkbox;
+#[cfg(feature = "code_editor")]
 mod code_editor;
 mod color_input;
 mod combo;
@@ -212,7 +214,6 @@ mod tooltip;
 pub fn registerShards() {
   registerShard::<Button>();
   registerShard::<Checkbox>();
-  registerShard::<CodeEditor>();
   registerShard::<ColorInput>();
   registerShard::<Combo>();
   registerShard::<Hyperlink>();
@@ -241,4 +242,18 @@ pub fn registerShards() {
   registerShard::<Spinner>();
   registerShard::<TextInput>();
   registerShard::<Tooltip>();
+
+  if cfg!(feature = "code_editor") {
+    registerCodeEditor();
+  }
 }
+
+#[cfg(feature = "code_editor")]
+#[inline(always)]
+pub fn registerCodeEditor() {
+  registerShard::<CodeEditor>();
+}
+
+#[cfg(not(feature = "code_editor"))]
+#[inline(always)]
+pub fn registerCodeEditor() {}

--- a/rust/src/shards/gui/widgets/mod.rs
+++ b/rust/src/shards/gui/widgets/mod.rs
@@ -29,6 +29,15 @@ struct Checkbox {
   should_expose: bool,
 }
 
+struct CodeEditor {
+  parents: ParamVar,
+  requiring: ExposedTypes,
+  variable: ParamVar,
+  exposing: ExposedTypes,
+  should_expose: bool,
+  mutable_text: bool,
+}
+
 struct ColorInput {
   parents: ParamVar,
   requiring: ExposedTypes,
@@ -184,6 +193,7 @@ decl_ui_slider!(Int4Slider, [i32; 4]);
 
 mod button;
 mod checkbox;
+mod code_editor;
 mod color_input;
 mod combo;
 mod hyperlink;
@@ -202,6 +212,7 @@ mod tooltip;
 pub fn registerShards() {
   registerShard::<Button>();
   registerShard::<Checkbox>();
+  registerShard::<CodeEditor>();
   registerShard::<ColorInput>();
   registerShard::<Combo>();
   registerShard::<Hyperlink>();


### PR DESCRIPTION
A `TextInput` with support for syntax highlighting.

It is currently behind a `"code_editor"` feature flag. We might decide to have it enabled by default (as part of `"shards"`) or only when building an app such as claymore.

Uses the `Syntech` crate and the current implementation is mainly based on the `egui_demo_lib` from the `egui` repository for the layouting part.

---

Part of fragcolor-xyz/management#31