### PR TITLE
Reenable most rust warnings

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -5,7 +5,7 @@
 
 use crate::shard::shard_construct;
 use crate::shard::Shard;
-use crate::shardsc::SHBool;
+
 use crate::shardsc::SHContext;
 use crate::shardsc::SHCore;
 use crate::shardsc::SHEnumInfo;
@@ -13,16 +13,16 @@ use crate::shardsc::SHOptionalString;
 use crate::shardsc::SHString;
 use crate::shardsc::SHStrings;
 use crate::shardsc::SHVar;
-use crate::shardsc::SHWireState;
+
 use crate::shardsc::ShardPtr;
 use crate::types::ClonedVar;
 use crate::types::Context;
 use crate::types::DerivedType;
 use crate::types::ExternalVar;
 use crate::types::InstanceData;
-use crate::types::Mesh;
-use crate::types::ParameterInfo;
-use crate::types::Parameters;
+
+
+
 use crate::types::Var;
 use crate::types::WireRef;
 use crate::types::WireState;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,14 +2,7 @@
 /* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #![cfg_attr(all(target_os = "windows", target_arch = "x86"), feature(abi_thiscall))]
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(unused_imports)]
-#![allow(unused_macros)]
-#![allow(dead_code)]
-#![allow(improper_ctypes)]
-#![allow(improper_ctypes_definitions)]
+
 #![feature(allocator_api)]
 
 #[macro_use]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,17 +5,11 @@
 
 #![feature(allocator_api)]
 
-#[macro_use]
-#[cfg(test)]
-extern crate ctor;
-
-#[macro_use]
 extern crate approx;
 
 #[macro_use]
 extern crate lazy_static;
 
-#[macro_use]
 extern crate compile_time_crc32;
 
 pub mod core;
@@ -28,16 +22,16 @@ pub mod types;
 #[cfg(feature = "shards")]
 pub mod shards;
 
-use crate::core::log;
+
 use crate::core::Core;
 use crate::shard::Shard;
 pub use crate::shardsc::*;
 use crate::types::Types;
 use crate::types::Var;
-use std::convert::TryInto;
+
 use std::ffi::CString;
 
-pub const fn fourCharacterCode(val: [u8; 4]) -> i32 {
+pub const fn four_character_code(val: [u8; 4]) -> i32 {
   let unsigned_val = ((val[0] as u32) << 24 & 0xff000000)
     | ((val[1] as u32) << 16 & 0x00ff0000)
     | ((val[2] as u32) << 8 & 0x0000ff00)
@@ -61,335 +55,6 @@ where
 {
   fn into_var(self) -> Var {
     Var::from(self)
-  }
-}
-
-// use this to develop/debug:
-// cargo +nightly rustc --profile=check -- -Zunstable-options --pretty=expanded
-
-macro_rules! var {
-    ((-> $($param:tt) *)) => {{
-        let blks = shards!($($param) *);
-        let mut vblks = Vec::<$crate::types::Var>::new();
-        for blk in blks {
-            vblks.push($crate::types::Var::from(blk));
-        }
-        // this is sad, we do a double copy cos set param will copy too
-        // but for now it's the easiest
-        $crate::types::ClonedVar::from($crate::types::Var::from(&vblks))
-    }};
-
-    ($vexp:expr) => { $crate::types::WrappedVar(crate::IntoVar::into_var($vexp)) };
-}
-
-macro_rules! shards {
-    (@shard Set :Name .$var:ident) => { shards!(@shard Set (stringify!($var))) };
-    (@shard Set .$var:ident) => { shards!(@shard Set (stringify!($var))) };
-    (@shard Set :Name .$var:ident) => { shards!(@shard Set (stringify!($var))) };
-    (@shard Set .$var:ident) => { shards!(@shard Set (stringify!($var))) };
-
-    // (ShardName)
-    (@shard $shard:ident) => {{
-        let blk = $crate::core::createShardPtr(stringify!($shard));
-        unsafe {
-            (*blk).setup.unwrap()(blk);
-        }
-            blk
-    }};
-
-    // (ShardName.ShardName :ParamName ParamVar ...)
-    (@shard $shard0:ident.$shard1:ident $(:$pname:tt $param:tt) *) => {{
-      let blkname = concat!(stringify!($shard0), ".", stringify!($shard1));
-      let blk = $crate::core::createShardPtr(blkname);
-      unsafe {
-          (*blk).setup.unwrap()(blk);
-      }
-      let cparams: $crate::shardsc::SHParametersInfo;
-      unsafe {
-          cparams = (*blk).parameters.unwrap()(blk);
-      }
-      let params: &[$crate::shardsc::SHParameterInfo] = cparams.into();
-      $(
-          {
-              let param = stringify!($pname);
-              let mut piter = params.iter();
-              let idx = piter.position(|&x| -> bool {
-                  unsafe {
-                      let cname = x.name as *const std::os::raw::c_char as *mut std::os::raw::c_char;
-                      let cstr =  std::ffi::CString::from_raw(cname);
-                      let s = cstr.to_str();
-                      s.is_err() || s.unwrap() == param
-                  }
-              });
-              if let Some(pidx) = idx {
-                  let pvar = var!($param);
-                  unsafe {
-                      (*blk).setParam.unwrap()(blk, pidx as i32, &pvar.0 as * const _);
-                  }
-              } else {
-                  panic!("Parameter not found: {} for shard: {}!", param, blkname);
-              }
-          }
-      ) *
-          blk
-   }};
-
-    // (ShardName :ParamName ParamVar ...)
-    (@shard $shard:ident $(:$pname:tt $param:tt) *) => {{
-        let blkname = stringify!($shard);
-        let blk = $crate::core::createShardPtr(blkname);
-        unsafe {
-            (*blk).setup.unwrap()(blk);
-        }
-        let cparams: $crate::shardsc::SHParametersInfo;
-        unsafe {
-            cparams = (*blk).parameters.unwrap()(blk);
-        }
-        let params: &[$crate::shardsc::SHParameterInfo] = cparams.into();
-        $(
-            {
-                let param = stringify!($pname);
-                let mut piter = params.iter();
-                let idx = piter.position(|&x| -> bool {
-                    unsafe {
-                        let cname = x.name as *const std::os::raw::c_char as *mut std::os::raw::c_char;
-                        let cstr =  std::ffi::CString::from_raw(cname);
-                        let s = cstr.to_str();
-                        s.is_err() || s.unwrap() == param
-                    }
-                });
-                if let Some(pidx) = idx {
-                    let pvar = var!($param);
-                    unsafe {
-                        (*blk).setParam.unwrap()(blk, pidx as i32, &pvar.0 as * const _);
-                    }
-                } else {
-                    panic!("Parameter not found: {} for shard: {}!", param, blkname);
-                }
-            }
-        ) *
-            blk
-     }};
-
-     // (ShardName.ShardName ParamVar ...)
-    (@shard $shard0:ident.$shard1:ident $($param:tt) *) => {{
-      let blk = $crate::core::createShardPtr(concat!(stringify!($shard0), ".", stringify!($shard1)));
-      unsafe {
-          (*blk).setup.unwrap()(blk);
-      }
-      let mut _pidx: i32 = 0;
-      $(
-          {
-              let pvar = var!($param);
-              unsafe {
-                  (*blk).setParam.unwrap()(blk, _pidx, &pvar.0 as *const _);
-              }
-              _pidx += 1;
-          }
-      ) *
-          blk
-    }};
-
-    // (ShardName ParamVar ...)
-    (@shard $shard:ident $($param:tt) *) => {{
-        let blk = $crate::core::createShardPtr(stringify!($shard));
-        unsafe {
-            (*blk).setup.unwrap()(blk);
-        }
-        let mut _pidx: i32 = 0;
-        $(
-            {
-                let pvar = var!($param);
-                unsafe {
-                    (*blk).setParam.unwrap()(blk, _pidx, &pvar.0 as *const _);
-                }
-                _pidx += 1;
-            }
-        ) *
-            blk
-    }};
-
-    /*
-      I wanted to make just regular literals work but I could not
-      e.g.: 10 (Log)
-      but in this macro (. 10) (Log) has to be used.
-      I will implement a (.) builtin maybe in mal to allow copy pasting of such scripts.. but not sure we are going to use either.. again WIP but don't wanna loose it in history.
-    */
-    (@shard . $a:expr) => { shards!(@shard Const $a) };
-
-    // this is the CORE evaluator takes a list of shards expressions
-    // the current limit is that everything has to be between parenthesis (...)
-    ($(($shard:tt $($param:tt) *)) *) => {{
-        let mut blks = Vec::<$crate::shardsc::ShardPtr>::new();
-        $(
-            blks.push(shards!(@shard $shard $($param) *));
-        ) *
-            blks
-    }};
-}
-
-// --features "dummy"
-#[cfg(any(all(test, not(feature = "sh_static")), target_arch = "wasm32"))]
-#[macro_use]
-mod dummy_shard {
-  // run with: RUST_BACKTRACE=1 cargo test -- --nocapture
-
-  use super::shard::create;
-  use super::Types;
-  use crate::core::cloneVar;
-  use crate::core::createShard;
-  use crate::core::init;
-  use crate::core::log;
-  use crate::core::registerShard;
-  use crate::core::sleep;
-  use crate::core::suspend;
-  use crate::core::Core;
-  use crate::shard::shard_construct;
-  use crate::shard::Shard;
-  use crate::shard::ShardWrapper;
-  use crate::shardsc::SHContext;
-  use crate::shardsc::SHTypeInfo;
-  use crate::shardsc::SHType_Int;
-  use crate::shardsc::SHTypesInfo;
-  use crate::shardsc::SHVar;
-  use crate::shardsc::Shard as CShard;
-  use crate::shlog;
-  use crate::types::common_type;
-  use crate::types::ClonedVar;
-  use crate::types::Table;
-  use crate::types::Var;
-  use core::convert::TryInto;
-  use std::ffi::CStr;
-  use std::ffi::CString;
-
-  lazy_static! {
-    static ref PROPERTIES: Table = {
-      let mut table = Table::default();
-      table.insert_fast_static(cstr!("experimental"), true.into());
-      table
-    };
-  }
-
-  pub struct DummyShard {
-    inputTypes: Types,
-    outputTypes: Types,
-  }
-
-  impl Default for DummyShard {
-    fn default() -> Self {
-      DummyShard {
-        inputTypes: vec![common_type::none],
-        outputTypes: vec![common_type::any],
-      }
-    }
-  }
-
-  impl Shard for DummyShard {
-    fn name(&mut self) -> &str {
-      "Dummy"
-    }
-
-    fn inputTypes(&mut self) -> &Types {
-      &self.inputTypes
-    }
-
-    fn outputTypes(&mut self) -> &Types {
-      &self.outputTypes
-    }
-
-    fn properties(&mut self) -> Option<&Table> {
-      Some(&PROPERTIES)
-    }
-
-    fn activate(&mut self, context: &SHContext, _input: &Var) -> Result<Var, &str> {
-      log("Dummy - activate: Ok!\0");
-      let mut x: String = "Before...\0".to_string();
-      log(&x);
-      suspend(context, 2.0);
-      x.push_str(" - and After!\0");
-      log(&x);
-      log("Dummy - activate: Resumed!\0");
-      Ok(Var::default())
-    }
-
-    fn registerName() -> &'static str {
-      "Dummy\0"
-    }
-
-    fn hash() -> u32 {
-      compile_time_crc32::crc32!("Dummy-rust-0x20200101")
-    }
-  }
-
-  #[cfg(test)]
-  #[ctor]
-  fn registerDummy() {
-    init();
-    registerShard::<DummyShard>();
-  }
-
-  fn macroTest() {
-    let rust_variable = "Hello World!";
-    let rust_variable2 = 2;
-    shards!(
-      (. 10)
-      (Math.Multiply rust_variable2)
-      (Math.Subtract :Operand 1)
-      (Set .x)
-      (Log)
-      (ToString)
-      (Set :Name .x)
-      (Repeat
-        (->
-        (Msg "repeating...")
-        (Log)
-        (. rust_variable) (Log)))
-      (Msg :Message "Done"));
-
-    shards!(
-      (. "Hello")
-      (Msg)
-    );
-  }
-
-  #[test]
-  fn instantiate() {
-    init();
-
-    let mut blk = create::<DummyShard>();
-    assert_eq!("Dummy".to_string(), blk.shard.name());
-
-    let blkname = CString::new("Dummy").expect("CString failed...");
-    unsafe {
-      let shlk = (*Core).createShard.unwrap()(blkname.as_ptr());
-      (*shlk).setup.unwrap()(shlk);
-      (*shlk).destroy.unwrap()(shlk);
-    }
-
-    let svar1: Var = Var::ephemeral_string("Hello\0");
-    let svar2: Var = Var::ephemeral_string("Hello\0");
-    let svar3: Var = 10.into();
-    let sstr1: &str = svar1.as_ref().try_into().unwrap();
-    assert_eq!("Hello", sstr1);
-    assert!(svar1 == svar2);
-    assert!(svar1 != svar3);
-
-    let a = Var::from(10);
-    let mut b = Var::from(true);
-    cloneVar(&mut b, &a);
-    unsafe {
-      assert_eq!(a.valueType, SHType_Int);
-      assert_eq!(b.valueType, SHType_Int);
-      assert_eq!(a.payload.__bindgen_anon_1.intValue, 10);
-      assert_eq!(
-        a.payload.__bindgen_anon_1.intValue,
-        b.payload.__bindgen_anon_1.intValue
-      );
-    }
-
-    let _v: ClonedVar = a.into();
-
-    shlog!("Hello shards-rs");
   }
 }
 
