### PR TITLE
Upgrade some CI actions

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -23,7 +23,7 @@ jobs:
           repository: fragcolor-xyz/shards
           fetch-depth: 1
       - name: Download shards
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: shards-win64 Release
           path: docs/samples
@@ -65,7 +65,7 @@ jobs:
           repository: fragcolor-xyz/shards
           fetch-depth: 1
       - name: Download shards
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: shards-win64 Debug
           path: ./
@@ -119,12 +119,12 @@ jobs:
           pip install mkdocs-awesome-pages-plugin
           pip install mkdocs-macros-plugin
       - name: Download markdown
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docs-markdown
           path: docs/docs/shards
       - name: Download samples logs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: samples-logs
           path: docs/samples

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -45,7 +45,7 @@ jobs:
             ./shards.exe run-sample.edn --file "$i" > >(tee "$i.log");
           done
       - name: Upload samples logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: samples-logs
           path: docs/samples/**/*.log
@@ -84,7 +84,7 @@ jobs:
           ./shards.exe src/tests/infos-docs.edn
           mv docs/docs/shards/General/UI.md docs/docs/shards/UI/index.md
       - name: Upload markdown
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs-markdown
           path: |
@@ -143,7 +143,7 @@ jobs:
 
           Using MkDocs {version}."
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs-website
           path: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -41,7 +41,7 @@ jobs:
           rustup +nightly target add aarch64-apple-ios
           rustup +nightly target add x86_64-apple-ios
           rustup default nightly
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
       - name: Build device
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -76,7 +76,7 @@ jobs:
           ./bootstrap
           rustup toolchain install nightly
           rustup default nightly
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}
@@ -127,7 +127,7 @@ jobs:
           ./bootstrap
           rustup toolchain install nightly
           rustup default nightly
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}
@@ -268,7 +268,7 @@ jobs:
           ./bootstrap
           rustup toolchain install nightly
           rustup default nightly
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -140,7 +140,7 @@ jobs:
           ninja shards
       - name: Download artifact (Release)
         if: ${{ steps.setup.outputs.build-type == 'Release' }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: shards-linux ${{ steps.setup.outputs.build-type }}
           path: build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -106,6 +106,7 @@ jobs:
         id: setup
         run: |
           echo "::set-output name=build-type::${{ github.event.inputs.build-type || inputs.build-type }}"
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
 
           if [ "${{ github.event.inputs.build-type || inputs.build-type }}" == "Debug" ]
           then
@@ -128,7 +129,7 @@ jobs:
           rustup toolchain install nightly
           rustup default nightly
       - uses: Swatinem/rust-cache@v2
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}
       - name: Build (Debug)
@@ -249,6 +250,10 @@ jobs:
     name: Extra Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Setup
+        id: setup
+        run: |
+          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
       - name: Checkout shards
         uses: actions/checkout@v3
         with:
@@ -269,9 +274,9 @@ jobs:
           rustup toolchain install nightly
           rustup default nightly
       - uses: Swatinem/rust-cache@v2
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
-          key: ${{ steps.setup.outputs.build-type }}
+          key: Debug
       - name: Build
         run: |
           cmake -Bbuild -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=1 -DSHARDS_BUILD_TESTS=1

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -87,7 +87,7 @@ jobs:
           cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ steps.setup.outputs.build-type }} ..
           ninja shards
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: shards-linux ${{ steps.setup.outputs.build-type }}
           path: build/shards
@@ -234,7 +234,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"
       - name: Upload coverage
         if: ${{ steps.setup.outputs.build-type == 'Debug' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: shards-linux-coverage
           path: coverage
@@ -298,7 +298,7 @@ jobs:
           genhtml coverage/coverage.f.info --output-directory coverage/output
           bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: shards-linux-coverage-extra
           path: coverage

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -76,7 +76,7 @@ jobs:
           ./bootstrap
           rustup toolchain install nightly
           rustup default nightly
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -95,7 +95,7 @@ jobs:
           ninja test-runtime
           ./test-runtime
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: shards-macos ${{ steps.setup.outputs.build-type }}
           path: build/shards

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -121,7 +121,7 @@ jobs:
           fetch-depth: 1
           submodules: false
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: shards-macos ${{ steps.setup.outputs.build-type }}
           path: build

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ steps.setup.outputs.run-tests == 'true' && steps.setup.outputs.threading == 'mt' }}
         run: |
           rustup +nightly component add rust-src
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.threading }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -114,7 +114,7 @@ jobs:
           cp shards-mt.js shards/
           cp shards-mt.worker.js shards/
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: shards-wasm ${{ steps.setup.outputs.threading }}
           path: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -256,7 +256,7 @@ jobs:
           fetch-depth: 1
           submodules: false
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ steps.setup.outputs.artifact }} ${{ steps.setup.outputs.build-type }}
           path: build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -143,7 +143,7 @@ jobs:
           # choco exit with code 1 after successful install
           choco install -y --force llvm || exit 0
           echo "LIBCLANG_PATH=C:\Program Files\LLVM\lib" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
         with:
           key: ${{ steps.setup.outputs.build-type }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -207,7 +207,7 @@ jobs:
           ninja test-gfx
           GFX_BACKEND=D3D12 GFX_TEST_PLATFORM_ID="github-windows" ./test-gfx
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.setup.outputs.artifact }} ${{ steps.setup.outputs.build-type }}
           path: ${{ steps.setup.outputs.artifact-path }}


### PR DESCRIPTION
**Description**

`Node 12` is deprecated and causing warnings which could soon become errors.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: Swatinem/rust-cache, actions/upload-artifact
