### PR TITLE
CI update

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -57,7 +57,7 @@ jobs:
   docs-markdown:
     # needs: Windows-64bits-Debug
     name: Generate Markdown
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout shards
         uses: actions/checkout@v3

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -75,6 +75,9 @@ jobs:
           msystem: MINGW64
           release: false
           path-type: inherit
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
       - name: Generate markdown
         shell: msys2 {0}
         run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -2,7 +2,18 @@ name: Build (iOS)
 
 on:
   workflow_dispatch:
+    inputs:
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
   workflow_call:
+    inputs:
+      rust-cache:
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   #
@@ -11,6 +22,10 @@ jobs:
   iOS:
     runs-on: macos-latest
     steps:
+      - name: Setup
+        id: setup
+        run: |
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
       - name: Checkout shards
         uses: actions/checkout@v3
         with:
@@ -27,7 +42,7 @@ jobs:
           rustup +nightly target add x86_64-apple-ios
           rustup default nightly
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
       - name: Build device
         run: |
           cmake -Bbuild_arm64 -GXcode -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=iphoneos

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       build-type:
@@ -34,6 +39,10 @@ on:
       run-extra-tests:
         required: false
         default: false
+        type: boolean
+      rust-cache:
+        required: false
+        default: true
         type: boolean
 
 jobs:
@@ -53,6 +62,7 @@ jobs:
           echo "::set-output name=build-type::${{ github.event.inputs.build-type || inputs.build-type }}"
           echo "::set-output name=run-tests::${{ github.event.inputs.run-tests || inputs.run-tests }}"
           echo "::set-output name=run-extra-tests::${{ github.event.inputs.run-extra-tests || inputs.run-extra-tests }}"
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
       - name: Checkout shards
         uses: actions/checkout@v3
         with:
@@ -67,7 +77,7 @@ jobs:
           rustup toolchain install nightly
           rustup default nightly
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}
       - name: Build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       build-type:
@@ -34,6 +39,10 @@ on:
       run-tests:
         required: false
         default: false
+        type: boolean
+      rust-cache:
+        required: false
+        default: true
         type: boolean
 
 jobs:
@@ -53,6 +62,7 @@ jobs:
           echo "::set-output name=build-type::${{ github.event.inputs.build-type || inputs.build-type }}"
           echo "::set-output name=runtime-tests::${{ github.event.inputs.runtime-tests || inputs.runtime-tests }}"
           echo "::set-output name=run-tests::${{ github.event.inputs.run-tests || inputs.run-tests }}"
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
       - name: Checkout shards
         uses: actions/checkout@v3
         with:
@@ -67,7 +77,7 @@ jobs:
           rustup toolchain install nightly
           rustup default nightly
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}
       - name: Build

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       threading:
@@ -25,6 +30,10 @@ on:
       run-tests:
         required: false
         default: false
+        type: boolean
+      rust-cache:
+        required: false
+        default: true
         type: boolean
 
 jobs:
@@ -41,6 +50,7 @@ jobs:
         run: |
           echo "::set-output name=threading::${{ github.event.inputs.threading || inputs.threading }}"
           echo "::set-output name=run-tests::${{ github.event.inputs.run-tests || inputs.run-tests }}"
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
       - name: Checkout shards
         uses: actions/checkout@v3
         with:
@@ -69,7 +79,7 @@ jobs:
         run: |
           rustup +nightly component add rust-src
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.threading }}
       - name: Build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -75,7 +75,7 @@ jobs:
   #
   Windows:
     name: Build (${{ github.event.inputs.binary-type || inputs.binary-type }}, ${{ github.event.inputs.build-type || inputs.build-type }}, ${{ github.event.inputs.bitness || inputs.bitness }})
-    runs-on: windows-2019
+    runs-on: windows-latest
     outputs:
       binary-type: ${{ steps.setup.outputs.binary-type }}
       run-tests: ${{ steps.setup.outputs.run-tests }}
@@ -226,7 +226,7 @@ jobs:
     if: ${{ needs.Windows.outputs.run-tests == 'true' && needs.Windows.outputs.binary-type == 'Exe' }}
     needs: Windows
     name: Test
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Setup
         id: setup

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: false
         type: boolean
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       bitness:
@@ -59,6 +64,10 @@ on:
         required: false
         default: false
         type: boolean
+      rust-cache:
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   #
@@ -80,6 +89,7 @@ jobs:
           echo "::set-output name=binary-type::${{ github.event.inputs.binary-type || inputs.binary-type }}"
           echo "::set-output name=run-tests::${{ github.event.inputs.run-tests || inputs.run-tests }}"
           echo "::set-output name=runtime-tests::${{ github.event.inputs.runtime-tests || inputs.runtime-tests }}"
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
 
           if [ "${{ github.event.inputs.binary-type || inputs.binary-type }}" == "Exe" ]
           then
@@ -134,7 +144,7 @@ jobs:
           choco install -y --force llvm || exit 0
           echo "LIBCLANG_PATH=C:\Program Files\LLVM\lib" >> $GITHUB_ENV
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}
       - name: Set up MSYS2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -260,12 +260,23 @@ jobs:
         with:
           name: ${{ steps.setup.outputs.artifact }} ${{ steps.setup.outputs.build-type }}
           path: build
-      - name: Set up MSYS2
+      - name: Set up MSYS2 (Release)
+        if: ${{ steps.setup.outputs.build-type == 'Release' }}
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ steps.setup.outputs.msystem }}
           release: false
           path-type: inherit
+      - name: Set up MSYS2 (Debug)
+        if: ${{ steps.setup.outputs.build-type == 'Debug' }}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ steps.setup.outputs.msystem }}
+          release: false
+          path-type: inherit
+          install: >-
+            base-devel
+            mingw-w64-${{ steps.setup.outputs.arch }}-toolchain
       - name: Test
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,12 @@ on:
       - devel
   pull_request:
   workflow_dispatch:
+    inputs:
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # cancel-previous-workflows:


### PR DESCRIPTION
- Use latest windows image
- Add missing MSYS dependencies when testing Windows Debug on latest
  - Most likely the default packages list on the latest Windows image was simplified and didn't include all required packages
- Add the ability to use the rust cache when building manually (off by default)