@@ -498,28 +163,28 @@ pub extern "C" fn registerRustShards(core: *mut SHCore) {
   }
 
   #[cfg(not(target_arch = "wasm32"))]
-  shards::http::registerShards();
+  shards::http::register_shards();
 
-  shards::casting::registerShards();
-  shards::hash::registerShards();
-  shards::ecdsa::registerShards();
-  shards::physics::simulation::registerShards();
-  shards::physics::shapes::registerShards();
-  shards::physics::rigidbody::registerShards();
-  shards::physics::queries::registerShards();
-  shards::physics::forces::registerShards();
-  shards::svg::registerShards();
-  shards::eth::registerShards();
-  shards::csv::registerShards();
-  shards::curve25519::registerShards();
-  shards::substrate::registerShards();
-  shards::chachapoly::registerShards();
-  shards::gui::registerShards();
-  shards::date::registerShards();
-  shards::onnx::registerShards();
+  shards::casting::register_shards();
+  shards::hash::register_shards();
+  shards::ecdsa::register_shards();
+  shards::physics::simulation::register_shards();
+  shards::physics::shapes::register_shards();
+  shards::physics::rigidbody::register_shards();
+  shards::physics::queries::register_shards();
+  shards::physics::forces::register_shards();
+  shards::svg::register_shards();
+  shards::eth::register_shards();
+  shards::csv::register_shards();
+  shards::curve25519::register_shards();
+  shards::substrate::register_shards();
+  shards::chachapoly::register_shards();
+  shards::gui::register_shards();
+  shards::date::register_shards();
+  shards::onnx::register_shards();
 
   #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
-  shards::browse::registerShards();
+  shards::browse::register_shards();
 }
 
 #[no_mangle]

