### PR TITLE
UI plot

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -361,6 +361,8 @@ jobs:
           ./shards ../src/tests/ui.edn
           echo "Running test: egui_demo"
           ./shards ../src/tests/egui-demo.edn
+          echo "Running test: egui-plot"
+          ./shards ../src/tests/egui-plot.edn
           echo "Running test: imgui_demo"
           ./shards ../src/tests/imgui-demo.edn
       - name: Test (64bits)

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -95,6 +95,9 @@ jobs:
           echo "Running egui demo"
           build/shards src/tests/egui-demo.edn
 
+          echo "Running egui plot"
+          build/shards src/tests/egui-plot.edn
+
           echo "Running imgui demo"
           build/shards src/tests/imgui-demo.edn
 

--- a/docs/samples/shards/UI/Plot/1.edn
+++ b/docs/samples/shards/UI/Plot/1.edn
@@ -1,0 +1,20 @@
+(defloop main-wire
+  (GFX.MainWindow
+   :Contents
+   (->
+    (Setup
+     (GFX.DrawQueue) >= .ui-draw-queue
+     (GFX.UIPass .ui-draw-queue) >> .render-steps)
+    .ui-draw-queue (GFX.ClearQueue)
+
+    (UI
+     .ui-draw-queue
+     (UI.CentralPanel
+      (UI.Plot
+       (->
+        [(float2 -1) (float2 0) (float2 1)] (UI.PlotLine)))))
+
+    (GFX.Render :Steps .render-steps))))
+(defmesh root)
+(schedule root main-wire)
+(run root 0.02 100)

--- a/docs/samples/shards/UI/Plot/2.edn
+++ b/docs/samples/shards/UI/Plot/2.edn
@@ -1,0 +1,38 @@
+(defloop main-wire
+  (GFX.MainWindow
+   :Contents
+   (->
+    (Setup
+     (GFX.DrawQueue) >= .ui-draw-queue
+     (GFX.UIPass .ui-draw-queue) >> .render-steps)
+    .ui-draw-queue (GFX.ClearQueue)
+
+    (UI
+     .ui-draw-queue
+     (->
+      (UI.TopPanel
+       :Contents
+       (UI.Checkbox "Horizontal" .horizontal))
+      (UI.CentralPanel
+       (UI.Plot
+        (->
+         [] >= .hist
+         (ForRange
+          -40 39
+          (->
+           (Setup
+            0.02 (Math.Multiply 3.1415926535) (Math.Sqrt) = .f)
+           (ToFloat) (Math.Divide 10.0) (Math.Add 0.05) >= .x
+           .x (Math.Multiply .x) (Math.Divide -2.0) (Math.Exp) (Math.Divide .f) >= .y
+           [.x .y] (ToFloat2) >> .hist))
+
+         .hist (ExpectLike [(float2 0)])
+         (UI.PlotBar
+          :Horizontal .horizontal
+          :Width 0.095
+          :Color (color 173 216 230)))))))
+
+    (GFX.Render :Steps .render-steps))))
+(defmesh root)
+(schedule root main-wire)
+(run root 0.02 100)

--- a/docs/samples/shards/UI/Plot/3.edn
+++ b/docs/samples/shards/UI/Plot/3.edn
@@ -1,0 +1,33 @@
+(def N 32)
+(defloop main-wire
+  (GFX.MainWindow
+   :Contents
+   (->
+    (Setup
+     (GFX.DrawQueue) >= .ui-draw-queue
+     (GFX.UIPass .ui-draw-queue) >> .render-steps)
+    .ui-draw-queue (GFX.ClearQueue)
+
+    (UI
+     .ui-draw-queue
+     (UI.CentralPanel
+      (UI.Plot
+       :Legend true
+       :Contents
+       (->
+        [] >= .sin
+        (ForRange
+         (- N) N
+         (->
+          (ToFloat) (Math.Divide  (/ N 3.1415926535)) >= .x
+          .x (Math.Sin) >= .y
+          [.x .y] (ToFloat2) >> .sin))
+        .sin (ExpectLike [(float2 0)])
+        (UI.PlotPoints
+         :Color (color 200 100 100)
+         :Name "sin")))))
+
+    (GFX.Render :Steps .render-steps))))
+(defmesh root)
+(schedule root main-wire)
+(run root 0.02 100)

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -28,6 +28,7 @@ static COLOR_VAR_OR_NONE_SLICE: &[Type] = &[
   common_type::none,
 ];
 static FLOAT_VAR_SLICE: &[Type] = &[common_type::float, common_type::float_var];
+static FLOAT_VAR_OR_NONE_SLICE: &[Type] = &[common_type::float, common_type::float_var, common_type::none];
 static FLOAT2_VAR_SLICE: &[Type] = &[common_type::float2, common_type::float2_var];
 static INT_VAR_OR_NONE_SLICE: &[Type] =
   &[common_type::int, common_type::int_var, common_type::none];

