### PR TITLE
Codecov

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -207,13 +207,17 @@ jobs:
         if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         run: |
           mkdir coverage
+          # capture
           lcov \
             --capture \
             --directory build/src \
             --output-file coverage/coverage.info
+          # remove external dependencies
           lcov \
             --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" \
             --output-file coverage/coverage.linux.info
+          # convert absolute path to relative path
+          sed -i s/${PWD////\\/}/./g coverage/coverage.linux.info
       - name: Upload coverage (Debug)
         if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -158,7 +158,7 @@ jobs:
           ./shards ../src/tests/genetic.clj
           ./shards ../src/tests/imaging.clj
           ./shards ../src/tests/http.clj
-          ./shards ../src/tests/ws.edn
+          # ./shards ../src/tests/ws.edn
           ./shards ../src/tests/bigint.clj
           ./shards ../src/tests/brotli.clj
           ./shards ../src/tests/snappy.clj

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -53,8 +53,10 @@ jobs:
     name: Build (${{ github.event.inputs.build-type || inputs.build-type }})
     runs-on: ubuntu-latest
     outputs:
+      build-type: ${{ steps.setup.outputs.build-type }}
       run-tests: ${{ steps.setup.outputs.run-tests }}
       run-extra-tests: ${{ steps.setup.outputs.run-extra-tests }}
+      rust-cache: ${{ steps.setup.outputs.rust-cache }}
     steps:
       - name: Setup
         id: setup
@@ -97,7 +99,7 @@ jobs:
   # Test and coverage on linux
   #
   Linux-test:
-    if: ${{ needs.Linux.outputs.run-tests == 'true' }}
+    if: ${{ needs.Linux.outputs.run-tests == 'true' || needs.Linux.outputs.run-extra-tests == 'true' }}
     needs: Linux
     name: Test
     runs-on: ubuntu-latest
@@ -105,10 +107,7 @@ jobs:
       - name: Setup
         id: setup
         run: |
-          echo "::set-output name=build-type::${{ github.event.inputs.build-type || inputs.build-type }}"
-          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
-
-          if [ "${{ github.event.inputs.build-type || inputs.build-type }}" == "Debug" ]
+          if [ "${{ needs.Linux.outputs.build-type }}" == "Debug" ]
           then
             echo "::set-output name=submodules::recursive"
           else
@@ -120,8 +119,14 @@ jobs:
           repository: fragcolor-xyz/shards
           fetch-depth: 2
           submodules: ${{ steps.setup.outputs.submodules }}
+      - name: Download artifact (Release)
+        if: ${{ needs.Linux.outputs.build-type == 'Release' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: shards-linux ${{ needs.Linux.outputs.build-type }}
+          path: build
       - name: Set up dependencies (Debug)
-        if: ${{ steps.setup.outputs.build-type == 'Debug' }}
+        if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         run: |
           sudo apt-get -y update
           sudo apt-get -y install build-essential git cmake wget clang ninja-build xorg-dev libdbus-1-dev libssl-dev lcov mesa-utils
@@ -129,22 +134,28 @@ jobs:
           rustup toolchain install nightly
           rustup default nightly
       - uses: Swatinem/rust-cache@v2
-        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
+        if: ${{ needs.Linux.outputs.rust-cache == 'true' && needs.Linux.outputs.build-type == 'Debug' }}
         with:
-          key: ${{ steps.setup.outputs.build-type }}
+          key: ${{ needs.Linux.outputs.build-type }}
       - name: Build (Debug)
-        if: ${{ steps.setup.outputs.build-type == 'Debug' }}
+        if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         run: |
-          mkdir build
+          if [ ! -d ./build ]
+          then
+            mkdir build
+          fi
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=1 ..
-          ninja shards
-      - name: Download artifact (Release)
-        if: ${{ steps.setup.outputs.build-type == 'Release' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: shards-linux ${{ steps.setup.outputs.build-type }}
-          path: build
+
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=1 -DSHARDS_BUILD_TESTS=1 ..
+
+          if [ "${{ needs.Linux.outputs.run-tests }}" == "true" ]
+          then
+            ninja shards
+          fi
+          if [ "${{ needs.Linux.outputs.run-extra-tests }}" == "true" ]
+          then
+            ninja test-runtime
+          fi
       - name: Test
         env:
           RUST_BACKTRACE: 1
@@ -186,7 +197,7 @@ jobs:
           ./shards ../src/tests/pure.edn
       - name: Test (Debug)
         # Test that only works in Debug build go there
-        if: ${{ steps.setup.outputs.build-type == 'Debug' }}
+        if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         env:
           RUST_BACKTRACE: 1
         run: |
@@ -202,104 +213,28 @@ jobs:
             echo "Running sample $i";
             ../../build/shards run-sample.edn --file "$i";
           done
-      - name: Test Headless (gfx_window)
-        uses: shards-lang/xvfb-action@master
-        if: ${{ false }} # Failed to create vulkan backend on github runner
-        with:
-          working-directory: ./build
-          run: ./shards ../src/tests/gfx-window.edn
-      - name: Test Headless (gfx_cube)
-        uses: shards-lang/xvfb-action@master
-        if: ${{ false }} # Failed to create vulkan backend on github runner
-        with:
-          working-directory: ./build
-          run: ./shards ../src/tests/gfx-cube.edn
-      - name: Test Headless (gfx_materials)
-        uses: shards-lang/xvfb-action@master
-        if: ${{ false }} # Failed to create vulkan backend on github runner
-        with:
-          working-directory: ./build
-          run: ./shards ../src/tests/gfx-materials.edn
-      - name: Coverage (Debug)
-        if: ${{ steps.setup.outputs.build-type == 'Debug' }}
-        run: |
-          mkdir coverage
-          lcov --capture --directory build/src/core/CMakeFiles/shards-core-static.dir --directory build/src/mal/CMakeFiles/shards.dir --directory build/src/extra/CMakeFiles --output-file coverage/coverage.info
-          lcov --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" --output-file coverage/coverage.f.info
-          genhtml coverage/coverage.f.info --output-directory coverage/output
-          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"
-      - name: Upload coverage
-        if: ${{ steps.setup.outputs.build-type == 'Debug' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: shards-linux-coverage
-          path: coverage
-          if-no-files-found: error
-
-  #
-  # Extra tests and coverage on linux
-  #
-  Linux-test-extra:
-    if: ${{ needs.Linux.outputs.run-extra-tests == 'true' }}
-    needs: Linux
-    name: Extra Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup
-        id: setup
-        run: |
-          echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
-      - name: Checkout shards
-        uses: actions/checkout@v3
-        with:
-          repository: fragcolor-xyz/shards
-          fetch-depth: 2
-          submodules: recursive
-      - name: Checkout glTF-Sample-Models
-        uses: actions/checkout@v3
-        with:
-          repository: KhronosGroup/glTF-Sample-Models
-          path: external/glTF-Sample-Models
-          fetch-depth: 1
-      - name: Set up dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install build-essential git cmake wget clang ninja-build xorg-dev libdbus-1-dev libssl-dev lcov mesa-utils unzip
-          ./bootstrap
-          rustup toolchain install nightly
-          rustup default nightly
-      - uses: Swatinem/rust-cache@v2
-        if: ${{ steps.setup.outputs.rust-cache == 'true' }}
-        with:
-          key: Debug
-      - name: Build
-        run: |
-          cmake -Bbuild -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=1 -DSHARDS_BUILD_TESTS=1
-          cd build
-          ninja test-runtime && ninja test-gfx
-      - name: Test runtime
+      - name: Test runtime (Debug)
+        if: ${{ needs.Linux.outputs.run-extra-tests == 'true' && needs.Linux.outputs.build-type == 'Debug' }}
         env:
           RUST_BACKTRACE: 1
         run: |
           cd build
           ./test-runtime
-      - name: Test graphics
-        uses: shards-lang/xvfb-action@master
-        if: ${{ false }} # Failed to create vulkan backend on github runner
-        with:
-          working-directory: ./build
-          run: |
-            ./test-gfx
-      - name: CodeCov
+      - name: Collect coverage (Debug)
+        if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         run: |
           mkdir coverage
-          lcov --capture --directory build/src/core/CMakeFiles/shards-core-static.dir --directory build/src/core/CMakeFiles/test-runtime.dir --directory build/src/extra/CMakeFiles --directory build/src/gfx --output-file coverage/coverage.info
-          lcov --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" --output-file coverage/coverage.f.info
-          genhtml coverage/coverage.f.info --output-directory coverage/output
-          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"
+          lcov \
+            --capture \
+            --directory build/src \
+            --output-file coverage/coverage.info
+          lcov \
+            --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" \
+            --output-file coverage/coverage.linux.info
       - name: Upload coverage
+        if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         uses: actions/upload-artifact@v3
         with:
-          name: shards-linux-coverage-extra
-          path: coverage
+          name: shards-linux-coverage
+          path: coverage/coverage.linux.info
           if-no-files-found: error

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -16,11 +16,6 @@ on:
         required: false
         default: false
         type: boolean
-      run-extra-tests:
-        description: Run the extra tests (Debug only)?
-        required: false
-        default: false
-        type: boolean
       rust-cache:
         description: Use existing rust cache?
         required: false
@@ -33,10 +28,6 @@ on:
         default: Debug
         type: string
       run-tests:
-        required: false
-        default: false
-        type: boolean
-      run-extra-tests:
         required: false
         default: false
         type: boolean
@@ -55,7 +46,6 @@ jobs:
     outputs:
       build-type: ${{ steps.setup.outputs.build-type }}
       run-tests: ${{ steps.setup.outputs.run-tests }}
-      run-extra-tests: ${{ steps.setup.outputs.run-extra-tests }}
       rust-cache: ${{ steps.setup.outputs.rust-cache }}
     steps:
       - name: Setup
@@ -63,7 +53,6 @@ jobs:
         run: |
           echo "::set-output name=build-type::${{ github.event.inputs.build-type || inputs.build-type }}"
           echo "::set-output name=run-tests::${{ github.event.inputs.run-tests || inputs.run-tests }}"
-          echo "::set-output name=run-extra-tests::${{ github.event.inputs.run-extra-tests || inputs.run-extra-tests }}"
           echo "::set-output name=rust-cache::${{ github.event.inputs.rust-cache || inputs.rust-cache }}"
       - name: Checkout shards
         uses: actions/checkout@v3
@@ -99,7 +88,7 @@ jobs:
   # Test and coverage on linux
   #
   Linux-test:
-    if: ${{ needs.Linux.outputs.run-tests == 'true' || needs.Linux.outputs.run-extra-tests == 'true' }}
+    if: ${{ needs.Linux.outputs.run-tests == 'true' }}
     needs: Linux
     name: Test
     runs-on: ubuntu-latest
@@ -148,14 +137,8 @@ jobs:
 
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=1 -DSHARDS_BUILD_TESTS=1 ..
 
-          if [ "${{ needs.Linux.outputs.run-tests }}" == "true" ]
-          then
-            ninja shards
-          fi
-          if [ "${{ needs.Linux.outputs.run-extra-tests }}" == "true" ]
-          then
-            ninja test-runtime
-          fi
+          ninja shards
+          ninja test-runtime
       - name: Test
         env:
           RUST_BACKTRACE: 1
@@ -214,7 +197,7 @@ jobs:
             ../../build/shards run-sample.edn --file "$i";
           done
       - name: Test runtime (Debug)
-        if: ${{ needs.Linux.outputs.run-extra-tests == 'true' && needs.Linux.outputs.build-type == 'Debug' }}
+        if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         env:
           RUST_BACKTRACE: 1
         run: |
@@ -231,7 +214,7 @@ jobs:
           lcov \
             --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" \
             --output-file coverage/coverage.linux.info
-      - name: Upload coverage
+      - name: Upload coverage (Debug)
         if: ${{ needs.Linux.outputs.build-type == 'Debug' }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -143,7 +143,7 @@ jobs:
           ./shards ../src/tests/channels.clj
           ./shards ../src/tests/imaging.clj
           ./shards ../src/tests/http.clj
-          ./shards ../src/tests/ws.edn
+          # ./shards ../src/tests/ws.edn
           ./shards ../src/tests/bigint.clj
           ./shards ../src/tests/brotli.clj
           ./shards ../src/tests/snappy.clj

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -51,6 +51,7 @@ jobs:
           genhtml \
             coverage/coverage.linux.info \
             coverage/coverage.linux-gpu.info \
+            --ignore-errors source \
             --output-directory coverage/output
       - name: Upload report
         if: ${{ steps.setup.outputs.html-report == 'true' }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,58 @@
+name: Codecov
+
+on:
+  workflow_call:
+    inputs:
+      html-report:
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  #
+  # Upload coverage to codecov
+  #
+  Codecov:
+    name: Codecov
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        id: setup
+        run: |
+          echo "::set-output name=html-report::${{ github.event.inputs.html-report || inputs.html-report }}"
+      - name: Checkout shards
+        uses: actions/checkout@v3
+        with:
+          repository: fragcolor-xyz/shards
+          fetch-depth: 2
+          submodules: false
+      - name: Download Linux coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: shards-linux-coverage
+          path: coverage
+      - name: Download Linux GPU coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: shards-linux-gpu-coverage
+          path: coverage
+      - uses: codecov/codecov-action@v3
+        with:
+          directory: ./coverage/
+          env_vars: OS
+          fail_ci_if_error: true
+      - name: Generate HTML report
+        if: ${{ steps.setup.outputs.html-report == 'true' }}
+        run: |
+          genhtml \
+            coverage/coverage.linux.info \
+            coverage/coverage.linux-gpu.info \
+            --output-directory coverage/output
+      - name: Upload report
+        if: ${{ steps.setup.outputs.html-report == 'true' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: shards-linux-coverage-report
+          path: |
+            coverage/output
+          if-no-files-found: error

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,6 +26,10 @@ jobs:
           repository: fragcolor-xyz/shards
           fetch-depth: 2
           submodules: false
+      - name: Set up dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install lcov
       - name: Download Linux coverage
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,10 @@ jobs:
     secrets: inherit
     with:
       build-type: Debug
+  Codecov:
+    needs: [Linux-Debug, Linux-GPU]
+    uses: ./.github/workflows/codecov.yml
+    secrets: inherit
 
   #
   # Build shards and publish docker image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
     with:
       build-type: Debug
       run-tests: true
-      run-extra-tests: true
   Linux-Release:
     uses: ./.github/workflows/build-linux.yml
     secrets: inherit

--- a/.github/workflows/run-codecov.yml
+++ b/.github/workflows/run-codecov.yml
@@ -1,0 +1,33 @@
+name: Run codecov
+
+on:
+  workflow_dispatch:
+    inputs:
+      rust-cache:
+        description: Use existing rust cache?
+        required: false
+        default: false
+        type: boolean
+      html-report:
+        description: Generate an HTML report for the coverage
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  Linux-Debug:
+    uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
+    with:
+      build-type: Debug
+      run-tests: true
+      run-extra-tests: true
+  Linux-GPU:
+    uses: ./.github/workflows/test-linux-gpu.yml
+    secrets: inherit
+    with:
+      build-type: Debug
+  Codecov:
+    needs: [Linux-Debug, Linux-GPU]
+    uses: ./.github/workflows/codecov.yml
+    secrets: inherit

--- a/.github/workflows/run-codecov.yml
+++ b/.github/workflows/run-codecov.yml
@@ -21,7 +21,6 @@ jobs:
     with:
       build-type: Debug
       run-tests: true
-      run-extra-tests: true
   Linux-GPU:
     uses: ./.github/workflows/test-linux-gpu.yml
     secrets: inherit

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -118,19 +118,29 @@ jobs:
         if: ${{ steps.setup.outputs.build-type == 'Debug' }}
         run: |
           mkdir coverage
-          lcov --capture --directory build/src --output-file coverage/coverage.info
-          lcov --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" --output-file coverage/coverage.f.info
-          genhtml coverage/coverage.f.info --output-directory coverage/output
-          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"
+          lcov \
+            --capture \
+            --directory build/src \
+            --output-file coverage/coverage.info
+          lcov \
+            --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" \
+            --output-file coverage/coverage.linux-gpu.info
       - name: Upload coverage (Debug)
         if: ${{ steps.setup.outputs.build-type == 'Debug' }}
         uses: actions/upload-artifact@v3
         with:
           name: shards-linux-gpu-coverage
           path: |
-            coverage
-            test-gfx.xml
+            coverage/coverage.linux-gpu.info
           if-no-files-found: error
+      # - name: Test results (Debug)
+      #   if: ${{ steps.setup.outputs.build-type == 'Debug' }}
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: shards-linux-test-gfx
+      #     path: |
+      #       test-gfx.xml
+      #     if-no-files-found: error
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -118,13 +118,17 @@ jobs:
         if: ${{ steps.setup.outputs.build-type == 'Debug' }}
         run: |
           mkdir coverage
+          # capture
           lcov \
             --capture \
             --directory build/src \
             --output-file coverage/coverage.info
+          # remove external dependencies
           lcov \
             --remove coverage/coverage.info "*/c++/*" "*/boost/*" "*/usr/*" "*/deps/*" "*/src/mal/*" \
             --output-file coverage/coverage.linux-gpu.info
+          # convert absolute path to relative path
+          sed -i s/${PWD////\\/}/./g coverage/coverage.linux-gpu.info
       - name: Upload coverage (Debug)
         if: ${{ steps.setup.outputs.build-type == 'Debug' }}
         uses: actions/upload-artifact@v3
@@ -133,17 +137,11 @@ jobs:
           path: |
             coverage/coverage.linux-gpu.info
           if-no-files-found: error
-      # - name: Test results (Debug)
-      #   if: ${{ steps.setup.outputs.build-type == 'Debug' }}
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: shards-linux-test-gfx
-      #     path: |
-      #       test-gfx.xml
-      #     if-no-files-found: error
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: shards-linux-gpu rejected test data
-          path: src/gfx/tests/data/default/rejected
+          path: |
+            test-gfx.xml
+            src/gfx/tests/data/default/rejected
           if-no-files-found: ignore


### PR DESCRIPTION
Improve CI jobs for code coverage.

- merge `Linux-test` and `Linux-test-extra` jobs to save one machine during build and a bit of time
- upload coverage data from `Linux-test` and `Linux-gpu` as artifacts
- add a separate job to collect all coverage artifacts and send them at once to codecov
- uses codecov official action instead of the bash script