--- a/rust/src/shard.rs
+++ b/rust/src/shard.rs
@@ -2,24 +2,24 @@
 /* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 use crate::core::abortWire;
-use crate::core::Core;
+
 use crate::shardsc::SHContext;
 use crate::shardsc::SHError;
 use crate::shardsc::SHExposedTypesInfo;
 use crate::shardsc::SHInstanceData;
 use crate::shardsc::SHOptionalString;
-use crate::shardsc::SHParameterInfo;
+
 use crate::shardsc::SHParametersInfo;
-use crate::shardsc::SHSeq;
+
 use crate::shardsc::SHShardComposeResult;
-use crate::shardsc::SHString;
+
 use crate::shardsc::SHTable;
 use crate::shardsc::SHTypeInfo;
 use crate::shardsc::SHTypesInfo;
 use crate::shardsc::SHVar;
 use crate::shardsc::SHWire;
 use crate::shardsc::Shard as CShard;
-use crate::shardsc::ShardPtr;
+
 use crate::types::ComposeResult;
 use crate::types::Context;
 use crate::types::ExposedTypes;
@@ -30,13 +30,13 @@ use crate::types::Table;
 use crate::types::Type;
 use crate::types::Types;
 use crate::types::Var;
-use crate::types::Wire;
-use core::convert::TryInto;
+
+
 use core::result::Result;
-use core::slice;
-use std::ffi::CStr;
+
+
 use std::ffi::CString;
-use std::os::raw::c_char;
+
 
 pub trait Shard {
   fn registerName() -> &'static str

--- a/rust/src/shards/browse.rs
+++ b/rust/src/shards/browse.rs
@@ -1,24 +1,24 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::types::common_type;
-use crate::types::ClonedVar;
+
 use crate::types::Context;
-use crate::types::ParamVar;
-use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
+
+
 use crate::types::Type;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
 use std::convert::TryInto;
 
 lazy_static! {
-  static ref INPUT_TYPES: Vec<Type> = vec![common_type::string,];
+  static ref INPUT_TYPES: Vec<Type> = vec![common_type::STRING,];
 }
 
 #[derive(Default)]
@@ -49,6 +49,6 @@ impl Shard for Browse {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Browse>();
 }

--- a/rust/src/shards/casting.rs
+++ b/rust/src/shards/casting.rs
@@ -1,32 +1,32 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::types::common_type;
 use crate::types::ClonedVar;
 use crate::types::Context;
-use crate::types::ParamVar;
+
 use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
 use crate::types::Type;
 use crate::types::BOOL_TYPES_SLICE;
 use crate::types::BYTES_TYPES;
 use crate::types::INT_TYPES;
 use crate::types::STRING_TYPES;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
-use core::time::Duration;
-use std::convert::TryFrom;
+
+
 use std::convert::TryInto;
-use std::ffi::CStr;
+
 use wasabi_leb128::{ReadLeb128, WriteLeb128};
 
 lazy_static! {
-  pub static ref INPUT_TYPES: Vec<Type> = vec![common_type::bytes, common_type::string,];
+  pub static ref INPUT_TYPES: Vec<Type> = vec![common_type::BYTES, common_type::STRING,];
 }
 
 struct ToBase58 {
@@ -263,7 +263,7 @@ impl Shard for FromLEB128 {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<ToBase58>();
   registerShard::<FromBase58>();
   registerShard::<ToLEB128>();

--- a/rust/src/shards/chachapoly.rs
+++ b/rust/src/shards/chachapoly.rs
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::shards::CRYPTO_KEY_TYPES;
@@ -10,19 +10,19 @@ use crate::types::ClonedVar;
 use crate::types::Context;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
 use crate::types::Type;
 use crate::types::BYTES_TYPES;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
 use chacha20poly1305::aead::{Aead, NewAead};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
-use std::convert::TryInto;
+
 
 lazy_static! {
-  static ref INPUT_TYPES: Vec<Type> = vec![common_type::string, common_type::bytes,];
+  static ref INPUT_TYPES: Vec<Type> = vec![common_type::STRING, common_type::BYTES,];
   static ref PARAMETERS: Parameters = vec![(
     cstr!("Key"),
     shccstr!("The private key to be used to encrypt/decrypt the input payload."),
@@ -229,7 +229,7 @@ impl Shard for Decrypt {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Encrypt>();
   registerShard::<Decrypt>();
 }

--- a/rust/src/shards/csv.rs
+++ b/rust/src/shards/csv.rs
@@ -1,28 +1,28 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
-use crate::types::common_type;
+
 use crate::types::ClonedVar;
 use crate::types::Context;
 use crate::types::OptionalString;
-use crate::types::ParamVar;
+
 use crate::types::Parameters;
 use crate::types::Seq;
-use crate::types::Table;
+
 use crate::types::Type;
 use crate::types::BOOL_TYPES_SLICE;
 use crate::types::SEQ_OF_STRINGS_TYPES;
 use crate::types::STRING_TYPES;
 use crate::types::STRING_TYPES_SLICE;
 use crate::CString;
-use crate::Types;
+
 use crate::Var;
-use core::convert::TryFrom;
+
 use core::convert::TryInto;
-use ext_csv::Reader;
+
 use ext_csv::ReaderBuilder;
 use ext_csv::WriterBuilder;
 
@@ -246,7 +246,7 @@ impl Shard for CSVWrite {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<CSVRead>();
   registerShard::<CSVWrite>();
 }

--- a/rust/src/shards/curve25519.rs
+++ b/rust/src/shards/curve25519.rs
@@ -1,37 +1,37 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::shards::CRYPTO_KEY_TYPES;
-use crate::shardsc::SHType_String;
+
 use crate::types::common_type;
 use crate::types::ClonedVar;
 use crate::types::Context;
-use crate::types::InstanceData;
+
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
 use crate::types::Type;
 use crate::types::BYTES_TYPES;
 use crate::types::STRING_TYPES;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
-use core::time::Duration;
+
 use sp_core::crypto::Pair;
 use sp_core::ed25519;
 use sp_core::sr25519;
-use std::convert::TryFrom;
-use std::convert::TryInto;
-use std::ffi::CStr;
 
-static SIGNATURE_TYPES: &[Type] = &[common_type::bytezs, common_type::bytess_var];
+use std::convert::TryInto;
+
+
+static SIGNATURE_TYPES: &[Type] = &[common_type::BYTEZS, common_type::BYTESS_VAR];
 
 lazy_static! {
-  static ref PK_TYPES: Vec<Type> = vec![common_type::bytes, common_type::string];
+  static ref PK_TYPES: Vec<Type> = vec![common_type::BYTES, common_type::STRING];
   static ref PARAMETERS: Parameters = vec![(
     cstr!("Key"),
     shccstr!("The private key to be used to sign the hashed message input."),
@@ -275,7 +275,7 @@ add_priv_key!(
   32
 );
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Sr25519Sign>();
   registerShard::<Ed25519Sign>();
   registerShard::<Sr25519PublicKey>();

--- a/rust/src/shards/date.rs
+++ b/rust/src/shards/date.rs
@@ -1,30 +1,30 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
-use crate::types::common_type;
+
 use crate::types::ClonedVar;
 use crate::types::Context;
 use crate::types::OptionalString;
-use crate::types::ParamVar;
+
 use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
 use crate::types::Type;
-use crate::types::BOOL_TYPES_SLICE;
+
 use crate::types::INT_TYPES;
-use crate::types::SEQ_OF_STRINGS_TYPES;
+
 use crate::types::STRING_TYPES;
 use crate::types::STRING_TYPES_SLICE;
 use crate::CString;
-use crate::Types;
+
 use crate::Var;
-use chrono::{DateTime, LocalResult, TimeZone, Utc};
-use core::convert::TryFrom;
+use chrono::{LocalResult, TimeZone, Utc};
+
 use core::convert::TryInto;
-use usvg::fontdb::Database;
+
 
 lazy_static! {
   static ref PARAMETERS: Parameters = vec![
@@ -139,6 +139,6 @@ impl Default for CSVWrite {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<DateFormat>();
 }

--- a/rust/src/shards/ecdsa.rs
+++ b/rust/src/shards/ecdsa.rs
@@ -1,34 +1,34 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::shards::CRYPTO_KEY_TYPES;
-use crate::shardsc::SHType_String;
+
 use crate::types::common_type;
 use crate::types::ClonedVar;
 use crate::types::Context;
-use crate::types::InstanceData;
+
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
 use crate::types::Type;
 use crate::types::BOOL_TYPES_SLICE;
 use crate::types::BYTES_TYPES;
 use crate::types::STRING_TYPES;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
-use core::time::Duration;
+
 use sp_core::crypto::Pair;
 use sp_core::ecdsa;
-use std::convert::TryFrom;
-use std::convert::TryInto;
-use std::ffi::CStr;
 
-static SIGNATURE_TYPES: &[Type] = &[common_type::bytes, common_type::bytes_var];
+use std::convert::TryInto;
+
+
+static SIGNATURE_TYPES: &[Type] = &[common_type::BYTES, common_type::BYTES_VAR];
 
 lazy_static! {
   static ref PARAMETERS: Parameters = vec![(
@@ -37,7 +37,7 @@ lazy_static! {
     CRYPTO_KEY_TYPES
   )
     .into()];
-  static ref PK_TYPES: Vec<Type> = vec![common_type::bytes, common_type::string];
+  static ref PK_TYPES: Vec<Type> = vec![common_type::BYTES, common_type::STRING];
   static ref PK_PARAMETERS: Parameters = vec![(
     cstr!("Compressed"),
     shccstr!("If the output PublicKey should use the compressed format."),
@@ -366,7 +366,7 @@ impl Shard for ECDSARecover {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<ECDSASign>();
   registerShard::<ECDSAPubKey>();
   registerShard::<ECDSAPrivKey>();

--- a/rust/src/shards/eth.rs
+++ b/rust/src/shards/eth.rs
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::types::common_type;
@@ -10,13 +10,13 @@ use crate::types::Context;
 use crate::types::ParamVar;
 use crate::types::Parameters;
 use crate::types::Seq;
-use crate::types::Table;
+
 use crate::types::Type;
 use crate::types::BOOL_TYPES_SLICE;
 use crate::types::STRING_OR_NONE_SLICE;
 use crate::types::STRING_VAR_OR_NONE_SLICE;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
 use core::convert::TryFrom;
 use ethabi::Contract;
@@ -26,10 +26,10 @@ use ethereum_types::U256;
 use std::convert::TryInto;
 
 lazy_static! {
-  static ref INPUT_TYPES: Vec<Type> = vec![common_type::anys];
-  static ref DECODE_INPUT_TYPES: Vec<Type> = vec![common_type::bytes, common_type::string];
-  static ref OUTPUT_TYPES: Vec<Type> = vec![common_type::bytes];
-  static ref DECODE_OUTPUT_TYPES: Vec<Type> = vec![common_type::anys];
+  static ref INPUT_TYPES: Vec<Type> = vec![common_type::ANYS];
+  static ref DECODE_INPUT_TYPES: Vec<Type> = vec![common_type::BYTES, common_type::STRING];
+  static ref OUTPUT_TYPES: Vec<Type> = vec![common_type::BYTES];
+  static ref DECODE_OUTPUT_TYPES: Vec<Type> = vec![common_type::ANYS];
   static ref PARAMETERS: Parameters = vec![
     (
       cstr!("ABI"),
@@ -424,7 +424,7 @@ impl Shard for DecodeCall {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<EncodeCall>();
   registerShard::<DecodeCall>();
 }

--- a/rust/src/shards/gui/containers/area.rs
+++ b/rust/src/shards/gui/containers/area.rs
@@ -18,15 +18,15 @@ use crate::types::InstanceData;
 use crate::types::OptionalString;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::RawString;
+
 use crate::types::ShardsVar;
 use crate::types::Type;
 use crate::types::Types;
 use crate::types::Var;
 use crate::types::ANY_TYPES;
 use crate::types::SHARDS_OR_NONE_TYPES;
-use crate::types::STRING_OR_NONE_SLICE;
-use egui::Context as EguiNativeContext;
+
+
 
 lazy_static! {
   static ref AREA_PARAMETERS: Parameters = vec![

--- a/rust/src/shards/gui/containers/mod.rs
+++ b/rust/src/shards/gui/containers/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::core::registerEnumType;
 use crate::core::registerShard;
-use crate::fourCharacterCode;
+use crate::four_character_code;
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::ShardsVar;
@@ -38,7 +38,7 @@ shenum! {
 
 shenum_types! {
   AnchorInfo,
-  const AnchorCC = fourCharacterCode(*b"egAn");
+  const AnchorCC = four_character_code(*b"egAn");
   static ref AnchorEnumInfo;
   static ref ANCHOR_TYPE: Type;
   static ref ANCHOR_TYPES: Vec<Type>;
@@ -79,7 +79,7 @@ shenum! {
 
 shenum_types! {
   WindowFlagsInfo,
-  const WindowFlagsCC = fourCharacterCode(*b"egWF");
+  const WindowFlagsCC = four_character_code(*b"egWF");
   static ref WindowFlagsEnumInfo;
   static ref WINDOW_FLAGS_TYPE: Type;
   static ref WINDOW_FLAGS_TYPES: Vec<Type>;
@@ -121,7 +121,7 @@ mod panels;
 mod scope;
 mod window;
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Area>();
   registerEnumType(FRAG_CC, AnchorCC, AnchorEnumInfo.as_ref().into());
   registerShard::<Scope>();

--- a/rust/src/shards/gui/containers/panels.rs
+++ b/rust/src/shards/gui/containers/panels.rs
@@ -20,7 +20,7 @@ use crate::types::InstanceData;
 use crate::types::OptionalString;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::RawString;
+
 use crate::types::ShardsVar;
 use crate::types::Type;
 use crate::types::Types;
@@ -28,7 +28,7 @@ use crate::types::Var;
 use crate::types::ANY_TYPES;
 use crate::types::FLOAT_OR_NONE_TYPES_SLICE;
 use crate::types::SHARDS_OR_NONE_TYPES;
-use egui::Context as EguiNativeContext;
+
 
 lazy_static! {
   static ref CENTRALPANEL_PARAMETERS: Parameters = vec![(

--- a/rust/src/shards/gui/containers/scope.rs
+++ b/rust/src/shards/gui/containers/scope.rs
@@ -6,7 +6,7 @@ use crate::shard::Shard;
 use crate::shards::gui::util;
 use crate::shards::gui::PARENTS_UI_NAME;
 use crate::types::Context;
-use crate::types::ExposedInfo;
+
 use crate::types::ExposedTypes;
 use crate::types::InstanceData;
 use crate::types::OptionalString;

--- a/rust/src/shards/gui/containers/window.rs
+++ b/rust/src/shards/gui/containers/window.rs
@@ -20,7 +20,7 @@ use crate::types::InstanceData;
 use crate::types::OptionalString;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::RawString;
+
 use crate::types::Seq;
 use crate::types::ShardsVar;
 use crate::types::Type;
@@ -30,7 +30,7 @@ use crate::types::ANY_TYPES;
 use crate::types::INT_OR_NONE_TYPES_SLICE;
 use crate::types::SHARDS_OR_NONE_TYPES;
 use crate::types::STRING_TYPES;
-use egui::Context as EguiNativeContext;
+
 
 lazy_static! {
   static ref WINDOW_FLAGS_OR_SEQ_TYPES: Vec<Type> = vec![*WINDOW_FLAGS_TYPE, *SEQ_OF_WINDOW_FLAGS];

--- a/rust/src/shards/gui/context.rs
+++ b/rust/src/shards/gui/context.rs
@@ -18,7 +18,7 @@ use crate::types::InstanceData;
 use crate::types::OptionalString;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::RawString;
+
 use crate::types::Seq;
 use crate::types::ShardsVar;
 use crate::types::Type;
@@ -27,7 +27,7 @@ use crate::types::WireState;
 use crate::types::ANY_TYPES;
 use crate::types::SHARDS_OR_NONE_TYPES;
 use egui::Context as EguiNativeContext;
-use egui::RawInput;
+
 use std::ffi::CStr;
 
 lazy_static! {

--- a/rust/src/shards/gui/layouts/collapsing_header.rs
+++ b/rust/src/shards/gui/layouts/collapsing_header.rs
@@ -7,7 +7,7 @@ use crate::shards::gui::util;
 use crate::shards::gui::EguiId;
 use crate::shards::gui::PARENTS_UI_NAME;
 use crate::shards::gui::STRING_OR_SHARDS_OR_NONE_TYPES_SLICE;
-use crate::types::common_type;
+
 use crate::types::Context;
 use crate::types::ExposedTypes;
 use crate::types::InstanceData;

--- a/rust/src/shards/gui/layouts/frame.rs
+++ b/rust/src/shards/gui/layouts/frame.rs
@@ -24,9 +24,9 @@ use crate::types::SHARDS_OR_NONE_TYPES;
 
 lazy_static! {
   static ref COLOR_VAR_OR_NONE_TYPES: Vec<Type> = vec![
-    common_type::color,
-    common_type::color_var,
-    common_type::none
+    common_type::COLOR,
+    common_type::COLOR_VAR,
+    common_type::NONE
   ];
   static ref FRAME_PARAMETERS: Parameters = vec![
     (

--- a/rust/src/shards/gui/layouts/mod.rs
+++ b/rust/src/shards/gui/layouts/mod.rs
@@ -107,7 +107,7 @@ mod separator;
 mod space;
 mod vertical;
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<CollapsingHeader>();
   registerShard::<Columns>();
   registerShard::<Disable>();

--- a/rust/src/shards/gui/menus/menu.rs
+++ b/rust/src/shards/gui/menus/menu.rs
@@ -210,7 +210,7 @@ impl Shard for Menu {
       self.contents.compose(data)?;
     }
 
-    Ok(common_type::bool)
+    Ok(common_type::BOOL)
   }
 
   fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
@@ -354,7 +354,7 @@ impl Shard for MenuBar {
       self.contents.compose(data)?;
     }
 
-    Ok(common_type::bool)
+    Ok(common_type::BOOL)
   }
 
   fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {

--- a/rust/src/shards/gui/menus/mod.rs
+++ b/rust/src/shards/gui/menus/mod.rs
@@ -23,7 +23,7 @@ struct MenuBar {
   contents: ShardsVar,
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<CloseMenu>();
   registerShard::<Menu>();
   registerShard::<MenuBar>();

--- a/rust/src/shards/gui/misc/mod.rs
+++ b/rust/src/shards/gui/misc/mod.rs
@@ -18,7 +18,7 @@ struct Style {
 mod reset;
 mod style;
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Reset>();
   registerShard::<Style>();
 }

--- a/rust/src/shards/gui/misc/style.rs
+++ b/rust/src/shards/gui/misc/style.rs
@@ -19,7 +19,7 @@ use crate::types::Var;
 use crate::types::ANY_TYPES;
 
 lazy_static! {
-  static ref INPUT_TYPES: Types = vec![common_type::any_table, common_type::any_table_var];
+  static ref INPUT_TYPES: Types = vec![common_type::ANY_TABLE, common_type::ANY_TABLE_VAR];
 }
 
 macro_rules! apply_style {

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::core::cloneVar;
 use crate::core::registerShard;
-use crate::fourCharacterCode;
+use crate::four_character_code;
 use crate::shard::Shard;
 use crate::shardsc;
 use crate::types::common_type;
@@ -15,38 +15,38 @@ use crate::types::Var;
 use crate::types::FRAG_CC;
 use egui::Context as EguiNativeContext;
 use std::ffi::c_void;
-use std::ffi::CStr;
 
-static ANY_VAR_SLICE: &[Type] = &[common_type::any, common_type::any_var];
-static BOOL_OR_NONE_SLICE: &[Type] = &[common_type::bool, common_type::none];
+
+static ANY_VAR_SLICE: &[Type] = &[common_type::ANY, common_type::ANY_VAR];
+static BOOL_OR_NONE_SLICE: &[Type] = &[common_type::BOOL, common_type::NONE];
 static BOOL_VAR_OR_NONE_SLICE: &[Type] =
-  &[common_type::bool, common_type::bool_var, common_type::none];
+  &[common_type::BOOL, common_type::BOOL_VAR, common_type::NONE];
 static COLOR_VAR_OR_NONE_SLICE: &[Type] = &[
-  common_type::color,
-  common_type::color_var,
-  common_type::none,
+  common_type::COLOR,
+  common_type::COLOR_VAR,
+  common_type::NONE,
 ];
-static FLOAT_VAR_SLICE: &[Type] = &[common_type::float, common_type::float_var];
-static FLOAT2_VAR_SLICE: &[Type] = &[common_type::float2, common_type::float2_var];
+static FLOAT_VAR_SLICE: &[Type] = &[common_type::FLOAT, common_type::FLOAT_VAR];
+static FLOAT2_VAR_SLICE: &[Type] = &[common_type::FLOAT2, common_type::FLOAT2_VAR];
 static INT_VAR_OR_NONE_SLICE: &[Type] =
-  &[common_type::int, common_type::int_var, common_type::none];
-static STRING_VAR_SLICE: &[Type] = &[common_type::string, common_type::string_var];
+  &[common_type::INT, common_type::INT_VAR, common_type::NONE];
+static STRING_VAR_SLICE: &[Type] = &[common_type::STRING, common_type::STRING_VAR];
 static STRING_OR_SHARDS_OR_NONE_TYPES_SLICE: &[Type] = &[
-  common_type::string,
-  common_type::shard,
-  common_type::shards,
-  common_type::none,
+  common_type::STRING,
+  common_type::SHARD,
+  common_type::SHARDS,
+  common_type::NONE,
 ];
 
-static EGUI_UI_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"eguU"));
+static EGUI_UI_TYPE: Type = Type::object(FRAG_CC, four_character_code(*b"eguU"));
 static EGUI_UI_SLICE: &[Type] = &[EGUI_UI_TYPE];
 static EGUI_UI_SEQ_TYPE: Type = Type::seq(EGUI_UI_SLICE);
 
-static EGUI_CTX_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"eguC"));
+static EGUI_CTX_TYPE: Type = Type::object(FRAG_CC, four_character_code(*b"eguC"));
 static EGUI_CTX_SLICE: &[Type] = &[EGUI_CTX_TYPE];
 static EGUI_CTX_SEQ_TYPE: Type = Type::seq(EGUI_CTX_SLICE);
 
-const TextureCC: i32 = fourCharacterCode(*b"tex_");
+const TextureCC: i32 = four_character_code(*b"tex_");
 
 lazy_static! {
   static ref GFX_GLOBALS_TYPE: Type = unsafe { *shardsc::gfx_getMainWindowGlobalsType() };
@@ -55,7 +55,7 @@ lazy_static! {
   static ref GFX_QUEUE_VAR: Type = Type::context_variable(&GFX_QUEUE_TYPES);
   static ref GFX_QUEUE_VAR_TYPES: Vec<Type> = vec![*GFX_QUEUE_VAR];
   static ref TEXTURE_TYPE: Type = Type::object(FRAG_CC, TextureCC);
-  static ref TEXTURE_OR_IMAGE_TYPES: Vec<Type> = vec![common_type::image, *TEXTURE_TYPE];
+  static ref TEXTURE_OR_IMAGE_TYPES: Vec<Type> = vec![common_type::IMAGE, *TEXTURE_TYPE];
 }
 
 const CONTEXT_NAME: &str = "UI.Context";
@@ -208,11 +208,11 @@ impl egui::TextBuffer for MutableVar<'_> {
   }
 }
 
-pub fn registerShards() {
-  containers::registerShards();
+pub fn register_shards() {
+  containers::register_shards();
   registerShard::<EguiContext>();
-  layouts::registerShards();
-  menus::registerShards();
-  misc::registerShards();
-  widgets::registerShards();
+  layouts::register_shards();
+  menus::register_shards();
+  misc::register_shards();
+  widgets::register_shards();
 }

--- a/rust/src/shards/gui/widgets/button.rs
+++ b/rust/src/shards/gui/widgets/button.rs
@@ -143,7 +143,7 @@ impl Shard for Button {
       self.action.compose(data)?;
     }
 
-    Ok(common_type::bool)
+    Ok(common_type::BOOL)
   }
 
   fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {

--- a/rust/src/shards/gui/widgets/checkbox.rs
+++ b/rust/src/shards/gui/widgets/checkbox.rs
@@ -143,7 +143,7 @@ impl Shard for Checkbox {
       }
     }
 
-    Ok(common_type::bool)
+    Ok(common_type::BOOL)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
@@ -151,7 +151,7 @@ impl Shard for Checkbox {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::bool,
+        exposedType: common_type::BOOL,
         name: self.variable.get_name(),
         help: cstr!("The exposed bool variable").into(),
         ..ExposedInfo::default()
@@ -180,7 +180,7 @@ impl Shard for Checkbox {
     self.variable.warmup(ctx);
 
     if self.should_expose {
-      self.variable.get_mut().valueType = common_type::bool.basicType;
+      self.variable.get_mut().valueType = common_type::BOOL.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/code_editor/mod.rs
+++ b/rust/src/shards/gui/widgets/code_editor/mod.rs
@@ -24,7 +24,7 @@ use crate::types::Parameters;
 use crate::types::Type;
 use crate::types::Types;
 use crate::types::Var;
-use crate::types::BOOL_TYPES_SLICE;
+
 use crate::types::NONE_TYPES;
 use crate::types::STRING_TYPES;
 use std::cmp::Ordering;
@@ -153,7 +153,7 @@ impl Shard for CodeEditor {
       self.mutable_text = false;
     }
 
-    Ok(common_type::string)
+    Ok(common_type::STRING)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
@@ -161,7 +161,7 @@ impl Shard for CodeEditor {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::string,
+        exposedType: common_type::STRING,
         name: self.variable.get_name(),
         help: cstr!("The exposed string variable").into(),
         ..ExposedInfo::default()
@@ -195,7 +195,7 @@ impl Shard for CodeEditor {
     self.language.warmup(ctx);
 
     if self.should_expose {
-      self.variable.get_mut().valueType = common_type::string.basicType;
+      self.variable.get_mut().valueType = common_type::STRING.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/code_editor/syntax_highlighting.rs
+++ b/rust/src/shards/gui/widgets/code_editor/syntax_highlighting.rs
@@ -5,9 +5,9 @@
 // Code partially extracted from egui_demo_lib
 // https://github.com/emilk/egui/blob/master/crates/egui_demo_lib/src/syntax_highlighting.rs
 
-use egui::epaint::text::layout;
+
 use egui::text::LayoutJob;
-use syntect::highlighting::Theme;
+
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 

--- a/rust/src/shards/gui/widgets/color_input.rs
+++ b/rust/src/shards/gui/widgets/color_input.rs
@@ -2,7 +2,7 @@
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
 use super::ColorInput;
-use crate::core::cloneVar;
+
 use crate::shard::Shard;
 use crate::shards::gui::util;
 use crate::shards::gui::COLOR_VAR_OR_NONE_SLICE;
@@ -131,7 +131,7 @@ impl Shard for ColorInput {
       }
     }
 
-    Ok(common_type::color)
+    Ok(common_type::COLOR)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
@@ -139,7 +139,7 @@ impl Shard for ColorInput {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::color,
+        exposedType: common_type::COLOR,
         name: self.variable.get_name(),
         help: cstr!("The exposed color variable").into(),
         ..ExposedInfo::default()
@@ -167,7 +167,7 @@ impl Shard for ColorInput {
     self.variable.warmup(ctx);
 
     if self.should_expose {
-      self.variable.get_mut().valueType = common_type::color.basicType;
+      self.variable.get_mut().valueType = common_type::COLOR.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/combo.rs
+++ b/rust/src/shards/gui/widgets/combo.rs
@@ -150,7 +150,7 @@ impl Shard for Combo {
       }
     }
 
-    Ok(common_type::any)
+    Ok(common_type::ANY)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
@@ -158,7 +158,7 @@ impl Shard for Combo {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::int,
+        exposedType: common_type::INT,
         name: self.index.get_name(),
         help: cstr!("The exposed int variable").into(),
         ..ExposedInfo::default()
@@ -188,7 +188,7 @@ impl Shard for Combo {
     self.width.warmup(ctx);
 
     if self.should_expose {
-      self.index.get_mut().valueType = common_type::int.basicType;
+      self.index.get_mut().valueType = common_type::INT.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/image_button.rs
+++ b/rust/src/shards/gui/widgets/image_button.rs
@@ -154,7 +154,7 @@ impl Shard for ImageButton {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::bool,
+        exposedType: common_type::BOOL,
         name: self.selected.get_name(),
         help: cstr!("The exposed bool variable").into(),
         ..ExposedInfo::default()
@@ -208,7 +208,7 @@ impl Shard for ImageButton {
       }
       _ => (),
     }
-    Ok(common_type::bool)
+    Ok(common_type::BOOL)
   }
 
   fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
@@ -221,7 +221,7 @@ impl Shard for ImageButton {
     self.selected.warmup(ctx);
 
     if self.should_expose {
-      self.selected.get_mut().valueType = common_type::bool.basicType;
+      self.selected.get_mut().valueType = common_type::BOOL.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/listbox.rs
+++ b/rust/src/shards/gui/widgets/listbox.rs
@@ -128,7 +128,7 @@ impl Shard for ListBox {
       }
     }
 
-    Ok(common_type::any)
+    Ok(common_type::ANY)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
@@ -136,7 +136,7 @@ impl Shard for ListBox {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::int,
+        exposedType: common_type::INT,
         name: self.index.get_name(),
         help: cstr!("The exposed int variable").into(),
         ..ExposedInfo::default()
@@ -164,7 +164,7 @@ impl Shard for ListBox {
     self.index.warmup(ctx);
 
     if self.should_expose {
-      self.index.get_mut().valueType = common_type::int.basicType;
+      self.index.get_mut().valueType = common_type::INT.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/mod.rs
+++ b/rust/src/shards/gui/widgets/mod.rs
@@ -3,11 +3,11 @@
 
 use crate::core::registerShard;
 use crate::shardsc;
-use crate::types::common_type;
+
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::ShardsVar;
-use crate::types::Type;
+
 use crate::types::Var;
 
 /// Clickable button with a text label.
@@ -212,7 +212,7 @@ mod spinner;
 mod text_input;
 mod tooltip;
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Button>();
   registerShard::<Checkbox>();
   registerShard::<ColorInput>();

--- a/rust/src/shards/gui/widgets/numeric_input.rs
+++ b/rust/src/shards/gui/widgets/numeric_input.rs
@@ -12,7 +12,7 @@ use super::IntInput;
 use crate::core::cloneVar;
 use crate::shard::Shard;
 use crate::shards::gui::util;
-use crate::shards::gui::EGUI_UI_TYPE;
+
 use crate::shards::gui::PARENTS_UI_NAME;
 use crate::types::common_type;
 use crate::types::Context;
@@ -22,7 +22,7 @@ use crate::types::InstanceData;
 use crate::types::OptionalString;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Seq;
+
 use crate::types::Type;
 use crate::types::Types;
 use crate::types::Var;
@@ -222,8 +222,8 @@ impl_ui_input!(
   "UI.IntInput",
   "UI.IntInput-rust-0x20200101",
   INT_VAR_SLICE,
-  int,
-  int_var,
+  INT,
+  INT_VAR,
   i64,
   INT_INPUT_PARAMETERS,
   INT_TYPES
@@ -234,8 +234,8 @@ impl_ui_input!(
   "UI.FloatInput",
   "UI.FloatInput-rust-0x20200101",
   FLOAT_VAR_SLICE,
-  float,
-  float_var,
+  FLOAT,
+  FLOAT_VAR,
   f64,
   FLOAT_INPUT_PARAMETERS,
   FLOAT_TYPES
@@ -247,8 +247,8 @@ macro_rules! impl_ui_n_input {
 
     lazy_static! {
       static ref $parameters: Parameters = vec![(
-        cstr!("Variable"),
-        cstr!("The variable that holds the input value."),
+        cstr!("VARIABLE"),
+        cstr!("THE variable that holds the input value."),
         $static,
       )
         .into(),];
@@ -437,8 +437,8 @@ impl_ui_n_input!(
   "UI.Float2Input",
   "UI.Float2Input-rust-0x20200101",
   FLOAT2_VAR_SLICE,
-  float2,
-  float2_var,
+  FLOAT2,
+  FLOAT2_VAR,
   f64,
   FLOAT2_INPUT_PARAMETERS,
   FLOAT2_TYPES
@@ -450,8 +450,8 @@ impl_ui_n_input!(
   "UI.Float3Input",
   "UI.Float3Input-rust-0x20200101",
   FLOAT3_VAR_SLICE,
-  float3,
-  float3_var,
+  FLOAT3,
+  FLOAT3_VAR,
   f32,
   FLOAT3_INPUT_PARAMETERS,
   FLOAT3_TYPES
@@ -463,8 +463,8 @@ impl_ui_n_input!(
   "UI.Float4Input",
   "UI.Float4Input-rust-0x20200101",
   FLOAT4_VAR_SLICE,
-  float4,
-  float4_var,
+  FLOAT4,
+  FLOAT4_VAR,
   f32,
   FLOAT4_INPUT_PARAMETERS,
   FLOAT4_TYPES
@@ -476,8 +476,8 @@ impl_ui_n_input!(
   "UI.Int2Input",
   "UI.Int2Input-rust-0x20200101",
   INT2_VAR_SLICE,
-  int2,
-  int2_var,
+  INT2,
+  INT2_VAR,
   i64,
   INT2_INPUT_PARAMETERS,
   INT2_TYPES
@@ -489,8 +489,8 @@ impl_ui_n_input!(
   "UI.Int3Input",
   "UI.Int3Input-rust-0x20200101",
   INT3_VAR_SLICE,
-  int3,
-  int3_var,
+  INT3,
+  INT3_VAR,
   i32,
   INT3_INPUT_PARAMETERS,
   INT3_TYPES
@@ -502,8 +502,8 @@ impl_ui_n_input!(
   "UI.Int4Input",
   "UI.Int4Input-rust-0x20200101",
   INT4_VAR_SLICE,
-  int4,
-  int4_var,
+  INT4,
+  INT4_VAR,
   i32,
   INT4_INPUT_PARAMETERS,
   INT4_TYPES

--- a/rust/src/shards/gui/widgets/numeric_slider.rs
+++ b/rust/src/shards/gui/widgets/numeric_slider.rs
@@ -12,7 +12,7 @@ use super::IntSlider;
 use crate::core::cloneVar;
 use crate::shard::Shard;
 use crate::shards::gui::util;
-use crate::shards::gui::EGUI_UI_TYPE;
+
 use crate::shards::gui::PARENTS_UI_NAME;
 use crate::types::common_type;
 use crate::types::Context;
@@ -22,7 +22,7 @@ use crate::types::InstanceData;
 use crate::types::OptionalString;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Seq;
+
 use crate::types::Type;
 use crate::types::Types;
 use crate::types::Var;
@@ -256,8 +256,8 @@ impl_ui_slider!(
   "UI.IntSlider",
   "UI.IntSlider-rust-0x20200101",
   INT_VAR_SLICE,
-  int,
-  int_var,
+  INT,
+  INT_VAR,
   i64,
   INT_SLIDER_PARAMETERS,
   INT_TYPES
@@ -268,8 +268,8 @@ impl_ui_slider!(
   "UI.FloatSlider",
   "UI.FloatSlider-rust-0x20200101",
   FLOAT_VAR_SLICE,
-  float,
-  float_var,
+  FLOAT,
+  FLOAT_VAR,
   f64,
   FLOAT_SLIDER_PARAMETERS,
   FLOAT_TYPES
@@ -508,8 +508,8 @@ impl_ui_n_slider!(
   "UI.Float2Slider",
   "UI.Float2Slider-rust-0x20200101",
   FLOAT2_VAR_SLICE,
-  float2,
-  float2_var,
+  FLOAT2,
+  FLOAT2_VAR,
   f64,
   FLOAT2_SLIDER_PARAMETERS,
   FLOAT2_TYPES
@@ -521,8 +521,8 @@ impl_ui_n_slider!(
   "UI.Float3Slider",
   "UI.Float3Slider-rust-0x20200101",
   FLOAT3_VAR_SLICE,
-  float3,
-  float3_var,
+  FLOAT3,
+  FLOAT3_VAR,
   f32,
   FLOAT3_SLIDER_PARAMETERS,
   FLOAT3_TYPES
@@ -534,8 +534,8 @@ impl_ui_n_slider!(
   "UI.Float4Slider",
   "UI.Float4Slider-rust-0x20200101",
   FLOAT4_VAR_SLICE,
-  float4,
-  float4_var,
+  FLOAT4,
+  FLOAT4_VAR,
   f32,
   FLOAT4_SLIDER_PARAMETERS,
   FLOAT4_TYPES
@@ -547,8 +547,8 @@ impl_ui_n_slider!(
   "UI.Int2Slider",
   "UI.Int2Slider-rust-0x20200101",
   INT2_VAR_SLICE,
-  int2,
-  int2_var,
+  INT2,
+  INT2_VAR,
   i64,
   INT2_SLIDER_PARAMETERS,
   INT2_TYPES
@@ -560,8 +560,8 @@ impl_ui_n_slider!(
   "UI.Int3Slider",
   "UI.Int3Slider-rust-0x20200101",
   INT3_VAR_SLICE,
-  int3,
-  int3_var,
+  INT3,
+  INT3_VAR,
   i32,
   INT3_SLIDER_PARAMETERS,
   INT3_TYPES
@@ -573,8 +573,8 @@ impl_ui_n_slider!(
   "UI.Int4Slider",
   "UI.Int4Slider-rust-0x20200101",
   INT4_VAR_SLICE,
-  int4,
-  int4_var,
+  INT4,
+  INT4_VAR,
   i32,
   INT4_SLIDER_PARAMETERS,
   INT4_TYPES

--- a/rust/src/shards/gui/widgets/radio_button.rs
+++ b/rust/src/shards/gui/widgets/radio_button.rs
@@ -152,7 +152,7 @@ impl Shard for RadioButton {
       }
     }
 
-    Ok(common_type::any)
+    Ok(common_type::ANY)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {

--- a/rust/src/shards/gui/widgets/text_input.rs
+++ b/rust/src/shards/gui/widgets/text_input.rs
@@ -147,7 +147,7 @@ impl Shard for TextInput {
       self.mutable_text = false;
     }
 
-    Ok(common_type::string)
+    Ok(common_type::STRING)
   }
 
   fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
@@ -155,7 +155,7 @@ impl Shard for TextInput {
       self.exposing.clear();
 
       let exp_info = ExposedInfo {
-        exposedType: common_type::string,
+        exposedType: common_type::STRING,
         name: self.variable.get_name(),
         help: cstr!("The exposed string variable").into(),
         ..ExposedInfo::default()
@@ -183,7 +183,7 @@ impl Shard for TextInput {
     self.multiline.warmup(ctx);
 
     if self.should_expose {
-      self.variable.get_mut().valueType = common_type::string.basicType;
+      self.variable.get_mut().valueType = common_type::STRING.basicType;
     }
 
     Ok(())

--- a/rust/src/shards/gui/widgets/tooltip.rs
+++ b/rust/src/shards/gui/widgets/tooltip.rs
@@ -7,7 +7,7 @@ use crate::shards::gui::util;
 use crate::shards::gui::PARENTS_UI_NAME;
 use crate::shards::gui::STRING_OR_SHARDS_OR_NONE_TYPES_SLICE;
 use crate::types::Context;
-use crate::types::ExposedInfo;
+
 use crate::types::ExposedTypes;
 use crate::types::InstanceData;
 use crate::types::OptionalString;

--- a/rust/src/shards/hash.rs
+++ b/rust/src/shards/hash.rs
@@ -1,42 +1,40 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::types::common_type;
-use crate::types::ClonedVar;
+
 use crate::types::Context;
-use crate::types::ParamVar;
-use crate::types::Parameters;
+
 use crate::types::Seq;
-use crate::types::Table;
+
 use crate::types::Type;
 use crate::types::BYTES_TYPES;
-use crate::CString;
-use crate::Types;
+
 use crate::Var;
-use core::time::Duration;
+
 use sha2::{Digest, Sha256, Sha512};
 use sp_core::twox_128;
 use sp_core::twox_64;
 use sp_core::{blake2_128, blake2_256};
-use std::convert::TryFrom;
+
 use std::convert::TryInto;
-use std::ffi::CStr;
+
 use tiny_keccak::{Hasher, Keccak, Sha3};
 
 lazy_static! {
   pub static ref INPUT_TYPES: Vec<Type> = vec![
-    common_type::bytes,
-    common_type::bytezs,
-    common_type::string,
-    common_type::strings
+    common_type::BYTES,
+    common_type::BYTEZS,
+    common_type::STRING,
+    common_type::STRINGS
   ];
 }
 
 macro_rules! add_hasher {
   ($shard_name:ident, $name_str:literal, $hash:literal, $algo:expr, $size:literal) => {
+    #[allow(non_camel_case_types)]
     struct $shard_name {
       output: Vec<u8>,
     }
@@ -104,6 +102,7 @@ add_hasher!(
   Keccak::v256,
   32
 );
+
 add_hasher!(
   Keccak_512,
   "Hash.Keccak-512",
@@ -111,6 +110,7 @@ add_hasher!(
   Keccak::v512,
   64
 );
+
 add_hasher!(
   SHSha3_256,
   "Hash.Sha3-256",
@@ -118,6 +118,7 @@ add_hasher!(
   Sha3::v256,
   32
 );
+
 add_hasher!(
   SHSha3_512,
   "Hash.Sha3-512",
@@ -202,6 +203,7 @@ add_hasher2!(
 
 macro_rules! add_hasher3 {
   ($shard_name:ident, $name_str:literal, $hash:literal, $algo:expr, $size:literal) => {
+    #[allow(non_camel_case_types)]
     struct $shard_name {
       output: Vec<u8>,
       scratch: Vec<u8>,
@@ -298,7 +300,7 @@ add_hasher3!(
   16
 );
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Keccak_256>();
   registerShard::<Keccak_512>();
   registerShard::<SHSha3_256>();

--- a/rust/src/shards/http.rs
+++ b/rust/src/shards/http.rs
@@ -1,13 +1,13 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2020 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::core::run_blocking;
 use crate::core::BlockingShard;
 use crate::shard::Shard;
 use crate::types::common_type;
-use crate::types::ClonedVar;
+
 use crate::types::Context;
 use crate::types::ParamVar;
 use crate::types::Parameters;
@@ -20,41 +20,41 @@ use crate::CString;
 use crate::Types;
 use crate::Var;
 use core::time::Duration;
-use reqwest::blocking::Request;
-use reqwest::blocking::RequestBuilder;
+
+
 use reqwest::blocking::Response;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE, USER_AGENT};
+use reqwest::header::{HeaderName, HeaderValue};
 use std::convert::TryInto;
-use std::ffi::CStr;
+
 
 const FULL_OUTPUT_KEYS: &[RawString] = &[shstr!("status"), shstr!("headers"), shstr!("body")];
 
-static URL_TYPES: &[Type] = &[common_type::string, common_type::string_var];
+static URL_TYPES: &[Type] = &[common_type::STRING, common_type::STRING_VAR];
 static HEADERS_TYPES: &[Type] = &[
-  common_type::none,
-  common_type::string_table,
-  common_type::string_table_var,
+  common_type::NONE,
+  common_type::STRING_TABLE,
+  common_type::STRING_TABLE_VAR,
 ];
 
 lazy_static! {
-  static ref GET_INPUT_TYPES: Vec<Type> = vec![common_type::none, common_type::string_table];
+  static ref GET_INPUT_TYPES: Vec<Type> = vec![common_type::NONE, common_type::STRING_TABLE];
   static ref POST_INPUT_TYPES: Vec<Type> = vec![
-    common_type::none,
-    common_type::string_table,
-    common_type::bytes,
-    common_type::string
+    common_type::NONE,
+    common_type::STRING_TABLE,
+    common_type::BYTES,
+    common_type::STRING
   ];
-  static ref STR_OUTPUT_TYPE: Vec<Type> = vec![common_type::string];
-  static ref BYTES_OUTPUT_TYPE: Vec<Type> = vec![common_type::bytes];
+  static ref STR_OUTPUT_TYPE: Vec<Type> = vec![common_type::STRING];
+  static ref BYTES_OUTPUT_TYPE: Vec<Type> = vec![common_type::BYTES];
   static ref _STR_FULL_OUTPUT_TYPES: Vec<Type> = vec![
-    common_type::int,
-    common_type::string_table,
-    common_type::string
+    common_type::INT,
+    common_type::STRING_TABLE,
+    common_type::STRING
   ];
   static ref _BYTES_FULL_OUTPUT_TYPES: Vec<Type> = vec![
-    common_type::int,
-    common_type::string_table,
-    common_type::bytes
+    common_type::INT,
+    common_type::STRING_TABLE,
+    common_type::BYTES
   ];
   static ref STR_FULL_OUTPUT_TTYPE: Type = Type::table(FULL_OUTPUT_KEYS, &_STR_FULL_OUTPUT_TYPES);
   static ref BYTES_FULL_OUTPUT_TTYPE: Type =
@@ -445,7 +445,7 @@ post_like!(Put, put, "Http.Put", "Http.Put-rust-0x20200101");
 post_like!(Patch, patch, "Http.Patch", "Http.Patch-rust-0x20200101");
 post_like!(Delete, delete, "Http.Delete", "Http.Delete-rust-0x20200101");
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Get>();
   registerShard::<Head>();
   registerShard::<Post>();

--- a/rust/src/shards/mod.rs
+++ b/rust/src/shards/mod.rs
@@ -35,8 +35,8 @@ pub mod date;
 pub mod onnx;
 
 static CRYPTO_KEY_TYPES: &[Type] = &[
-  common_type::bytes,
-  common_type::bytes_var,
-  common_type::string,
-  common_type::string_var,
+  common_type::BYTES,
+  common_type::BYTES_VAR,
+  common_type::STRING,
+  common_type::STRING_VAR,
 ];

--- a/rust/src/shards/onnx.rs
+++ b/rust/src/shards/onnx.rs
@@ -1,12 +1,11 @@
 use crate::shardsc::SHTypeInfo_Details_Object;
 use crate::types::{
-  ExposedInfo, ExposedTypes, ParamVar, Seq, NONE_TYPES, SEQ_OF_FLOAT_TYPES, SEQ_OF_INT_TYPES,
-  SEQ_OF_SEQ_OF_FLOAT_TYPES, STRINGS_TYPES, STRING_TYPES,
+  ExposedInfo, ExposedTypes, ParamVar, Seq, NONE_TYPES, SEQ_OF_FLOAT_TYPES, SEQ_OF_INT_TYPES, STRING_TYPES,
 };
 use crate::{
   core::registerShard,
   shard::Shard,
-  types::{common_type, Context, Parameters, Type, Types, Var, ANY_TYPES, FRAG_CC},
+  types::{common_type, Context, Parameters, Type, Types, Var, FRAG_CC},
 };
 use std::alloc::Global;
 use std::ffi::CString;
@@ -18,7 +17,7 @@ pub type OnnxModel =
 
 lazy_static! {
   static ref MODEL_TYPE: Type = {
-    let mut t = common_type::object;
+    let mut t = common_type::OBJECT;
     t.details.object = SHTypeInfo_Details_Object {
       vendorId: FRAG_CC, // 'frag'
       typeId: 0x6f6e6e78, // 'onnx'
@@ -288,7 +287,7 @@ impl Shard for Activate {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Load>();
   registerShard::<Activate>();
 }

--- a/rust/src/shards/physics/forces.rs
+++ b/rust/src/shards/physics/forces.rs
@@ -4,37 +4,35 @@
 use crate::core::registerShard;
 use crate::shards::physics::RigidBody;
 use crate::shards::physics::Simulation;
-use crate::shards::physics::EXPOSED_SIMULATION;
-use crate::shards::physics::RIGIDBODIES_TYPE;
+
+
 use crate::shards::physics::RIGIDBODIES_TYPES_SLICE;
 use crate::shards::physics::RIGIDBODY_TYPE;
-use crate::shards::physics::RIGIDBODY_VAR_TYPE;
+
 use crate::shards::physics::SIMULATION_TYPE;
-use crate::shardsc::SHPointer;
+
 use crate::types::common_type;
 use crate::types::Context;
 use crate::types::ExposedInfo;
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Seq;
+
 use crate::types::Type;
-use crate::types::ANY_TYPES;
+
 use crate::Shard;
 use crate::Types;
 use crate::Var;
-use rapier3d::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
-use rapier3d::geometry::{
-  BroadPhase, ColliderSet, ContactEvent, InteractionGroups, IntersectionEvent, NarrowPhase, Ray,
-};
-use rapier3d::na::{Point3, Vector3};
-use rapier3d::pipeline::{ChannelEventCollector, PhysicsPipeline, QueryPipeline};
+
+
+use rapier3d::na::{Vector3};
+
 use std::convert::TryInto;
-use std::rc::Rc;
+
 
 lazy_static! {
-  pub static ref INPUT_TYPES: Vec<Type> = vec![common_type::float3];
-  pub static ref OUTPUT_TYPES: Vec<Type> = vec![common_type::float3];
+  pub static ref INPUT_TYPES: Vec<Type> = vec![common_type::FLOAT3];
+  pub static ref OUTPUT_TYPES: Vec<Type> = vec![common_type::FLOAT3];
   static ref PARAMETERS: Parameters = vec![(
     cstr!("RigidBody"),
     shccstr!("The rigidbody to apply the impulse to."),
@@ -153,6 +151,6 @@ impl Shard for Impulse {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Impulse>();
 }

--- a/rust/src/shards/physics/mod.rs
+++ b/rust/src/shards/physics/mod.rs
@@ -4,19 +4,19 @@
 extern crate crossbeam;
 extern crate rapier3d;
 
-use crate::fourCharacterCode;
+use crate::four_character_code;
 use crate::shardsc::SHTypeInfo_Details_Object;
 use crate::shardsc::SHType_Float4;
-use crate::shardsc::SHType_None;
+
 use crate::types::common_type;
-use crate::types::ClonedVar;
+
 use crate::types::ExposedInfo;
-use crate::types::ExposedTypes;
+
 use crate::types::ParamVar;
 use crate::types::Seq;
 use crate::types::Type;
 use crate::types::FRAG_CC;
-use crate::Var;
+
 use rapier3d::dynamics::{
   CCDSolver, IntegrationParameters, JointSet, RigidBodyHandle, RigidBodySet,
 };
@@ -30,10 +30,10 @@ use rapier3d::prelude::IslandManager;
 
 lazy_static! {
   static ref SIMULATION_TYPE: Type = {
-    let mut t = common_type::object;
+    let mut t = common_type::OBJECT;
     t.details.object = SHTypeInfo_Details_Object {
       vendorId: FRAG_CC,
-      typeId: fourCharacterCode(*b"phys"),
+      typeId: four_character_code(*b"phys"),
     };
     t
   };
@@ -43,10 +43,10 @@ lazy_static! {
     *SIMULATION_TYPE
   )];
   static ref SHAPE_TYPE: Type = {
-    let mut t = common_type::object;
+    let mut t = common_type::OBJECT;
     t.details.object = SHTypeInfo_Details_Object {
       vendorId: FRAG_CC,
-      typeId: fourCharacterCode(*b"phyS"),
+      typeId: four_character_code(*b"phyS"),
     };
     t
   };
@@ -56,35 +56,35 @@ lazy_static! {
   static ref SHAPES_VAR_TYPE: Type = Type::context_variable(&SHAPE_TYPE_VEC);
   static ref SHAPE_TYPES: Vec<Type> = vec![*SHAPE_TYPE];
   static ref RIGIDBODY_TYPE: Type = {
-    let mut t = common_type::object;
+    let mut t = common_type::OBJECT;
     t.details.object = SHTypeInfo_Details_Object {
       vendorId: FRAG_CC,
-      typeId: fourCharacterCode(*b"phyR"),
+      typeId: four_character_code(*b"phyR"),
     };
     t
   };
   static ref RIGIDBODY_TYPE_VEC: Vec<Type> = vec![*RIGIDBODY_TYPE];
   static ref RIGIDBODIES_TYPE: Type = Type::seq(&RIGIDBODY_TYPE_VEC);
   static ref RIGIDBODY_VAR_TYPE: Type = Type::context_variable(&RIGIDBODY_TYPE_VEC);
-  static ref RIGIDBODIES_TYPES_SLICE: Vec<Type> = vec![*RIGIDBODY_VAR_TYPE, common_type::none];
+  static ref RIGIDBODIES_TYPES_SLICE: Vec<Type> = vec![*RIGIDBODY_VAR_TYPE, common_type::NONE];
   static ref SHAPES_TYPES_SLICE: Vec<Type> =
-    vec![*SHAPE_VAR_TYPE, *SHAPES_VAR_TYPE, common_type::none];
+    vec![*SHAPE_VAR_TYPE, *SHAPES_VAR_TYPE, common_type::NONE];
 }
 
 static POSITIONS_TYPES_SLICE: &[Type] = &[
-  common_type::float3,
-  common_type::float3_var,
-  common_type::float3s,
-  common_type::float3s_var,
+  common_type::FLOAT3,
+  common_type::FLOAT3_VAR,
+  common_type::FLOAT3S,
+  common_type::FLOAT3S_VAR,
 ];
 static ROTATIONS_TYPES_SLICE: &[Type] = &[
-  common_type::float4,
-  common_type::float4_var,
-  common_type::float4s,
-  common_type::float4s_var,
+  common_type::FLOAT4,
+  common_type::FLOAT4_VAR,
+  common_type::FLOAT4S,
+  common_type::FLOAT4S_VAR,
 ];
-static POSITION_TYPES_SLICE: &[Type] = &[common_type::float3, common_type::float3_var];
-static ROTATION_TYPES_SLICE: &[Type] = &[common_type::float4, common_type::float4_var];
+static POSITION_TYPES_SLICE: &[Type] = &[common_type::FLOAT3, common_type::FLOAT3_VAR];
+static ROTATION_TYPES_SLICE: &[Type] = &[common_type::FLOAT4, common_type::FLOAT4_VAR];
 
 struct Simulation {
   pipeline: PhysicsPipeline,

--- a/rust/src/shards/physics/queries.rs
+++ b/rust/src/shards/physics/queries.rs
@@ -10,27 +10,27 @@ use crate::shards::physics::SIMULATION_TYPE;
 use crate::shardsc::SHPointer;
 use crate::types::common_type;
 use crate::types::Context;
-use crate::types::ExposedInfo;
+
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
-use crate::types::Parameters;
+
 use crate::types::Seq;
 use crate::types::Type;
-use crate::types::ANY_TYPES;
+
 use crate::Shard;
 use crate::Types;
 use crate::Var;
-use rapier3d::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
+
 use rapier3d::geometry::{
-  BroadPhase, ColliderSet, ContactEvent, InteractionGroups, IntersectionEvent, NarrowPhase, Ray,
+  InteractionGroups, Ray,
 };
 use rapier3d::na::{Point3, Vector3};
-use rapier3d::pipeline::{ChannelEventCollector, PhysicsPipeline, QueryPipeline};
+
 use std::convert::TryInto;
 
 lazy_static! {
   pub static ref RAY_INPUT_TYPE: Type = {
-    let mut t = common_type::float3s;
+    let mut t = common_type::FLOAT3S;
     t.fixedSize = 2;
     t
   };
@@ -120,6 +120,6 @@ impl Shard for CastRay {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<CastRay>();
 }

--- a/rust/src/shards/physics/rigidbody.rs
+++ b/rust/src/shards/physics/rigidbody.rs
@@ -4,7 +4,7 @@
 use crate::core::deriveType;
 use crate::core::registerShard;
 use crate::shards::physics::fill_seq_from_mat4;
-use crate::shards::physics::mat4_from_seq;
+
 use crate::shards::physics::BaseShape;
 use crate::shards::physics::RigidBody;
 use crate::shards::physics::Simulation;
@@ -12,14 +12,14 @@ use crate::shards::physics::EXPOSED_SIMULATION;
 use crate::shards::physics::POSITIONS_TYPES_SLICE;
 use crate::shards::physics::RIGIDBODY_TYPE;
 use crate::shards::physics::ROTATIONS_TYPES_SLICE;
-use crate::shards::physics::SHAPES_TYPE;
+
 use crate::shards::physics::SHAPES_TYPES_SLICE;
-use crate::shards::physics::SHAPES_VAR_TYPE;
+
 use crate::shards::physics::SHAPE_TYPE;
-use crate::shards::physics::SHAPE_VAR_TYPE;
+
 use crate::shards::physics::SIMULATION_TYPE;
 use crate::types::common_type;
-use crate::types::ClonedVar;
+
 use crate::types::Context;
 use crate::types::ExposedInfo;
 use crate::types::ExposedTypes;
@@ -30,11 +30,11 @@ use crate::types::Parameters;
 use crate::types::Seq;
 use crate::types::Type;
 use crate::types::ANY_TYPES;
-use crate::types::FLOAT4X2_TYPE;
-use crate::types::FLOAT4X2_TYPES;
+
+
 use crate::types::FLOAT4X4S_TYPE;
 use crate::types::FLOAT4X4_TYPE;
-use crate::types::FLOAT4X4_TYPES;
+
 use crate::types::NONE_TYPES;
 use crate::types::STRING_OR_NONE_SLICE;
 use crate::Shard;
@@ -42,23 +42,22 @@ use crate::Types;
 use crate::Var;
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::dynamics::{
-  IntegrationParameters, JointSet, RigidBodyHandle, RigidBodySet, RigidBodyType,
+  RigidBodyHandle, RigidBodyType,
 };
 use rapier3d::geometry::{
-  BroadPhase, ColliderBuilder, ColliderHandle, ColliderSet, ContactEvent, IntersectionEvent,
-  NarrowPhase, SharedShape,
+  ColliderBuilder, ColliderHandle,
 };
-use rapier3d::math::Real;
+
 use rapier3d::na::Isometry3;
-use rapier3d::na::Projective3;
-use rapier3d::na::Rotation3;
-use rapier3d::na::Transform3;
+
+
+
 use rapier3d::na::{
-  Matrix, Matrix3, Matrix4, Quaternion, Similarity, Similarity3, Translation, UnitQuaternion,
-  Vector3, U3,
+  Matrix4, Quaternion, Translation, UnitQuaternion,
+  Vector3,
 };
-use rapier3d::pipeline::{ChannelEventCollector, PhysicsPipeline};
-use rapier3d::prelude::Collider;
+
+
 use std::convert::TryInto;
 use std::rc::Rc;
 
@@ -132,9 +131,9 @@ impl RigidBody {
     // we need to derive the position parameter type, because if it's a sequence we should create multiple RigidBodies
     // TODO we should also use input type to determine the output if dynamic
     let pvt = deriveType(&self.position.get_param(), data);
-    if pvt.0 == common_type::float3 {
+    if pvt.0 == common_type::FLOAT3 {
       Ok(*FLOAT4X4_TYPE)
-    } else if pvt.0 == common_type::float3s {
+    } else if pvt.0 == common_type::FLOAT3S {
       Ok(*FLOAT4X4S_TYPE)
     } else {
       Err("Physics.RigidBody: Invalid position or rotation parameter type, if one is a sequence the other must also be a sequence")
@@ -796,7 +795,7 @@ impl Shard for KinematicRigidBody {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<DynamicRigidBody>();
   registerShard::<StaticRigidBody>();
   registerShard::<KinematicRigidBody>();

--- a/rust/src/shards/physics/shapes.rs
+++ b/rust/src/shards/physics/shapes.rs
@@ -5,32 +5,32 @@
 
 use crate::core::registerShard;
 use crate::shards::physics::BaseShape;
-use crate::shards::physics::Simulation;
-use crate::shards::physics::EXPOSED_SIMULATION;
+
+
 use crate::shards::physics::POSITION_TYPES_SLICE;
 use crate::shards::physics::ROTATION_TYPES_SLICE;
 use crate::shards::physics::SHAPE_TYPE;
 use crate::shards::physics::SHAPE_TYPES;
-use crate::shards::physics::SIMULATION_TYPE;
-use crate::types::common_type;
+
+
 use crate::types::Context;
-use crate::types::ExposedInfo;
-use crate::types::ExposedTypes;
+
+
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Type;
-use crate::types::ANY_TYPES;
+
+
 use crate::types::FLOAT3_TYPES_SLICE;
 use crate::types::FLOAT_TYPES_SLICE;
 use crate::types::NONE_TYPES;
 use crate::Shard;
 use crate::Types;
 use crate::Var;
-use rapier3d::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
+
 use rapier3d::geometry::SharedShape;
-use rapier3d::geometry::{BroadPhase, ColliderSet, ContactEvent, IntersectionEvent, NarrowPhase};
+
 use rapier3d::na::{Isometry3, Quaternion, Translation, UnitQuaternion, Vector3};
-use rapier3d::pipeline::{ChannelEventCollector, PhysicsPipeline};
+
 use std::convert::TryInto;
 
 lazy_static! {
@@ -288,7 +288,7 @@ shape!(
   "Physics.Cuboid-rust-0x20200101"
 );
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<BallShape>();
   registerShard::<CubeShape>();
 }

--- a/rust/src/shards/physics/simulation.rs
+++ b/rust/src/shards/physics/simulation.rs
@@ -5,22 +5,22 @@ use crate::core::registerShard;
 use crate::shards::physics::Simulation;
 use crate::shards::physics::EXPOSED_SIMULATION;
 use crate::shards::physics::SIMULATION_TYPE;
-use crate::types::common_type;
+
 use crate::types::Context;
-use crate::types::ExposedInfo;
+
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::Type;
+
 use crate::types::ANY_TYPES;
 use crate::types::FLOAT_TYPES_SLICE;
 use crate::Shard;
 use crate::Types;
 use crate::Var;
 use rapier3d::dynamics::{CCDSolver, IntegrationParameters, JointSet, RigidBodySet};
-use rapier3d::geometry::{BroadPhase, ColliderSet, ContactEvent, IntersectionEvent, NarrowPhase};
+use rapier3d::geometry::{BroadPhase, ColliderSet, NarrowPhase};
 use rapier3d::na::Vector3;
-use rapier3d::pipeline::{ChannelEventCollector, PhysicsHooks, PhysicsPipeline, QueryPipeline};
+use rapier3d::pipeline::{ChannelEventCollector, PhysicsPipeline, QueryPipeline};
 use rapier3d::prelude::IslandManager;
 use std::convert::TryInto;
 
@@ -142,6 +142,6 @@ impl Shard for Simulation {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<Simulation>();
 }

--- a/rust/src/shards/substrate.rs
+++ b/rust/src/shards/substrate.rs
@@ -1,48 +1,48 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
-use crate::fourCharacterCode;
+use crate::four_character_code;
 use crate::shard::Shard;
 use crate::shardsc::SHTypeInfo_Details_Object;
 use crate::shardsc::SHType_Bool;
 use crate::shardsc::SHType_Bytes;
 use crate::shardsc::SHType_Int;
 use crate::shardsc::SHType_None;
-use crate::shardsc::SHType_Seq;
+
 use crate::shardsc::SHType_String;
 use crate::types::common_type;
 use crate::types::ClonedVar;
 use crate::types::Context;
-use crate::types::InstanceData;
+
 use crate::types::OptionalString;
-use crate::types::ParamVar;
+
 use crate::types::Parameters;
 use crate::types::Seq;
-use crate::types::Table;
+
 use crate::types::Type;
 use crate::types::ANYS_TYPES;
 use crate::types::BOOL_TYPES_SLICE;
 use crate::types::BYTES_TYPES;
-use crate::types::ENUMS_TYPE;
+
 use crate::types::ENUMS_TYPES;
 use crate::types::FRAG_CC;
 use crate::types::INT_TYPES_SLICE;
 use crate::types::STRINGS_TYPES;
 use crate::types::STRING_OR_NONE_SLICE;
 use crate::types::STRING_TYPES;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
-use core::time::Duration;
-use parity_scale_codec::{Compact, Decode, Encode, HasCompact};
+
+use parity_scale_codec::{Compact, Decode, Encode};
 use sp_core::crypto::{AccountId32, Pair, Ss58Codec};
-use sp_core::storage::StorageKey;
-use sp_core::{blake2_128, ecdsa, ed25519, sr25519, twox_128};
-use std::convert::{TryFrom, TryInto};
-use std::ffi::CStr;
-use std::rc::Rc;
+
+use sp_core::{blake2_128, ecdsa, sr25519, twox_128};
+use std::convert::{TryInto};
+
+
 use std::str::FromStr;
 
 lazy_static! {
@@ -91,10 +91,10 @@ lazy_static! {
   )
     .into()];
   static ref METADATA_TYPE: Type = {
-    let mut t = common_type::object;
+    let mut t = common_type::OBJECT;
     t.details.object = SHTypeInfo_Details_Object {
       vendorId: FRAG_CC,
-      typeId: fourCharacterCode(*b"subM"),
+      typeId: four_character_code(*b"subM"),
     };
     t
   };
@@ -750,7 +750,7 @@ impl Shard for SHDecode {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<AccountId>();
   registerShard::<SHStorageKey>();
   registerShard::<SHStorageMap>();

--- a/rust/src/shards/svg.rs
+++ b/rust/src/shards/svg.rs
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use crate::core::log;
+
 use crate::core::registerShard;
 use crate::shard::Shard;
 use crate::shardsc::SHImage;
@@ -10,19 +10,19 @@ use crate::shardsc::SHVarPayload__bindgen_ty_1;
 use crate::shardsc::SHIMAGE_FLAGS_PREMULTIPLIED_ALPHA;
 use crate::shardsc::{SHType_Bytes, SHType_Image, SHType_String};
 use crate::types::common_type;
-use crate::types::ClonedVar;
+
 use crate::types::Context;
-use crate::types::ParamVar;
+
 use crate::types::Parameters;
-use crate::types::Seq;
-use crate::types::Table;
+
+
 use crate::types::Type;
 use crate::types::IMAGE_TYPES;
 use crate::types::INT2_TYPES_SLICE;
-use crate::CString;
-use crate::Types;
+
+
 use crate::Var;
-use core::ptr::null_mut;
+
 use std::convert::TryInto;
 use tiny_skia::Pixmap;
 use usvg::ScreenSize;
@@ -48,7 +48,7 @@ impl From<&mut Pixmap> for Var {
 }
 
 lazy_static! {
-  static ref INPUT_TYPES: Vec<Type> = vec![common_type::string, common_type::bytes];
+  static ref INPUT_TYPES: Vec<Type> = vec![common_type::STRING, common_type::BYTES];
   static ref PARAMETERS: Parameters = vec![(
     cstr!("Size"),
     shccstr!(
@@ -161,6 +161,6 @@ impl Shard for ToImage {
   }
 }
 
-pub fn registerShards() {
+pub fn register_shards() {
   registerShard::<ToImage>();
 }

--- a/rust/src/shardsc.rs
+++ b/rust/src/shardsc.rs
@@ -1,1 +1,5 @@
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
 include!(concat!(env!("OUT_DIR"), "/shardsc.rs"));

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -4,12 +4,12 @@
 use crate::core::cloneVar;
 use crate::core::destroyVar;
 use crate::core::Core;
-use crate::fourCharacterCode;
+use crate::four_character_code;
 use crate::shardsc::SHBool;
 use crate::shardsc::SHColor;
 use crate::shardsc::SHComposeResult;
 use crate::shardsc::SHContext;
-use crate::shardsc::SHEnumInfo;
+
 use crate::shardsc::SHExposedTypeInfo;
 use crate::shardsc::SHExposedTypesInfo;
 use crate::shardsc::SHImage;
@@ -29,8 +29,8 @@ use crate::shardsc::SHTypeInfo_Details;
 use crate::shardsc::SHTypeInfo_Details_Enum;
 use crate::shardsc::SHTypeInfo_Details_Object;
 use crate::shardsc::SHTypeInfo_Details_Table;
-use crate::shardsc::SHType_Any;
-use crate::shardsc::SHType_Array;
+
+
 use crate::shardsc::SHType_Bool;
 use crate::shardsc::SHType_Bytes;
 use crate::shardsc::SHType_Color;
@@ -42,16 +42,16 @@ use crate::shardsc::SHType_Float3;
 use crate::shardsc::SHType_Float4;
 use crate::shardsc::SHType_Image;
 use crate::shardsc::SHType_Int;
-use crate::shardsc::SHType_Int16;
+
 use crate::shardsc::SHType_Int2;
 use crate::shardsc::SHType_Int3;
 use crate::shardsc::SHType_Int4;
-use crate::shardsc::SHType_Int8;
+
 use crate::shardsc::SHType_None;
 use crate::shardsc::SHType_Object;
 use crate::shardsc::SHType_Path;
 use crate::shardsc::SHType_Seq;
-use crate::shardsc::SHType_Set;
+
 use crate::shardsc::SHType_ShardRef;
 use crate::shardsc::SHType_String;
 use crate::shardsc::SHType_Table;
@@ -63,7 +63,7 @@ use crate::shardsc::SHVarPayload__bindgen_ty_1;
 use crate::shardsc::SHVarPayload__bindgen_ty_1__bindgen_ty_1;
 use crate::shardsc::SHVarPayload__bindgen_ty_1__bindgen_ty_2;
 use crate::shardsc::SHVarPayload__bindgen_ty_1__bindgen_ty_4;
-use crate::shardsc::SHWire;
+
 use crate::shardsc::SHWireRef;
 use crate::shardsc::SHWireState;
 use crate::shardsc::SHWireState_Continue;
@@ -74,8 +74,8 @@ use crate::shardsc::SHWireState_Stop;
 use crate::shardsc::Shard;
 use crate::shardsc::ShardPtr;
 use crate::shardsc::Shards;
-use crate::shardsc::SHIMAGE_FLAGS_16BITS_INT;
-use crate::shardsc::SHIMAGE_FLAGS_32BITS_FLOAT;
+
+
 use crate::shardsc::SHVAR_FLAGS_REF_COUNTED;
 use crate::SHWireState_Error;
 use crate::SHVAR_FLAGS_EXTERNAL;
@@ -84,13 +84,13 @@ use core::convert::TryInto;
 use core::mem::transmute;
 use core::ops::Index;
 use core::ops::IndexMut;
-use core::slice;
+
 use serde::ser::{SerializeMap, SerializeSeq};
-use serde::{Deserialize, Serialize};
+use serde::{Serialize};
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::i32::MAX;
+
 use std::rc::Rc;
 
 #[macro_export]
@@ -582,7 +582,7 @@ pub mod common_type {
     }
   }
 
-  pub static none: SHTypeInfo = base_info();
+  pub static NONE: SHTypeInfo = base_info();
 
   macro_rules! shtype {
     ($fname:ident, $type:expr, $name:ident, $names:ident, $name_var:ident, $names_var:ident, $name_table:ident, $name_table_var:ident) => {
@@ -676,192 +676,192 @@ pub mod common_type {
   shtype!(
     make_any,
     SHType_Any,
-    any,
-    anys,
-    any_var,
-    anys_var,
-    any_table,
-    any_table_var
+    ANY,
+    ANYS,
+    ANY_VAR,
+    ANYS_VAR,
+    ANY_TABLE,
+    ANY_TABLE_VAR
   );
   shtype!(
     make_object,
     SHType_Object,
-    object,
-    objects,
-    object_var,
-    objects_var,
-    object_table,
-    object_table_var
+    OBJECT,
+    OBJECTS,
+    OBJECT_VAR,
+    OBJECTS_VAR,
+    OBJECT_TABLE,
+    OBJECT_TABLE_VAR
   );
   shtype!(
     make_enum,
     SHType_Enum,
-    enumeration,
-    enums,
-    enum_var,
-    enums_var,
-    enum_table,
-    enum_table_var
+    ENUMERATION,
+    ENUMS,
+    ENUM_VAR,
+    ENUMS_VAR,
+    ENUM_TABLE,
+    ENUM_TABLE_VAR
   );
   shtype!(
     make_string,
     SHType_String,
-    string,
-    strings,
-    string_var,
-    strings_var,
-    string_table,
-    string_table_var
+    STRING,
+    STRINGS,
+    STRING_VAR,
+    STRINGS_VAR,
+    STRING_TABLE,
+    STRING_TABLE_VAR
   );
   shtype!(
     make_bytes,
     SHType_Bytes,
-    bytes,
-    bytezs,
-    bytes_var,
-    bytess_var,
-    bytes_table,
-    bytes_table_var
+    BYTES,
+    BYTEZS,
+    BYTES_VAR,
+    BYTESS_VAR,
+    BYTES_TABLE,
+    BYTES_TABLE_VAR
   );
   shtype!(
     make_image,
     SHType_Image,
-    image,
-    images,
-    image_var,
-    images_var,
-    image_table,
-    images_table_var
+    IMAGE,
+    IMAGES,
+    IMAGE_VAR,
+    IMAGES_VAR,
+    IMAGE_TABLE,
+    IMAGES_TABLE_VAR
   );
   shtype!(
     make_int,
     SHType_Int,
-    int,
-    ints,
-    int_var,
-    ints_var,
-    int_table,
-    int_table_var
+    INT,
+    INTS,
+    INT_VAR,
+    INTS_VAR,
+    INT_TABLE,
+    INT_TABLE_VAR
   );
   shtype!(
     make_int2,
     SHType_Int2,
-    int2,
-    int2s,
-    int2_var,
-    int2s_var,
-    int2_table,
-    int2_table_var
+    INT2,
+    INT2S,
+    INT2_VAR,
+    INT2S_VAR,
+    INT2_TABLE,
+    INT2_TABLE_VAR
   );
   shtype!(
     make_int3,
     SHType_Int3,
-    int3,
-    int3s,
-    int3_var,
-    int3s_var,
-    int3_table,
-    int3_table_var
+    INT3,
+    INT3S,
+    INT3_VAR,
+    INT3S_VAR,
+    INT3_TABLE,
+    INT3_TABLE_VAR
   );
   shtype!(
     make_int4,
     SHType_Int4,
-    int4,
-    int4s,
-    int4_var,
-    int4s_var,
-    int4_table,
-    int4_table_var
+    INT4,
+    INT4S,
+    INT4_VAR,
+    INT4S_VAR,
+    INT4_TABLE,
+    INT4_TABLE_VAR
   );
   shtype!(
     make_float,
     SHType_Float,
-    float,
-    floats,
-    float_var,
-    floats_var,
-    float_table,
-    float_table_var
+    FLOAT,
+    FLOATS,
+    FLOAT_VAR,
+    FLOATS_VAR,
+    FLOAT_TABLE,
+    FLOAT_TABLE_VAR
   );
   shtype!(
     make_float2,
     SHType_Float2,
-    float2,
-    float2s,
-    float2_var,
-    float2s_var,
-    float2_table,
-    float2_table_var
+    FLOAT2,
+    FLOAT2S,
+    FLOAT2_VAR,
+    FLOAT2S_VAR,
+    FLOAT2_TABLE,
+    FLOAT2_TABLE_VAR
   );
   shtype!(
     make_float3,
     SHType_Float3,
-    float3,
-    float3s,
-    float3_var,
-    float3s_var,
-    float3_table,
-    float3_table_var
+    FLOAT3,
+    FLOAT3S,
+    FLOAT3_VAR,
+    FLOAT3S_VAR,
+    FLOAT3_TABLE,
+    FLOAT3_TABLE_VAR
   );
   shtype!(
     make_float4,
     SHType_Float4,
-    float4,
-    float4s,
-    float4_var,
-    float4s_var,
-    float4_table,
-    float4_table_var
+    FLOAT4,
+    FLOAT4S,
+    FLOAT4_VAR,
+    FLOAT4S_VAR,
+    FLOAT4_TABLE,
+    FLOAT4_TABLE_VAR
   );
   shtype!(
     make_color,
     SHType_Color,
-    color,
-    colors,
-    color_var,
-    colors_var,
-    color_table,
-    color_table_var
+    COLOR,
+    COLORS,
+    COLOR_VAR,
+    COLORS_VAR,
+    COLOR_TABLE,
+    COLOR_TABLE_VAR
   );
   shtype!(
     make_bool,
     SHType_Bool,
-    bool,
-    bools,
-    bool_var,
-    bools_var,
-    bool_table,
-    bool_table_var
+    BOOL,
+    BOOLS,
+    BOOL_VAR,
+    BOOLS_VAR,
+    BOOL_TABLE,
+    BOOL_TABLE_VAR
   );
   shtype!(
     make_shard,
     SHType_ShardRef,
-    shard,
-    shards,
-    shard_var,
-    shards_var,
-    shard_table,
-    shard_table_var
+    SHARD,
+    SHARDS,
+    SHARD_VAR,
+    SHARDS_VAR,
+    SHARD_TABLE,
+    SHARD_TABLE_VAR
   );
   shtype!(
     make_wire,
     SHType_Wire,
-    wire,
-    wires,
-    wire_var,
-    wires_var,
-    wire_table,
-    wire_table_var
+    WIRE,
+    WIRES,
+    WIRE_VAR,
+    WIRES_VAR,
+    WIRE_TABLE,
+    WIRE_TABLE_VAR
   );
   shtype!(
     make_path,
     SHType_Path,
-    path,
-    paths,
-    path_var,
-    paths_var,
-    path_table,
-    path_table_var
+    PATH,
+    PATHS,
+    PATH_VAR,
+    PATHS_VAR,
+    PATH_TABLE,
+    PATH_TABLE_VAR
   );
 }
 
@@ -3950,18 +3950,6 @@ impl Drop for Table {
   }
 }
 
-unsafe extern "C" fn table_foreach_callback(
-  key: *const ::std::os::raw::c_char,
-  value: *mut SHVar,
-  userData: *mut ::std::os::raw::c_void,
-) -> SHBool {
-  let ptrs = userData as *mut (&mut Vec<&str>, &mut Vec<Var>);
-  let cstr = CStr::from_ptr(key);
-  (*ptrs).0.push(cstr.to_str().unwrap());
-  (*ptrs).1.push(*value);
-  true // false aborts iteration
-}
-
 impl Default for Table {
   fn default() -> Self {
     Self::new()
@@ -4164,39 +4152,39 @@ impl PartialEq for Type {
   }
 }
 
-pub const FRAG_CC: i32 = fourCharacterCode(*b"frag");
+pub const FRAG_CC: i32 = four_character_code(*b"frag");
 
-pub static INT_TYPES_SLICE: &[Type] = &[common_type::int];
-pub static INT_OR_NONE_TYPES_SLICE: &[Type] = &[common_type::int, common_type::none];
-pub static INT2_TYPES_SLICE: &[Type] = &[common_type::int2];
-pub static FLOAT_TYPES_SLICE: &[Type] = &[common_type::float];
-pub static FLOAT_OR_NONE_TYPES_SLICE: &[Type] = &[common_type::float, common_type::none];
-pub static FLOAT2_TYPES_SLICE: &[Type] = &[common_type::float2];
-pub static FLOAT3_TYPES_SLICE: &[Type] = &[common_type::float3];
-pub static BOOL_TYPES_SLICE: &[Type] = &[common_type::bool];
-pub static STRING_TYPES_SLICE: &[Type] = &[common_type::string];
-pub static STRING_OR_NONE_SLICE: &[Type] = &[common_type::string, common_type::none];
+pub static INT_TYPES_SLICE: &[Type] = &[common_type::INT];
+pub static INT_OR_NONE_TYPES_SLICE: &[Type] = &[common_type::INT, common_type::NONE];
+pub static INT2_TYPES_SLICE: &[Type] = &[common_type::INT2];
+pub static FLOAT_TYPES_SLICE: &[Type] = &[common_type::FLOAT];
+pub static FLOAT_OR_NONE_TYPES_SLICE: &[Type] = &[common_type::FLOAT, common_type::NONE];
+pub static FLOAT2_TYPES_SLICE: &[Type] = &[common_type::FLOAT2];
+pub static FLOAT3_TYPES_SLICE: &[Type] = &[common_type::FLOAT3];
+pub static BOOL_TYPES_SLICE: &[Type] = &[common_type::BOOL];
+pub static STRING_TYPES_SLICE: &[Type] = &[common_type::STRING];
+pub static STRING_OR_NONE_SLICE: &[Type] = &[common_type::STRING, common_type::NONE];
 pub static STRING_VAR_OR_NONE_SLICE: &[Type] = &[
-  common_type::string,
-  common_type::string_var,
-  common_type::none,
+  common_type::STRING,
+  common_type::STRING_VAR,
+  common_type::NONE,
 ];
 
 // TODO share those from C++ ones to reduce binary size
 lazy_static! {
-  pub static ref ANY_TYPES: Vec<Type> = vec![common_type::any];
-  pub static ref ANYS_TYPES: Vec<Type> = vec![common_type::anys];
-  pub static ref NONE_TYPES: Vec<Type> = vec![common_type::none];
-  pub static ref STRING_TYPES: Vec<Type> = vec![common_type::string];
-  pub static ref STRINGS_TYPES: Vec<Type> = vec![common_type::strings];
+  pub static ref ANY_TYPES: Vec<Type> = vec![common_type::ANY];
+  pub static ref ANYS_TYPES: Vec<Type> = vec![common_type::ANYS];
+  pub static ref NONE_TYPES: Vec<Type> = vec![common_type::NONE];
+  pub static ref STRING_TYPES: Vec<Type> = vec![common_type::STRING];
+  pub static ref STRINGS_TYPES: Vec<Type> = vec![common_type::STRINGS];
   pub static ref SEQ_OF_STRINGS: Type = Type::seq(&STRINGS_TYPES);
   pub static ref SEQ_OF_STRINGS_TYPES: Vec<Type> = vec![*SEQ_OF_STRINGS];
-  pub static ref COLOR_TYPES: Vec<Type> = vec![common_type::color];
-  pub static ref INT_TYPES: Vec<Type> = vec![common_type::int];
-  pub static ref INT2_TYPES: Vec<Type> = vec![common_type::int2];
-  pub static ref INT3_TYPES: Vec<Type> = vec![common_type::int3];
-  pub static ref INT4_TYPES: Vec<Type> = vec![common_type::int4];
-  pub static ref FLOAT_TYPES: Vec<Type> = vec![common_type::float];
+  pub static ref COLOR_TYPES: Vec<Type> = vec![common_type::COLOR];
+  pub static ref INT_TYPES: Vec<Type> = vec![common_type::INT];
+  pub static ref INT2_TYPES: Vec<Type> = vec![common_type::INT2];
+  pub static ref INT3_TYPES: Vec<Type> = vec![common_type::INT3];
+  pub static ref INT4_TYPES: Vec<Type> = vec![common_type::INT4];
+  pub static ref FLOAT_TYPES: Vec<Type> = vec![common_type::FLOAT];
   pub static ref SEQ_OF_INT: Type = Type::seq(&INT_TYPES);
   pub static ref SEQ_OF_INT_TYPES: Vec<Type> = vec![*SEQ_OF_INT];
   pub static ref SEQ_OF_SEQ_OF_INT: Type = Type::seq(&SEQ_OF_INT_TYPES);
@@ -4205,13 +4193,13 @@ lazy_static! {
   pub static ref SEQ_OF_FLOAT_TYPES: Vec<Type> = vec![*SEQ_OF_FLOAT];
   pub static ref SEQ_OF_SEQ_OF_FLOAT: Type = Type::seq(&SEQ_OF_FLOAT_TYPES);
   pub static ref SEQ_OF_SEQ_OF_FLOAT_TYPES: Vec<Type> = vec![*SEQ_OF_SEQ_OF_FLOAT];
-  pub static ref FLOAT2_TYPES: Vec<Type> = vec![common_type::float2];
-  pub static ref FLOAT3_TYPES: Vec<Type> = vec![common_type::float3];
-  pub static ref FLOAT4_TYPES: Vec<Type> = vec![common_type::float4];
-  pub static ref BOOL_TYPES: Vec<Type> = vec![common_type::bool];
-  pub static ref BYTES_TYPES: Vec<Type> = vec![common_type::bytes];
+  pub static ref FLOAT2_TYPES: Vec<Type> = vec![common_type::FLOAT2];
+  pub static ref FLOAT3_TYPES: Vec<Type> = vec![common_type::FLOAT3];
+  pub static ref FLOAT4_TYPES: Vec<Type> = vec![common_type::FLOAT4];
+  pub static ref BOOL_TYPES: Vec<Type> = vec![common_type::BOOL];
+  pub static ref BYTES_TYPES: Vec<Type> = vec![common_type::BYTES];
   pub static ref FLOAT4X4_TYPE: Type = {
-    let mut t = common_type::float4s;
+    let mut t = common_type::FLOAT4S;
     t.fixedSize = 4;
     t
   };
@@ -4219,37 +4207,38 @@ lazy_static! {
   pub static ref FLOAT4X4S_TYPE: Type = Type::seq(&FLOAT4X4_TYPES);
   pub static ref FLOAT4X4orS_TYPES: Vec<Type> = vec![*FLOAT4X4_TYPE, *FLOAT4X4S_TYPE];
   pub static ref FLOAT3X3_TYPE: Type = {
-    let mut t = common_type::float3s;
+    let mut t = common_type::FLOAT3S;
     t.fixedSize = 3;
     t
   };
   pub static ref FLOAT3X3_TYPES: Vec<Type> = vec![*FLOAT3X3_TYPE];
   pub static ref FLOAT3X3S_TYPE: Type = Type::seq(&FLOAT3X3_TYPES);
   pub static ref FLOAT4X2_TYPE: Type = {
-    let mut t = common_type::float4s;
+    let mut t = common_type::FLOAT4S;
     t.fixedSize = 2;
     t
   };
   pub static ref FLOAT4X2_TYPES: Vec<Type> = vec![*FLOAT4X2_TYPE];
   pub static ref FLOAT4X2S_TYPE: Type = Type::seq(&FLOAT4X2_TYPES);
   pub static ref ENUM_TYPE: Type = {
-    let mut t = common_type::enumeration;
+    let mut t = common_type::ENUMERATION;
     t.details.enumeration = SHTypeInfo_Details_Enum {
       vendorId: FRAG_CC,
-      typeId: fourCharacterCode(*b"type"),
+      typeId: four_character_code(*b"type"),
     };
     t
   };
   pub static ref ENUM_TYPES: Vec<Type> = vec![*ENUM_TYPE];
   pub static ref ENUMS_TYPE: Type = Type::seq(&ENUM_TYPES);
   pub static ref ENUMS_TYPES: Vec<Type> = vec![*ENUMS_TYPE];
-  pub static ref IMAGE_TYPES: Vec<Type> = vec![common_type::image];
+  pub static ref IMAGE_TYPES: Vec<Type> = vec![common_type::IMAGE];
   pub static ref SHARDS_OR_NONE_TYPES: Vec<Type> =
-    vec![common_type::none, common_type::shard, common_type::shards];
+    vec![common_type::NONE, common_type::SHARD, common_type::SHARDS];
   pub static ref SEQ_OF_SHARDS: Type = Type::seq(&SHARDS_OR_NONE_TYPES);
   pub static ref SEQ_OF_SHARDS_TYPES: Vec<Type> = vec![*SEQ_OF_SHARDS];
 }
 
+#[cfg(test)]
 macro_rules! test_to_from_vec1 {
   ($type:ty, $value:expr, $msg:literal) => {
     let fromNum: $type = $value;
@@ -4259,6 +4248,7 @@ macro_rules! test_to_from_vec1 {
   };
 }
 
+#[cfg(test)]
 macro_rules! test_to_from_vec2 {
   ($type:ty, $value:expr, $msg:literal) => {
     let fromNum: ($type, $type) = ($value, $value);
@@ -4268,6 +4258,7 @@ macro_rules! test_to_from_vec2 {
   };
 }
 
+#[cfg(test)]
 macro_rules! test_to_from_vec3 {
   ($type:ty, $value:expr, $msg:literal) => {
     let fromNum: ($type, $type, $type) = ($value, $value, $value);
@@ -4277,6 +4268,7 @@ macro_rules! test_to_from_vec3 {
   };
 }
 
+#[cfg(test)]
 macro_rules! test_to_from_vec4 {
   ($type:ty, $value:expr, $msg:literal) => {
     let fromNum: ($type, $type, $type, $type) = ($value, $value, $value, $value);


### PR DESCRIPTION
Removes the allow attributes from the root module.

Also tries to address most of the generated warnings.
Applied `cargo fix` automatically, leaving the manual renaming for later.