--- a/rust/src/shards/gui/widgets/mod.rs
+++ b/rust/src/shards/gui/widgets/mod.rs
@@ -174,6 +174,7 @@ macro_rules! decl_ui_input {
       parents: ParamVar,
       requiring: ExposedTypes,
       variable: ParamVar,
+      prefix: ParamVar,
       exposing: ExposedTypes,
       should_expose: bool,
       tmp: $tmp_type,
@@ -231,6 +232,7 @@ mod link;
 mod listbox;
 mod numeric_input;
 mod numeric_slider;
+mod plots;
 mod progress_bar;
 mod radio_button;
 mod spinner;
@@ -266,6 +268,7 @@ pub fn registerShards() {
   registerShard::<Int2Slider>();
   registerShard::<Int3Slider>();
   registerShard::<Int4Slider>();
+  plots::registerShards();
   registerShard::<ProgressBar>();
   registerShard::<RadioButton>();
   registerShard::<Spinner>();

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2022 Fragcolor Pte. Ltd. */
+
+use crate::core::registerShard;
+use crate::fourCharacterCode;
+use crate::types::ExposedTypes;
+use crate::types::FRAG_CC;
+use crate::types::ParamVar;
+use crate::types::ShardsVar;
+use crate::types::Type;
+
+static EGUI_PLOT_UI_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"egPC"));
+
+const PLOT_UI_NAME: &'static str = "UI.PlotUI";
+
+struct Plot {
+  parents: ParamVar,
+  requiring: ExposedTypes,
+  contents: ShardsVar,
+  view_aspect: ParamVar,
+  data_aspect: ParamVar,
+  legend: ParamVar,
+  plot_context: ParamVar,
+  exposing: ExposedTypes,
+}
+
+mod plot;
+
+pub fn registerShards() {
+  registerShard::<Plot>();
+}

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -4,12 +4,18 @@
 use crate::core::registerShard;
 use crate::fourCharacterCode;
 use crate::types::ExposedTypes;
+use crate::types::FLOAT2_TYPES;
 use crate::types::FRAG_CC;
 use crate::types::ParamVar;
 use crate::types::ShardsVar;
 use crate::types::Type;
 
 static EGUI_PLOT_UI_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"egPC"));
+
+lazy_static!{  
+  pub static ref SEQ_OF_FLOAT2: Type = Type::seq(&FLOAT2_TYPES);
+  pub static ref SEQ_OF_FLOAT2_TYPES: Vec<Type> = vec![*SEQ_OF_FLOAT2];
+}
 
 const PLOT_UI_NAME: &'static str = "UI.PlotUI";
 
@@ -24,8 +30,17 @@ struct Plot {
   exposing: ExposedTypes,
 }
 
+struct PlotLine {
+  plot_ui: ParamVar,
+  requiring: ExposedTypes,
+  color: ParamVar,
+  name: ParamVar,
+}
+
 mod plot;
+mod plot_line;
 
 pub fn registerShards() {
   registerShard::<Plot>();
+  registerShard::<PlotLine>();
 }

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -30,6 +30,15 @@ struct Plot {
   exposing: ExposedTypes,
 }
 
+struct PlotBar {
+  plot_ui: ParamVar,
+  requiring: ExposedTypes,
+  color: ParamVar,
+  bar_width: ParamVar,
+  horizontal: ParamVar,
+  name: ParamVar,
+}
+
 struct PlotLine {
   plot_ui: ParamVar,
   requiring: ExposedTypes,
@@ -38,9 +47,11 @@ struct PlotLine {
 }
 
 mod plot;
+mod plot_bar;
 mod plot_line;
 
 pub fn registerShards() {
   registerShard::<Plot>();
+  registerShard::<PlotBar>();
   registerShard::<PlotLine>();
 }

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -46,12 +46,21 @@ struct PlotLine {
   name: ParamVar,
 }
 
+struct PlotPoints {
+  plot_ui: ParamVar,
+  requiring: ExposedTypes,
+  color: ParamVar,
+  name: ParamVar,
+}
+
 mod plot;
 mod plot_bar;
 mod plot_line;
+mod plot_points;
 
 pub fn registerShards() {
   registerShard::<Plot>();
   registerShard::<PlotBar>();
   registerShard::<PlotLine>();
+  registerShard::<PlotPoints>();
 }

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -1,18 +1,19 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
+use crate::core::registerEnumType;
 use crate::core::registerShard;
 use crate::fourCharacterCode;
 use crate::types::ExposedTypes;
-use crate::types::FLOAT2_TYPES;
-use crate::types::FRAG_CC;
 use crate::types::ParamVar;
 use crate::types::ShardsVar;
 use crate::types::Type;
+use crate::types::FLOAT2_TYPES;
+use crate::types::FRAG_CC;
 
 static EGUI_PLOT_UI_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"egPC"));
 
