### PR TITLE
Mark GUI shards as deprecated

### DIFF
--- a/docs/docs/docs/shards/GUI/index.md
+++ b/docs/docs/docs/shards/GUI/index.md
@@ -1,0 +1,13 @@
+---
+authors: Fragcolor & contributors
+license: CC-BY-SA-4.0
+---
+
+
+# GUI
+
+!!! warning "Obsolete"
+    This API is obsolete and might be removed at any time. Consider using [`UI`](../UI/index.md) instead.
+
+
+--8<-- "includes/license.md"

--- a/docs/includes/deprecated.md
+++ b/docs/includes/deprecated.md
@@ -1,0 +1,3 @@
+
+!!! warning "Obsolete"
+    This API is obsolete and might be removed at any time. Consider other alternatives.

--- a/src/extra/imgui.cpp
+++ b/src/extra/imgui.cpp
@@ -12,6 +12,8 @@ namespace shards {
 namespace ImGui {
 using namespace shards;
 
+static TableVar deprecated{{"deprecated", Var(true)}};
+
 struct Base {
   SHExposedTypesInfo requiredVariables() { return SHExposedTypesInfo(gfx::Base::requiredInfo); }
 
@@ -20,6 +22,8 @@ struct Base {
 
   static SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
   static SHOptionalString outputHelp() { return SHCCSTR("The output of this shard will be its input."); }
+
+  static const SHTable *properties() { return &deprecated.payload.tableValue; }
 };
 
 struct IDContext {

--- a/src/tests/infos-docs.edn
+++ b/src/tests/infos-docs.edn
@@ -55,6 +55,11 @@
    ; title
    "# " >> .o name >> .o "\r\n\r\n" >> .o
 
+   ; deprecated warning
+   (When
+    (-> (Get .properties "deprecated" :Default false))
+    (-> "--8<-- \"includes/deprecated.md\"\r\n\r\n" >> .o))
+
    ; experimental warning
    (When
     (-> (Get .properties "experimental" :Default false))


### PR DESCRIPTION
**Description**
`ImGui`-based shards (prefixed by `GUI`) have mostly be replaced by `egui`-based one (prefixed by `UI`). Mark them as obsolete and display a warning in the API documentation.