-lazy_static!{  
+lazy_static! {
   pub static ref SEQ_OF_FLOAT2: Type = Type::seq(&FLOAT2_TYPES);
   pub static ref SEQ_OF_FLOAT2_TYPES: Vec<Type> = vec![*SEQ_OF_FLOAT2];
 }
@@ -46,11 +47,41 @@ struct PlotLine {
   name: ParamVar,
 }
 
+shenum! {
+  struct MarkerShape {
+    const Circle = 0;
+    const Diamond = 1;
+    const Square = 2;
+    const Cross = 3;
+    const Plus = 4;
+    const Up = 5;
+    const Down = 6;
+    const Left = 7;
+    const Right = 8;
+    const Asterisk = 9;
+  }
+  struct MarkerShapeInfo {}
+}
+
+shenum_types! {
+  MarkerShapeInfo,
+  const MarkerShapeCC = fourCharacterCode(*b"egMS");
+  static ref MarkerShapeEnumInfo;
+  static ref MARKER_SHAPE_TYPE: Type;
+  static ref MARKER_SHAPE_TYPES: Vec<Type>;
+  static ref SEQ_OF_MARKER_SHAPE: Type;
+  static ref SEQ_OF_MARKER_SHAPE_TYPES: Vec<Type>;
+}
+
+// egui::widgets::plot::items::MarkerShape
+
 struct PlotPoints {
   plot_ui: ParamVar,
   requiring: ExposedTypes,
-  color: ParamVar,
   name: ParamVar,
+  color: ParamVar,
+  shape: ParamVar,
+  radius: ParamVar,
 }
 
 mod plot;
@@ -63,4 +94,5 @@ pub fn registerShards() {
   registerShard::<PlotBar>();
   registerShard::<PlotLine>();
   registerShard::<PlotPoints>();
+  registerEnumType(FRAG_CC, MarkerShapeCC, MarkerShapeEnumInfo.as_ref().into());
 }

--- a/rust/src/shards/gui/widgets/plots/plot.rs
+++ b/rust/src/shards/gui/widgets/plots/plot.rs
@@ -1,0 +1,248 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2022 Fragcolor Pte. Ltd. */
+
+use super::Plot;
+use super::EGUI_PLOT_UI_TYPE;
+use super::PLOT_UI_NAME;
+use crate::shard::Shard;
+use crate::shards::gui::util;
+use crate::shards::gui::EguiId;
+use crate::shards::gui::BOOL_OR_NONE_SLICE;
+use crate::shards::gui::FLOAT_VAR_OR_NONE_SLICE;
+use crate::shards::gui::PARENTS_UI_NAME;
+use crate::types::Context;
+use crate::types::ExposedInfo;
+use crate::types::ExposedTypes;
+use crate::types::InstanceData;
+use crate::types::ParamVar;
+use crate::types::Parameters;
+use crate::types::Seq;
+use crate::types::ShardsVar;
+use crate::types::Type;
+use crate::types::Types;
+use crate::types::Var;
+use crate::types::WireState;
+use crate::types::ANY_TYPES;
+use crate::types::SHARDS_OR_NONE_TYPES;
+
+lazy_static! {
+  static ref PLOT_PARAMETERS: Parameters = vec![
+    (
+      cstr!("Contents"),
+      cstr!("The UI contents."),
+      &SHARDS_OR_NONE_TYPES[..],
+    )
+      .into(),
+    (
+      cstr!("ViewAspect"),
+      cstr!("Width / height ratio of the plot region."),
+      FLOAT_VAR_OR_NONE_SLICE,
+    )
+      .into(),
+    (
+      cstr!("DataAspect"),
+      cstr!("Width / height ratio of the data."),
+      FLOAT_VAR_OR_NONE_SLICE,
+    )
+      .into(),
+    (
+      cstr!("Legend"),
+      cstr!("Whether to display the legend."),
+      BOOL_OR_NONE_SLICE,
+    )
+      .into(),
+  ];
+}
+
+impl Default for Plot {
+  fn default() -> Self {
+    let mut parents = ParamVar::default();
+    parents.set_name(PARENTS_UI_NAME);
+    let mut plot_context = ParamVar::default();
+    plot_context.set_name(PLOT_UI_NAME);
+    Self {
+      parents,
+      requiring: Vec::new(),
+      contents: ShardsVar::default(),
+      view_aspect: ParamVar::default(),
+      data_aspect: ParamVar::default(),
+      legend: ParamVar::default(),
+      plot_context,
+      exposing: Vec::new(),
+    }
+  }
+}
+
+impl Shard for Plot {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.Plot")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.Plot-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "UI.Plot"
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&PLOT_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => self.contents.set_param(value),
+      1 => Ok(self.view_aspect.set_param(value)),
+      2 => Ok(self.data_aspect.set_param(value)),
+      3 => Ok(self.legend.set_param(value)),
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.contents.get_param(),
+      1 => self.view_aspect.get_param(),
+      2 => self.data_aspect.get_param(),
+      3 => self.legend.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.Parents to the list of required variables
+    util::require_parents(&mut self.requiring, &self.parents);
+
+    Some(&self.requiring)
+  }
+
+  fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
+    self.exposing.clear();
+
+    if util::expose_contents_variables(&mut self.exposing, &self.contents) {
+      Some(&self.exposing)
+    } else {
+      None
+    }
+  }
+
+  fn hasCompose() -> bool {
+    true
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    // we need to inject the UI context to the inner shards
+    let mut data = *data;
+    // clone shared into a new vector we can append things to
+    let mut shared: ExposedTypes = data.shared.into();
+    // expose UI context
+    let ctx_info = ExposedInfo {
+      exposedType: EGUI_PLOT_UI_TYPE,
+      name: self.plot_context.get_name(),
+      help: cstr!("The UI plot context.").into(),
+      isMutable: false,
+      isProtected: true, // don't allow to be used in code/wires
+      isTableEntry: false,
+      global: false,
+      isPushTable: false,
+    };
+    shared.push(ctx_info);
+    // update shared
+    data.shared = (&shared).into();
+
+    if !self.contents.is_empty() {
+      self.contents.compose(&data)?;
+    }
+
+    Ok(data.inputType)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.parents.warmup(ctx);
+    self.plot_context.warmup(ctx);
+    self.plot_context.set(Seq::new().as_ref().into());
+
+    if !self.contents.is_empty() {
+      self.contents.warmup(ctx)?;
+    }
+    self.view_aspect.warmup(ctx);
+    self.data_aspect.warmup(ctx);
+    self.legend.warmup(ctx);
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.legend.cleanup();
+    self.data_aspect.cleanup();
+    self.view_aspect.cleanup();
+    if !self.contents.is_empty() {
+      self.contents.cleanup();
+    }
+
+    self.plot_context.cleanup();
+    self.parents.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
+    if self.contents.is_empty() {
+      return Ok(*input);
+    }
+
+    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+      let mut plot = egui::plot::Plot::new(EguiId::new(self, 0));
+
+      let view_aspect = self.view_aspect.get();
+      if !view_aspect.is_none() {
+        plot = plot.view_aspect(view_aspect.try_into()?);
+      }
+
+      let data_aspect = self.data_aspect.get();
+      if !data_aspect.is_none() {
+        plot = plot.data_aspect(data_aspect.try_into()?);
+      }
+
+      let legend = self.legend.get();
+      if !legend.is_none() {
+        plot = plot.legend(Default::default());
+      }
+
+      plot
+        .show(ui, |plot_ui| unsafe {
+          let var = Var::new_object_from_ptr(plot_ui as *const _, &EGUI_PLOT_UI_TYPE);
+          self.plot_context.set(var);
+
+          let mut _output = Var::default();
+          if self.contents.activate(context, input, &mut _output) == WireState::Error {
+            return Err("Failed to activate contents");
+          }
+
+          Ok(())
+        })
+        .inner?;
+
+      Ok(*input)
+    } else {
+      Err("No UI parent")
+    }
+  }
+}

--- a/rust/src/shards/gui/widgets/plots/plot_bar.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_bar.rs
@@ -1,0 +1,201 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2022 Fragcolor Pte. Ltd. */
+
+use super::PlotBar;
+use super::EGUI_PLOT_UI_TYPE;
+use super::PLOT_UI_NAME;
+use super::SEQ_OF_FLOAT2_TYPES;
+use crate::shard::Shard;
+use crate::shards::gui::BOOL_VAR_OR_NONE_SLICE;
+use crate::shards::gui::COLOR_VAR_OR_NONE_SLICE;
+use crate::shardsc::SHColor;
+use crate::types::Context;
+use crate::types::ExposedInfo;
+use crate::types::ExposedTypes;
+use crate::types::ParamVar;
+use crate::types::Parameters;
+use crate::types::Seq;
+use crate::types::Types;
+use crate::types::Var;
+use crate::types::FLOAT_TYPES;
+use crate::types::STRING_OR_NONE_SLICE;
+
+lazy_static! {
+  static ref BAR_PARAMETERS: Parameters = vec![
+    (
+      cstr!("Color"),
+      cstr!("Stroke color"),
+      COLOR_VAR_OR_NONE_SLICE,
+    )
+      .into(),
+    (cstr!("Width"), cstr!("Width of a bar."), &FLOAT_TYPES[..],).into(),
+    (
+      cstr!("Horizontal"),
+      cstr!("Display the bars horizontally."),
+      BOOL_VAR_OR_NONE_SLICE,
+    )
+      .into(),
+    (
+      cstr!("Name"),
+      cstr!("Name of this chart, displayed in the plot legend."),
+      STRING_OR_NONE_SLICE,
+    )
+      .into(),
+  ];
+}
+
+impl Default for PlotBar {
+  fn default() -> Self {
+    let mut plot_ui = ParamVar::default();
+    plot_ui.set_name(PLOT_UI_NAME);
+    Self {
+      plot_ui,
+      requiring: Vec::new(),
+      color: ParamVar::default(),
+      bar_width: ParamVar::default(),
+      horizontal: ParamVar::default(),
+      name: ParamVar::default(),
+    }
+  }
+}
+
+impl Shard for PlotBar {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.PlotBar")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.PlotBar-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "UI.PlotBar"
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &SEQ_OF_FLOAT2_TYPES
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &SEQ_OF_FLOAT2_TYPES
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&BAR_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => Ok(self.color.set_param(value)),
+      1 => Ok(self.bar_width.set_param(value)),
+      2 => Ok(self.horizontal.set_param(value)),
+      3 => Ok(self.name.set_param(value)),
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.color.get_param(),
+      1 => self.bar_width.get_param(),
+      2 => self.horizontal.get_param(),
+      3 => self.name.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.PlotContext to the list of required variables
+    let exp_info = ExposedInfo {
+      exposedType: EGUI_PLOT_UI_TYPE,
+      name: self.plot_ui.get_name(),
+      help: cstr!("The exposed UI plot context.").into(),
+      ..ExposedInfo::default()
+    };
+    self.requiring.push(exp_info);
+
+    Some(&self.requiring)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.plot_ui.warmup(ctx);
+    self.color.warmup(ctx);
+    self.bar_width.warmup(ctx);
+    self.horizontal.warmup(ctx);
+    self.name.warmup(ctx);
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.name.cleanup();
+    self.horizontal.cleanup();
+    self.bar_width.cleanup();
+    self.color.cleanup();
+    self.plot_ui.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
+    let plot_ui: &mut egui::plot::PlotUi =
+      Var::from_object_ptr_mut_ref(*self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
+
+    let seq: Seq = input.try_into()?;
+    let points = seq.iter().map(|x| {
+      let v: (f64, f64) = x.as_ref().try_into().unwrap();
+      v
+    });
+
+    let bar_width = self.bar_width.get();
+    let bar_width = if !bar_width.is_none() {
+      let bar_width: f64 = bar_width.try_into()?;
+      Some(bar_width)
+    } else {
+      None
+    };
+
+    let mut chart = egui::plot::BarChart::new(
+      points
+        .map(|(x, y)| {
+          let mut bar = egui::plot::Bar::new(x, y);
+          if let Some(bar_width) = bar_width {
+            bar = bar.width(bar_width);
+          }
+          bar
+        })
+        .collect(),
+    );
+
+    let color = self.color.get();
+    if !color.is_none() {
+      let color: SHColor = color.try_into()?;
+      chart = chart.color(egui::Color32::from_rgba_unmultiplied(
+        color.r, color.g, color.b, color.a,
+      ));
+    }
+
+    let horizontal = self.horizontal.get();
+    if !horizontal.is_none() && horizontal.try_into()? {
+      chart = chart.horizontal();
+    }
+
+    let name = self.name.get();
+    if !name.is_none() {
+      let name: &str = name.try_into()?;
+      chart = chart.name(name);
+    }
+
+    plot_ui.bar_chart(chart);
+
+    Ok(*input)
+  }
+}

--- a/rust/src/shards/gui/widgets/plots/plot_line.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_line.rs
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2022 Fragcolor Pte. Ltd. */
+
+use super::PlotLine;
+use super::EGUI_PLOT_UI_TYPE;
+use super::PLOT_UI_NAME;
+use super::SEQ_OF_FLOAT2_TYPES;
+use crate::shard::Shard;
+use crate::shards::gui::COLOR_VAR_OR_NONE_SLICE;
+use crate::shardsc::SHColor;
+use crate::types::Context;
+use crate::types::ExposedInfo;
+use crate::types::ExposedTypes;
+use crate::types::ParamVar;
+use crate::types::Parameters;
+use crate::types::Seq;
+use crate::types::Types;
+use crate::types::Var;
+use crate::types::STRING_OR_NONE_SLICE;
+
+lazy_static! {
+  static ref LINE_PARAMETERS: Parameters = vec![
+    (
+      cstr!("Color"),
+      cstr!("Stroke color"),
+      COLOR_VAR_OR_NONE_SLICE,
+    )
+      .into(),
+    (
+      cstr!("Name"),
+      cstr!("Name of this chart, displayed in the plot legend."),
+      STRING_OR_NONE_SLICE,
+    )
+      .into(),
+  ];
+}
+
+impl Default for PlotLine {
+  fn default() -> Self {
+    let mut plot_ui = ParamVar::default();
+    plot_ui.set_name(PLOT_UI_NAME);
+    Self {
+      plot_ui,
+      requiring: Vec::new(),
+      color: ParamVar::default(),
+      name: ParamVar::default(),
+    }
+  }
+}
+
+impl Shard for PlotLine {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.PlotLine")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.PlotLine-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "UI.PlotLine"
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &SEQ_OF_FLOAT2_TYPES
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &SEQ_OF_FLOAT2_TYPES
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&LINE_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => Ok(self.color.set_param(value)),
+      1 => Ok(self.name.set_param(value)),
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.color.get_param(),
+      1 => self.name.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.PlotContext to the list of required variables
+    let exp_info = ExposedInfo {
+      exposedType: EGUI_PLOT_UI_TYPE,
+      name: self.plot_ui.get_name(),
+      help: cstr!("The exposed UI plot context.").into(),
+      ..ExposedInfo::default()
+    };
+    self.requiring.push(exp_info);
+
+    Some(&self.requiring)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.plot_ui.warmup(ctx);
+    self.color.warmup(ctx);
+    self.name.warmup(ctx);
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.name.cleanup();
+    self.color.cleanup();
+    self.plot_ui.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
+    let plot_ui: &mut egui::plot::PlotUi =
+      Var::from_object_ptr_mut_ref(*self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
+
+    let seq: Seq = input.try_into()?;
+    let points = seq.iter().map(|x| {
+      let v: (f64, f64) = x.as_ref().try_into().unwrap();
+      [v.0, v.1]
+    });
+    let mut chart = egui::plot::Line::new(egui::plot::PlotPoints::from_iter(points));
+
+    let color = self.color.get();
+    if !color.is_none() {
+      let color: SHColor = color.try_into()?;
+      chart = chart.color(egui::Color32::from_rgba_unmultiplied(
+        color.r, color.g, color.b, color.a,
+      ));
+    }
+
+    let name = self.name.get();
+    if !name.is_none() {
+      let name: &str = name.try_into()?;
+      chart = chart.name(name);
+    }
+
+    plot_ui.line(chart);
+
+    Ok(*input)
+  }
+}

--- a/rust/src/shards/gui/widgets/plots/plot_points.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_points.rs
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2022 Fragcolor Pte. Ltd. */
+
+use super::PlotPoints;
+use super::EGUI_PLOT_UI_TYPE;
+use super::PLOT_UI_NAME;
+use super::SEQ_OF_FLOAT2_TYPES;
+use crate::shard::Shard;
+use crate::shards::gui::COLOR_VAR_OR_NONE_SLICE;
+use crate::shardsc::SHColor;
+use crate::types::Context;
+use crate::types::ExposedInfo;
+use crate::types::ExposedTypes;
+use crate::types::ParamVar;
+use crate::types::Parameters;
+use crate::types::STRING_OR_NONE_SLICE;
+use crate::types::Seq;
+use crate::types::Types;
+use crate::types::Var;
+
+lazy_static! {
+  static ref POINTS_PARAMETERS: Parameters = vec![
+    (
+      cstr!("Color"),
+      cstr!("Stroke color"),
+      COLOR_VAR_OR_NONE_SLICE,
+    )
+      .into(),
+    (
+      cstr!("Name"),
+      cstr!("Name of this chart, displayed in the plot legend."),
+      STRING_OR_NONE_SLICE,
+    )
+      .into(),
+  ];
+}
+
+impl Default for PlotPoints {
+  fn default() -> Self {
+    let mut plot_ui = ParamVar::default();
+    plot_ui.set_name(PLOT_UI_NAME);
+    Self {
+      plot_ui,
+      requiring: Vec::new(),
+      color: ParamVar::default(),
+      name: ParamVar::default(),
+    }
+  }
+}
+
+impl Shard for PlotPoints {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.PlotPoints")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.PlotPoints-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "UI.PlotPoints"
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &SEQ_OF_FLOAT2_TYPES
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &SEQ_OF_FLOAT2_TYPES
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&POINTS_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => Ok(self.color.set_param(value)),
+      1 => Ok(self.name.set_param(value)),
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.color.get_param(),
+      1 => self.name.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.PlotContext to the list of required variables
+    let exp_info = ExposedInfo {
+      exposedType: EGUI_PLOT_UI_TYPE,
+      name: self.plot_ui.get_name(),
+      help: cstr!("The exposed UI plot context.").into(),
+      ..ExposedInfo::default()
+    };
+    self.requiring.push(exp_info);
+
+    Some(&self.requiring)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.plot_ui.warmup(ctx);
+    self.color.warmup(ctx);
+    self.name.warmup(ctx);
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.name.cleanup();
+    self.color.cleanup();
+    self.plot_ui.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
+    let plot_ui: &mut egui::plot::PlotUi =
+      Var::from_object_ptr_mut_ref(*self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
+
+    let seq: Seq = input.try_into()?;
+    let points = seq.iter().map(|x| {
+      let v: (f64, f64) = x.as_ref().try_into().unwrap();
+      [v.0, v.1]
+    });
+    let mut chart = egui::plot::Points::new(egui::plot::PlotPoints::from_iter(points));
+
+    let color = self.color.get();
+    if !color.is_none() {
+      let color: SHColor = color.try_into()?;
+      chart = chart.color(egui::Color32::from_rgba_unmultiplied(
+        color.r, color.g, color.b, color.a,
+      ));
+    }
+
+    let name = self.name.get();
+    if !name.is_none() {
+      let name: &str = name.try_into()?;
+      chart = chart.name(name);
+    }
+
+    plot_ui.points(chart);
+
+    Ok(*input)
+  }
+}

--- a/rust/src/shards/gui/widgets/plots/plot_points.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_points.rs
@@ -1,11 +1,13 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
+use super::MarkerShape;
 use super::PlotPoints;
 use super::EGUI_PLOT_UI_TYPE;
 use super::PLOT_UI_NAME;
 use super::SEQ_OF_FLOAT2_TYPES;
 use crate::shard::Shard;
+use crate::shards::gui::widgets::plots::MARKER_SHAPE_TYPES;
 use crate::shards::gui::COLOR_VAR_OR_NONE_SLICE;
 use crate::shardsc::SHColor;
 use crate::types::Context;
@@ -13,23 +15,36 @@ use crate::types::ExposedInfo;
 use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::Parameters;
-use crate::types::STRING_OR_NONE_SLICE;
 use crate::types::Seq;
 use crate::types::Types;
 use crate::types::Var;
+use crate::types::FLOAT_TYPES_SLICE;
+use crate::types::STRING_OR_NONE_SLICE;
 
 lazy_static! {
   static ref POINTS_PARAMETERS: Parameters = vec![
     (
+      cstr!("Name"),
+      cstr!("Name of this chart, displayed in the plot legend."),
+      STRING_OR_NONE_SLICE,
+    )
+      .into(),
+    (
       cstr!("Color"),
-      cstr!("Stroke color"),
+      cstr!("Stroke color."),
       COLOR_VAR_OR_NONE_SLICE,
     )
       .into(),
     (
-      cstr!("Name"),
-      cstr!("Name of this chart, displayed in the plot legend."),
-      STRING_OR_NONE_SLICE,
+      cstr!("Shape"),
+      cstr!("Shape of the marker."),
+      &MARKER_SHAPE_TYPES[..],
+    )
+      .into(),
+    (
+      cstr!("Radius"),
+      cstr!("Radius of the marker."),
+      FLOAT_TYPES_SLICE,
     )
       .into(),
   ];
@@ -42,8 +57,10 @@ impl Default for PlotPoints {
     Self {
       plot_ui,
       requiring: Vec::new(),
-      color: ParamVar::default(),
       name: ParamVar::default(),
+      color: ParamVar::default(),
+      shape: ParamVar::default(),
+      radius: ParamVar::default(),
     }
   }
 }
@@ -81,16 +98,20 @@ impl Shard for PlotPoints {
 
   fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
     match index {
-      0 => Ok(self.color.set_param(value)),
-      1 => Ok(self.name.set_param(value)),
+      0 => Ok(self.name.set_param(value)),
+      1 => Ok(self.color.set_param(value)),
+      2 => Ok(self.shape.set_param(value)),
+      3 => Ok(self.radius.set_param(value)),
       _ => Err("Invalid parameter index"),
     }
   }
 
   fn getParam(&mut self, index: i32) -> Var {
     match index {
-      0 => self.color.get_param(),
-      1 => self.name.get_param(),
+      0 => self.name.get_param(),
+      1 => self.color.get_param(),
+      2 => self.shape.get_param(),
+      3 => self.radius.get_param(),
       _ => Var::default(),
     }
   }
@@ -112,15 +133,21 @@ impl Shard for PlotPoints {
 
   fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
     self.plot_ui.warmup(ctx);
-    self.color.warmup(ctx);
+
     self.name.warmup(ctx);
+    self.color.warmup(ctx);
+    self.shape.warmup(ctx);
+    self.radius.warmup(ctx);
 
     Ok(())
   }
 
   fn cleanup(&mut self) -> Result<(), &str> {
-    self.name.cleanup();
+    self.radius.cleanup();
+    self.shape.cleanup();
     self.color.cleanup();
+    self.name.cleanup();
+
     self.plot_ui.cleanup();
 
     Ok(())
@@ -137,6 +164,12 @@ impl Shard for PlotPoints {
     });
     let mut chart = egui::plot::Points::new(egui::plot::PlotPoints::from_iter(points));
 
+    let name = self.name.get();
+    if !name.is_none() {
+      let name: &str = name.try_into()?;
+      chart = chart.name(name);
+    }
+
     let color = self.color.get();
     if !color.is_none() {
       let color: SHColor = color.try_into()?;
@@ -145,14 +178,43 @@ impl Shard for PlotPoints {
       ));
     }
 
-    let name = self.name.get();
-    if !name.is_none() {
-      let name: &str = name.try_into()?;
-      chart = chart.name(name);
+    let shape = self.shape.get();
+    if !shape.is_none() {
+      chart = chart.shape(
+        MarkerShape {
+          bits: unsafe { shape.payload.__bindgen_anon_1.__bindgen_anon_3.enumValue },
+        }
+        .into(),
+      );
+    }
+
+    let radius = self.radius.get();
+    if !radius.is_none() {
+      let radius: f32 = radius.try_into()?;
+      chart = chart.radius(radius);
     }
 
     plot_ui.points(chart);
 
     Ok(*input)
+  }
+}
+
+impl From<MarkerShape> for egui::plot::MarkerShape {
+  fn from(value: MarkerShape) -> Self {
+    match value {
+      MarkerShape::Circle => egui::plot::MarkerShape::Circle,
+      MarkerShape::Diamond => egui::plot::MarkerShape::Diamond,
+      MarkerShape::Square => egui::plot::MarkerShape::Square,
+      MarkerShape::Cross => egui::plot::MarkerShape::Cross,
+      MarkerShape::Plus => egui::plot::MarkerShape::Plus,
+      MarkerShape::Up => egui::plot::MarkerShape::Up,
+      MarkerShape::Down => egui::plot::MarkerShape::Down,
+      MarkerShape::Left => egui::plot::MarkerShape::Left,
+      MarkerShape::Right => egui::plot::MarkerShape::Right,
+      MarkerShape::Asterisk => egui::plot::MarkerShape::Asterisk,
+      // default
+      _ => egui::plot::MarkerShape::Circle,
+    }
   }
 }

--- a/src/tests/egui-plot.edn
+++ b/src/tests/egui-plot.edn
@@ -36,15 +36,17 @@
 
     [] >= .circle
     (ForRange
-     0 256
+     0 64
      (->
       (ToFloat)
-      (Math.Divide (float 128)) (Math.Multiply pi)
+      (Math.Divide (float 32)) (Math.Multiply pi)
       (| (Math.Cos) (Math.Multiply .circle-radius) (Math.Add .circle-center-x) >= .x)
       (| (Math.Sin) (Math.Multiply .circle-radius) (Math.Add .circle-center-y) >= .y)
       [.x .y] (ToFloat2) >> .circle))
     .circle (ExpectLike [(float2 0)])
-    (UI.PlotPoints :Color (color 100 200 100) :Name "circle"))))
+    (UI.PlotPoints
+     :Name "circle"
+     :Color (color 100 200 100) :Shape MarkerShape.Plus :Radius 3.0))))
 
 (defloop lines-wire
   (UI.Window

--- a/src/tests/egui-plot.edn
+++ b/src/tests/egui-plot.edn
@@ -1,0 +1,233 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2022 Fragcolor Pte. Ltd.
+
+(def timestep (/ 1.0 60.0))
+(def duration 100)
+
+(def pi 3.1415926535)
+(defshards lines-plot [view data]
+  (UI.Plot
+   :ViewAspect view
+   :DataAspect data
+   :Legend true
+   :Contents
+   (->
+    [] >= .sin
+    (ForRange
+     -128 128
+     (->
+      (ToFloat) (Math.Divide (float 128)) >= .x
+      .time (Math.Cos) >= .t
+      .x (Math.Multiply 2.0) (Math.Sin) (Math.Multiply 0.5) (Math.Multiply .t) >= .y
+      [.x .y] (ToFloat2) >> .sin))
+    .sin (ExpectLike [(float2 0)])
+    (UI.PlotLine :Color (color 200 100 100) :Name "wave")
+
+    [] >= .thingy
+    (ForRange
+     0 256
+     (->
+      (ToFloat) (Math.Divide (float 128)) (Math.Multiply pi)
+      (| (Math.Multiply 2.0) (Math.Add .time) (Math.Sin) >= .x)
+      (| (Math.Multiply 3.0) (Math.Sin) >= .y)
+      [.x .y] (ToFloat2) >> .thingy))
+    .thingy (ExpectLike [(float2 0)])
+    (UI.PlotLine :Color (color 100 150 250) :Name "x = sin(2t), y = sin(3t)")
+
+    [] >= .circle
+    (ForRange
+     0 256
+     (->
+      (ToFloat)
+      (Math.Divide (float 128)) (Math.Multiply pi)
+      (| (Math.Cos) (Math.Multiply .circle-radius) (Math.Add .circle-center-x) >= .x)
+      (| (Math.Sin) (Math.Multiply .circle-radius) (Math.Add .circle-center-y) >= .y)
+      [.x .y] (ToFloat2) >> .circle))
+    .circle (ExpectLike [(float2 0)])
+    (UI.PlotPoints :Color (color 100 200 100) :Name "circle"))))
+
+(defloop lines-wire
+  (UI.Window
+   :Title "Lines"
+   :Contents
+   (->
+    (Setup
+     1.0 >= .circle-radius
+     0.0 >= .circle-center-x
+     0.0 >= .circle-center-y
+     0.0 >= .time)
+    (UI.Horizontal
+     (->
+      (UI.Group
+       (UI.Vertical
+        (->
+         "Circle:" (UI.Label)
+         (UI.FloatInput .circle-radius "r: ")
+         (UI.Horizontal
+          (->
+           (UI.FloatInput .circle-center-x "x: ")
+           (UI.FloatInput .circle-center-y "y: "))))))
+      (UI.Vertical
+       (->
+        (UI.Checkbox "Animate" .animate)
+        (UI.Tooltip
+         (UI.Checkbox "Square View" .square)
+         (-> "Always keep the viewport square." (UI.Label)))
+        (UI.Tooltip
+         (UI.Checkbox "Proportional data axes" .proportional)
+         (-> "Ticks are the same size on both axes." (UI.Label)))
+        ;; (UI.Tooltip
+        ;;  (UI.Checkbox "Show coordinates" .coordinates)
+        ;;  (-> "Can take a custom formatting function." (UI.Label)))
+        ;; ["Solid" "Dashed" "Dotted"]
+        ;; (UI.Combo
+        ;;  :Label "Line style"
+        ;;  :Index .line-style-idx)
+        ))))
+
+    (If
+     (-> .proportional)
+     (If
+      (-> .square)
+      (-> (lines-plot 1.0 1.0))
+      (-> (lines-plot nil 1.0)))
+     (If
+      (-> .square)
+      (-> (lines-plot 1.0 nil))
+      (-> (lines-plot nil nil))))
+
+    (When
+     (-> .animate)
+     (-> .time (Math.Add timestep) > .time)))))
+
+;; (defloop markers-wire
+;;   "Markers" (UI.Label))
+
+;; (defloop legend-wire
+;;   "Legend" (UI.Label))
+
+(defloop charts-histogram-wire
+  (UI.Plot
+   :Contents
+   (->
+    [] >= .hist
+    (ForRange
+     -40 39
+     (->
+      (Setup
+       0.02 (Math.Multiply 3.1415926535) (Math.Sqrt) = .f)
+      (ToFloat) (Math.Divide 10.0) (Math.Add 0.05) >= .x
+      .x (Math.Multiply .x) (Math.Divide -2.0) (Math.Exp) (Math.Divide .f) >= .y
+      [.x .y] (ToFloat2) >> .hist))
+
+    .bar-orientation (Is 1) = .horizontal
+    .hist (ExpectLike [(float2 0)])
+    (UI.PlotBar
+     :Horizontal .horizontal
+     :Width 0.095
+     :Color (color 173 216 230)))))
+
+;; (defloop charts-stacked-bars-wire)
+
+;; (defloop charts-box-plot-wire)
+
+(defloop charts-wire
+  (UI.Window
+   :Title "Charts"
+   :Contents
+   (->
+    "Type:" (UI.Label)
+    (UI.Horizontal
+     (->
+      (Setup 0 >= .bar-type)
+      (UI.RadioButton "Histogram" .bar-type 0)
+    ;;   (UI.RadioButton "Stacked Bar Chart" .bar-type 1)
+    ;;   (UI.RadioButton "Box Plot" .bar-type 2)
+      ))
+    "Orientation:" (UI.Label)
+    (UI.Horizontal
+     (->
+      (Setup 0 >= .bar-orientation)
+      (UI.RadioButton "Vertical" .bar-orientation 0)
+      (UI.RadioButton "Horizontal" .bar-orientation 1)))
+
+    .bar-type
+    (Match
+     [0 (Step charts-histogram-wire)
+    ;;   1 (Step charts-stacked-bars-wire)
+    ;;   2 (Step charts-box-plot-wire)
+      ]))))
+
+;; (defloop items-wire
+;;   "Items" (UI.Label))
+
+;; (defloop interaction-wire
+;;   "Interaction" (UI.Label))
+
+;; (defloop custom-axes-wire
+;;   "Custom Axes" (UI.Label))
+
+;; (defloop linked-axes-wire
+;;   "Linked Axes" (UI.Label))
+
+(defloop ui-wire
+  (GFX.MainWindow
+   :Title "egui plot demo" :Width 1280 :Height 768 :Debug false
+   :Contents
+   (->
+    (Setup
+     (GFX.DrawQueue) >= .ui-draw-queue
+     (GFX.UIPass .ui-draw-queue) >> .render-steps)
+
+    .ui-draw-queue (GFX.ClearQueue)
+
+    (UI
+     .ui-draw-queue
+     (UI.CentralPanel
+      (->
+       (UI.Horizontal
+        (->
+         (UI.Button "Reset")
+         (UI.Collapsing
+          :Heading "Instructions"
+          :Contents
+          (->
+           "Pan by dragging, or scroll (+ shift = horizontal)." (UI.Label)
+           "Box zooming: Right click to zoom in and zoom out using a selection." (UI.Label)
+           "Zoom with ctrl + scroll." (UI.Label)
+           "Reset view with double-click." (UI.Label)))))
+       (UI.Separator)
+       (UI.Horizontal
+        (->
+         (Setup 0 >= .choice)
+         (UI.RadioButton "Lines" .choice 0)
+        ;;  (UI.RadioButton "Markers" .choice 1)
+        ;;  (UI.RadioButton "Legend" .choice 2)
+         (UI.RadioButton "Charts" .choice 3)
+        ;;  (UI.RadioButton "Items" .choice 4)
+        ;;  (UI.RadioButton "Interaction" .choice 5)
+        ;;  (UI.RadioButton "Custom Axes" .choice 6)
+        ;;  (UI.RadioButton "Linked Axes" .choice 7)
+         ))
+       (UI.Separator)
+
+       .choice
+       (Match
+        [0 (Step lines-wire)
+        ;;  1 (Step markers-wire)
+        ;;  2 (Step legend-wire)
+         3 (Step charts-wire)
+        ;;  4 (Step items-wire)
+        ;;  5 (Step interaction-wire)
+        ;;  6 (Step custom-axes-wire)
+        ;;  7 (Step linked-axes-wire)
+         ]))))
+
+    (GFX.Render :Steps .render-steps))))
+
+(defmesh main)
+(schedule main ui-wire)
+(run main timestep duration)
+
+(schedule main ui-wire)
+(run main timestep duration)


### PR DESCRIPTION
Plot widgets using `egui` instead of `ImGui`.

Similarly to what we had with the `ImGui` integration, it supports lines, points and bars. There are more features we can integrate later. However, the goal of this PR is to have a par implementation so that `ImGui` can be removed.