### PR TITLE
Vector constructors & more generic math implementations

### DIFF
--- a/include/number_types.hpp
+++ b/include/number_types.hpp
@@ -26,6 +26,8 @@ enum class NumberType {
 std::map<SHType, NumberType> getSHTypeToNumberTypeMap();
 const std::vector<NumberType> &getSHTypeToNumberTypeArrayMap();
 
+const Type& getCompatibleUnitType(NumberType numberType);
+
 inline NumberType shTypeToNumberType(SHType type) {
   auto &mapping = getSHTypeToNumberTypeArrayMap();
   shassert((size_t)type < mapping.size());

--- a/src/core/number_types.cpp
+++ b/src/core/number_types.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <type_traits>
+#include <stdexcept>
 
 namespace shards {
 
@@ -22,6 +23,23 @@ std::map<SHType, NumberType> getSHTypeToNumberTypeMap() {
   };
   // clang-format on
 };
+
+const Type &getCompatibleUnitType(NumberType numberType) {
+  switch (numberType) {
+  default:
+    throw std::logic_error("Invalid number type");
+  case NumberType::UInt8:
+  case NumberType::Int8:
+  case NumberType::Int16:
+  case NumberType::Int32:
+  case NumberType::Int64:
+    return CoreInfo::IntType;
+    break;
+  case NumberType::Float32:
+  case NumberType::Float64:
+    return CoreInfo::FloatType;
+  }
+}
 
 template <typename TIn, typename TOut> struct TNumberConversion : NumberConversion {
   TNumberConversion() {

--- a/src/core/shards/bigint.cpp
+++ b/src/core/shards/bigint.cpp
@@ -68,7 +68,6 @@ struct ToBigInt {
 struct BigIntOutputBuffer {
   struct Output {
     std::vector<uint8_t> data;
-    SHVar var;
   };
 
   std::deque<Output> _outputs;
@@ -82,12 +81,6 @@ struct BigIntOutputBuffer {
     auto &output = _outputs[_index];
     _index++;
     return output;
-  }
-
-  const SHVar &getLastOutputVar() const {
-    if (_index == 0)
-      throw std::out_of_range("No outputs");
-    return _outputs[_index - 1].var;
   }
 };
 
@@ -111,7 +104,7 @@ template <typename TOp> struct BigIntBinaryOperation {
     cpp_int bres = op.template apply(bia, bib);
 
     auto &output = _outputs.getOutput();
-    outputVar = output.var = to_var(bres, output.data);
+    outputVar = to_var(bres, output.data);
   }
 
   void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b) {

--- a/src/core/shards/casting.cpp
+++ b/src/core/shards/casting.cpp
@@ -584,6 +584,16 @@ void registerCastingShards() {
   REGISTER_SHARD("ToFloat3", ToNumber<Float3>);
   REGISTER_SHARD("ToFloat4", ToNumber<Float4>);
 
+  REGISTER_SHARD("MakeInt2", MakeVector<Int2>);
+  REGISTER_SHARD("MakeInt3", MakeVector<Int3>);
+  REGISTER_SHARD("MakeInt4", MakeVector<Int4>);
+  REGISTER_SHARD("MakeInt8", MakeVector<Int8>);
+  REGISTER_SHARD("MakeInt16", MakeVector<Int16>);
+  REGISTER_SHARD("MakeColor", MakeVector<Color>);
+  REGISTER_SHARD("MakeFloat2", MakeVector<Float2>);
+  REGISTER_SHARD("MakeFloat3", MakeVector<Float3>);
+  REGISTER_SHARD("MakeFloat4", MakeVector<Float4>);
+
   REGISTER_CORE_SHARD(ToString);
   REGISTER_CORE_SHARD(ToHex);
 

--- a/src/core/shards/casting.hpp
+++ b/src/core/shards/casting.hpp
@@ -328,7 +328,7 @@ template <SHType ToType> struct MakeVector {
       dstData += _componentConversion->outStride;
     }
 
-    // Apply broadcat be copying first element to remaining elements
+    // Apply broadcast by copying the first element to remaining elements
     if (isBroadcast) {
       uint8_t *broadcastSrc = dstData - _componentConversion->outStride;
       for (size_t i = 1; i < params.size(); i++) {

--- a/src/core/shards/casting.hpp
+++ b/src/core/shards/casting.hpp
@@ -226,13 +226,13 @@ template <SHType ToType> struct MakeVector {
   }
 
   void setParam(int index, const SHVar &value) {
-    if (index >= params.size())
+    if (index >= (int)params.size())
       return;
     params[index] = value;
   }
 
   SHVar getParam(int index) {
-    if (index >= params.size())
+    if (index >= (int)params.size())
       return Var::Empty;
     return params[index];
   }

--- a/src/core/shards/linalg.hpp
+++ b/src/core/shards/linalg.hpp
@@ -131,6 +131,18 @@ struct Normalize : public UnaryOperation<VectorUnaryOperation<NormalizeOp>> {
 
   void setParam(int index, const SHVar &value) { op.op.positiveOnly = value.payload.boolValue; }
   SHVar getParam(int index) { return Var(op.op.positiveOnly); }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    if (data.inputType.basicType == Seq && data.inputType.seqTypes.len == 1 &&
+        data.inputType.seqTypes.elements[0].basicType == Float) {
+      OVERRIDE_ACTIVATE(data, activateFloatSeq);
+      return data.inputType;
+    } else {
+      return UnaryOperation::compose(data);
+    }
+  }
+
+  SHVar activateFloatSeq(SHContext *context, const SHVar &input);
 };
 
 // MatMul is special...
@@ -153,9 +165,7 @@ struct MatMul : public BinaryBase {
     return OpType::Invalid;
   }
 
-  SHTypeInfo compose(const SHInstanceData &data) {
-    return this->genericCompose(*this, data);
-  }
+  SHTypeInfo compose(const SHInstanceData &data) { return this->genericCompose(*this, data); }
 
   SHVar activate(SHContext *context, const SHVar &input);
 };

--- a/src/core/shards/math.hpp
+++ b/src/core/shards/math.hpp
@@ -6,12 +6,14 @@
 #ifndef SH_CORE_SHARDS_MATH
 #define SH_CORE_SHARDS_MATH
 
+#include "foundation.hpp"
 #include "shards.h"
 #include "shards.hpp"
 #include "core.hpp"
 #include <sstream>
 #include <stdexcept>
 #include <variant>
+#include "math_ops.hpp"
 
 #define _PC
 #include "ShaderFastMathLib.h"
@@ -42,20 +44,39 @@ struct Base {
   }
 };
 
-struct UnaryBase : public Base {
-  static inline Types FloatOrSeqTypes{
-      {CoreInfo::FloatType, CoreInfo::Float2Type, CoreInfo::Float3Type, CoreInfo::Float4Type, CoreInfo::AnySeqType}};
+enum OpType {
+  Invalid,
+  // Operation on scalar & vector type
+  Broadcast,
+  // Same types
+  Direct,
+  // Operation on sequence and vector/scalar type matching the sequence element type
+  Seq1,
+  // Operation on two sequences with the same vector/scalar element type
+  SeqSeq
+};
 
-  static SHTypesInfo inputTypes() { return FloatOrSeqTypes; }
-  static SHOptionalString inputHelp() {
-    return SHCCSTR("Any valid floating point number(s) or a sequence of such entities supported by this operation.");
+struct UnaryBase : public Base {
+  OpType _opType = Invalid;
+
+  void validateTypes(const SHTypeInfo &ti) {
+    _opType = OpType::Invalid;
+    if (ti.basicType == SHType::Seq) {
+      _opType = OpType::Seq1;
+      if (ti.seqTypes.len != 1)
+        throw ComposeError("UnaryVarOperation expected a Seq with just one type as input");
+    } else {
+      _opType = OpType::Direct;
+    }
   }
-  static SHTypesInfo outputTypes() { return FloatOrSeqTypes; }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    validateTypes(data.inputType);
+    return data.inputType;
+  }
 };
 
 struct BinaryBase : public Base {
-  enum OpType { Invalid, Broadcast, Normal, Seq1, SeqSeq };
-
   static inline Types MathTypesOrVar{
       {CoreInfo::IntType,       CoreInfo::IntVarType,   CoreInfo::Int2Type,      CoreInfo::Int2VarType,  CoreInfo::Int3Type,
        CoreInfo::Int3VarType,   CoreInfo::Int4Type,     CoreInfo::Int4VarType,   CoreInfo::Int8Type,     CoreInfo::Int8VarType,
@@ -69,8 +90,6 @@ struct BinaryBase : public Base {
   ParamVar _operand{shards::Var(0)};
   ExposedInfo _requiredInfo{};
   OpType _opType = Invalid;
-  const VectorTypeTraits *_lhsVecType{};
-  const VectorTypeTraits *_rhsVecType{};
 
   void cleanup() { _operand.cleanup(); }
 
@@ -86,65 +105,42 @@ struct BinaryBase : public Base {
     return ComposeError(errStream.str());
   }
 
-  void validateTypes(const SHTypeInfo &lhs, const SHType &rhs, SHTypeInfo &resultType) {
-    if (rhs != Seq && lhs.basicType != Seq) {
-      _lhsVecType = VectorTypeLookup::getInstance().get(lhs.basicType);
-      _rhsVecType = VectorTypeLookup::getInstance().get(rhs);
-      if (_lhsVecType || _rhsVecType) {
-        if (!_lhsVecType || !_rhsVecType)
-          throw ComposeError("Unsupported type to Math.Multiply");
-
-        bool sameDimension = _lhsVecType->dimension == _rhsVecType->dimension;
-        // Don't check number type here because we have to convert Float64 -> Float32 for broadcasting
-        if (!_lhsVecType->isInteger && !sameDimension && (_lhsVecType->dimension == 1 || _rhsVecType->dimension == 1)) {
-          _opType = Broadcast;
-          // Result is the vector type
-          if (_rhsVecType->dimension == 1) {
-            resultType = _lhsVecType->type;
-          } else {
-            resultType = _rhsVecType->type;
-          }
-        } else {
-          if (!sameDimension || _lhsVecType->numberType != _rhsVecType->numberType) {
-            throw ComposeError(
-                fmt::format("Can not multiply vector of size {} and {}", _lhsVecType->dimension, _rhsVecType->dimension));
-          }
-          _opType = Normal;
-        }
-      }
-    } else if (rhs != Seq && lhs.basicType == Seq) {
+  OpType validateTypes(const SHTypeInfo &lhs, const SHType &rhs, SHTypeInfo &resultType) {
+    OpType opType = OpType::Invalid;
+    if (rhs != Seq && lhs.basicType == Seq) {
       if (lhs.seqTypes.len != 1 || rhs != lhs.seqTypes.elements[0].basicType)
         throw formatTypeError(lhs.seqTypes.elements[0].basicType, rhs);
-      _opType = Seq1;
+      opType = Seq1;
     } else if (rhs == Seq && lhs.basicType == Seq) {
       // TODO need to have deeper types compatibility at least
-      _opType = SeqSeq;
-    } else {
-      throw ComposeError("Math broadcasting not supported between given types!");
+      opType = SeqSeq;
     }
+    return opType;
   }
 
-  SHTypeInfo compose(const SHInstanceData &data) {
+  template <typename TValidator> SHTypeInfo genericCompose(TValidator &validator, const SHInstanceData &data) {
     SHTypeInfo resultType = data.inputType;
     SHVar operandSpec = _operand;
     if (operandSpec.valueType == ContextVar) {
       for (uint32_t i = 0; i < data.shared.len; i++) {
         // normal variable
         if (strcmp(data.shared.elements[i].name, operandSpec.payload.stringValue) == 0) {
-          validateTypes(data.inputType, data.shared.elements[i].exposedType.basicType, resultType);
+          _opType = validator.validateTypes(data.inputType, data.shared.elements[i].exposedType.basicType, resultType);
           break;
         }
       }
     } else {
-      validateTypes(data.inputType, operandSpec.valueType, resultType);
+      _opType = validator.validateTypes(data.inputType, operandSpec.valueType, resultType);
     }
 
     if (_opType == Invalid) {
-      throw ComposeError("Math operand variable not found: " + std::string(operandSpec.payload.stringValue));
+      throw ComposeError("Incompatible types for binary operation");
     }
 
     return resultType;
   }
+
+  SHTypeInfo compose(const SHInstanceData &data) { return genericCompose(*this, data); }
 
   SHExposedTypesInfo requiredVariables() {
     SHVar operandSpec = _operand;
@@ -161,74 +157,125 @@ struct BinaryBase : public Base {
   SHVar getParam(int index) { return _operand; }
 };
 
-template <class OP> struct BinaryOperation : public BinaryBase {
-  SH_HAS_MEMBER_TEST(hasApply);
+template <typename TOp> struct ApplyBinary {
+  template <SHType ValueType> void apply(SHVarPayload &out, const SHVarPayload &a, const SHVarPayload &b) {
+    typename PayloadTraits<ValueType>::ApplyBinary binary{};
+    binary.template apply<TOp>(getPayloadContents<ValueType>(out), getPayloadContents<ValueType>(a),
+                               getPayloadContents<ValueType>(b));
+  }
+};
+
+struct ApplyBroadcast {
+  template <SHType ValueType> void apply(SHVarPayload &out, const SHVarPayload &a) {
+    using PayloadTraits = PayloadTraits<ValueType>;
+    typename PayloadTraits::Broadcast broadcast{};
+    typename PayloadTraits::UnitType utt{};
+    broadcast.template apply(getPayloadContents<ValueType>(out), utt.getContents(const_cast<SHVarPayload &>(a)));
+  }
+};
+
+template <typename TOp, DispatchType DispatchType = DispatchType::NumberTypes> struct BasicBinaryOperation {
+  ApplyBinary<TOp> apply;
+  ApplyBroadcast applyBroadcast;
+  const VectorTypeTraits *_lhsVecType{};
+  const VectorTypeTraits *_rhsVecType{};
+
+  OpType validateTypes(const SHTypeInfo &lhs, const SHType &rhs, SHTypeInfo &resultType) {
+    OpType opType = OpType::Invalid;
+    if (rhs != Seq && lhs.basicType != Seq) {
+      _lhsVecType = VectorTypeLookup::getInstance().get(lhs.basicType);
+      _rhsVecType = VectorTypeLookup::getInstance().get(rhs);
+      if (_lhsVecType || _rhsVecType) {
+        if (!_lhsVecType || !_rhsVecType)
+          throw ComposeError("Unsupported type to Math.Multiply");
+
+        bool sameDimension = _lhsVecType->dimension == _rhsVecType->dimension;
+        // Don't check number type here because we have to convert Float64 -> Float32 for broadcasting
+        if (!_lhsVecType->isInteger && !sameDimension && (_lhsVecType->dimension == 1 || _rhsVecType->dimension == 1)) {
+          opType = Broadcast;
+          // Result is the vector type
+          if (_rhsVecType->dimension == 1) {
+            resultType = _lhsVecType->type;
+          } else {
+            resultType = _rhsVecType->type;
+          }
+        } else {
+          if (!sameDimension || _lhsVecType->numberType != _rhsVecType->numberType) {
+            throw ComposeError(
+                fmt::format("Can not multiply vector of size {} and {}", _lhsVecType->dimension, _rhsVecType->dimension));
+          }
+          opType = Direct;
+        }
+      }
+    }
+
+    return opType;
+  }
+
+  void operateDirect(SHVar &output, const SHVar &a, const SHVar &b) {
+    output.valueType = a.valueType;
+    dispatchType<DispatchType>(a.valueType, apply, output.payload, a.payload, b.payload);
+  }
+
+  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b) {
+    // This implements broadcast operators on float types
+    const VectorTypeTraits *scalarType = _lhsVecType;
+    const VectorTypeTraits *vecType = _rhsVecType;
+    SHVarPayload aPayload = a.payload;
+    SHVarPayload bPayload = b.payload;
+
+    // Oparands might be swapped (e.g. v*s, s*v)
+    if (vecType->dimension == 1) {
+      std::swap(vecType, scalarType);
+    }
+
+    // Expand scalars to vectors
+    if (_lhsVecType->dimension == 1) {
+      SHVarPayload temp = aPayload; // Need temp var if input/output are the same
+      dispatchType<DispatchType>(vecType->shType, applyBroadcast, aPayload, temp);
+    }
+    if (_rhsVecType->dimension == 1) {
+      SHVarPayload temp = bPayload;
+      dispatchType<DispatchType>(vecType->shType, applyBroadcast, bPayload, temp);
+    }
+
+    output.valueType = vecType->shType;
+    dispatchType<DispatchType>(vecType->shType, apply, output.payload, aPayload, bPayload);
+  }
+};
+
+///  The Op class has the following interface:
+///
+///  struct Op {
+///    // Return the OpType based on the input types
+///    // when OpType::Invalid is results, will fall back to BinaryOperation behaviour
+///    // resultType needs to be set when OpType is not OpType::Invalid
+///    OpType validateTypes(const SHTypeInfo &a, const SHType &b, SHTypeInfo &resultType);
+///    // Apply OpType::Direct
+///    void operateDirect(SHVar &output, const SHVar &a, const SHVar &b);
+///    // Apply OpType::Broadcast
+///    void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b);
+///  };
+template <class TOp> struct BinaryOperation : public BinaryBase {
+  TOp op;
 
   static SHOptionalString help() {
     return SHCCSTR("Applies the binary operation on the input value and the operand and returns the result (or a sequence of "
                    "results if the input and the operand are sequences).");
   }
 
-  SHTypeInfo compose(const SHInstanceData &data) {
-    SHTypeInfo resultType = BinaryBase::compose(data);
-    if (_opType == Broadcast) {
-      if constexpr (!has_hasApply<OP>::value) {
-        throw ComposeError("Operator broadcast not supported for this type");
-      }
-    }
-    return resultType;
+  OpType validateTypes(const SHTypeInfo &lhs, const SHType &rhs, SHTypeInfo &resultType) {
+    OpType opType = op.validateTypes(lhs, rhs, resultType);
+    if (opType == OpType::Invalid)
+      opType = BinaryBase::validateTypes(lhs, rhs, resultType);
+    return opType;
   }
+
+  SHTypeInfo compose(const SHInstanceData &data) { return this->genericCompose(*this, data); }
 
   void operate(OpType opType, SHVar &output, const SHVar &a, const SHVar &b) {
     if (opType == Broadcast) {
-      // This implements broadcast operators on float types
-      SHVar scalar = a;
-      SHVar vec = b;
-      const VectorTypeTraits *scalarType = _lhsVecType;
-      const VectorTypeTraits *vecType = _rhsVecType;
-      bool swapped = false;
-      if (_rhsVecType->dimension == 1) {
-        std::swap(scalar, vec);
-        std::swap(scalarType, vecType);
-        swapped = true;
-      }
-
-      if constexpr (has_hasApply<OP>::value) {
-        OP op;
-        output = vec;
-        if (vecType->numberType != scalarType->numberType) {
-          // Should be only one case for floating point types
-          assert(vecType->numberType == NumberType::Float32);
-          assert(scalarType->numberType == NumberType::Float64);
-
-          if (swapped) {
-            for (size_t i = 0; i < vecType->dimension; i++) {
-              output.payload.float4Value[i] =
-                  float(op.template apply<SHFloat>(SHFloat(output.payload.float4Value[i]), scalar.payload.floatValue));
-            }
-          } else {
-            for (size_t i = 0; i < vecType->dimension; i++) {
-              output.payload.float4Value[i] =
-                  float(op.template apply<SHFloat>(scalar.payload.floatValue, SHFloat(output.payload.float4Value[i])));
-            }
-          }
-        } else {
-          if (swapped) {
-            for (size_t i = 0; i < vecType->dimension; i++) {
-              output.payload.float2Value[i] =
-                  op.template apply<SHFloat>(output.payload.float2Value[i], scalar.payload.floatValue);
-            }
-          } else {
-            for (size_t i = 0; i < vecType->dimension; i++) {
-              output.payload.float2Value[i] =
-                  op.template apply<SHFloat>(scalar.payload.floatValue, output.payload.float2Value[i]);
-            }
-          }
-        }
-      } else {
-        // This should be caught during compose
-        throw std::logic_error("Operator broadcast not supported for this type");
-      }
+      op.operateBroadcast(output, a, b);
     } else if (opType == SeqSeq) {
       if (output.valueType != Seq) {
         destroyVar(output);
@@ -240,7 +287,7 @@ template <class OP> struct BinaryOperation : public BinaryBase {
       for (uint32_t i = 0; i < a.payload.seqValue.len && olen > 0; i++) {
         const auto &sa = a.payload.seqValue.elements[i];
         const auto &sb = b.payload.seqValue.elements[i % olen];
-        auto type = Normal;
+        auto type = Direct;
         if (likely(sa.valueType == Seq && sb.valueType == Seq)) {
           type = SeqSeq;
         } else if (sa.valueType == Seq && sb.valueType != Seq) {
@@ -251,7 +298,7 @@ template <class OP> struct BinaryOperation : public BinaryBase {
         operate(type, output.payload.seqValue.elements[len], sa, sb);
       }
     } else {
-      if (opType == Normal && output.valueType == Seq) {
+      if (opType == Direct && output.valueType == Seq) {
         // something changed, avoid leaking
         // this should happen only here, because compose of SeqSeq is loose
         // we are going from an seq to a regular value, this could be expensive!
@@ -264,23 +311,23 @@ template <class OP> struct BinaryOperation : public BinaryBase {
   }
 
   ALWAYS_INLINE void operateFast(OpType opType, SHVar &output, const SHVar &a, const SHVar &b) {
-    OP op;
-    if (likely(opType == Normal)) {
-      op(output, a, b, this);
+    if (likely(opType == Direct)) {
+      op.operateDirect(output, a, b);
     } else if (opType == Seq1) {
       if (output.valueType != Seq) {
         destroyVar(output);
         output.valueType = Seq;
       }
+
       shards::arrayResize(output.payload.seqValue, 0);
       for (uint32_t i = 0; i < a.payload.seqValue.len; i++) {
         // notice, we use scratch _output here
         SHVar scratch;
-        op(scratch, a.payload.seqValue.elements[i], b, this);
+        op.operateDirect(scratch, a.payload.seqValue.elements[i], b);
         shards::arrayPush(output.payload.seqValue, scratch);
       }
     } else {
-      operate(opType, output, a, b);
+      operate(_opType, output, a, b);
     }
   }
 
@@ -291,7 +338,7 @@ template <class OP> struct BinaryOperation : public BinaryBase {
   }
 };
 
-template <class OP> struct BinaryIntOperation : public BinaryOperation<OP> {
+template <class TOp> struct BinaryIntOperation : public BinaryOperation<TOp> {
   static inline Types IntOrSeqTypes{{CoreInfo::IntType, CoreInfo::Int2Type, CoreInfo::Int3Type, CoreInfo::Int4Type,
                                      CoreInfo::Int8Type, CoreInfo::Int16Type, CoreInfo::ColorType, CoreInfo::AnySeqType}};
 
@@ -302,110 +349,155 @@ template <class OP> struct BinaryIntOperation : public BinaryOperation<OP> {
   static SHTypesInfo outputTypes() { return IntOrSeqTypes; }
 };
 
-// TODO implement SHVar operators
-// and replace with functional std::plus etc
-#define MATH_BINARY_OPERATION(NAME, OPERATOR, DIV_BY_ZERO)                                              \
-  struct NAME##Op final {                                                                               \
-    static constexpr bool hasApply{};                                                                   \
-    template <typename T> T apply(const T &lhs, const T &rhs) { return lhs OPERATOR rhs; }              \
-    ALWAYS_INLINE void operator()(SHVar &output, const SHVar &input, const SHVar &operand, void *) {    \
-      switch (input.valueType) {                                                                        \
-      case Int:                                                                                         \
-        output.valueType = Int;                                                                         \
-        output.payload.intValue = input.payload.intValue OPERATOR operand.payload.intValue;             \
-        break;                                                                                          \
-      case Int2:                                                                                        \
-        output.valueType = Int2;                                                                        \
-        output.payload.int2Value = input.payload.int2Value OPERATOR operand.payload.int2Value;          \
-        break;                                                                                          \
-      case Int3:                                                                                        \
-        output.valueType = Int3;                                                                        \
-        output.payload.int3Value = input.payload.int3Value OPERATOR operand.payload.int3Value;          \
-        break;                                                                                          \
-      case Int4:                                                                                        \
-        output.valueType = Int4;                                                                        \
-        output.payload.int4Value = input.payload.int4Value OPERATOR operand.payload.int4Value;          \
-        break;                                                                                          \
-      case Int8:                                                                                        \
-        output.valueType = Int8;                                                                        \
-        output.payload.int8Value = input.payload.int8Value OPERATOR operand.payload.int8Value;          \
-        break;                                                                                          \
-      case Int16:                                                                                       \
-        output.valueType = Int16;                                                                       \
-        output.payload.int16Value = input.payload.int16Value OPERATOR operand.payload.int16Value;       \
-        break;                                                                                          \
-      case Float:                                                                                       \
-        output.valueType = Float;                                                                       \
-        output.payload.floatValue = input.payload.floatValue OPERATOR operand.payload.floatValue;       \
-        break;                                                                                          \
-      case Float2:                                                                                      \
-        output.valueType = Float2;                                                                      \
-        output.payload.float2Value = input.payload.float2Value OPERATOR operand.payload.float2Value;    \
-        break;                                                                                          \
-      case Float3:                                                                                      \
-        output.valueType = Float3;                                                                      \
-        output.payload.float3Value = input.payload.float3Value OPERATOR operand.payload.float3Value;    \
-        break;                                                                                          \
-      case Float4:                                                                                      \
-        output.valueType = Float4;                                                                      \
-        output.payload.float4Value = input.payload.float4Value OPERATOR operand.payload.float4Value;    \
-        break;                                                                                          \
-      case Color:                                                                                       \
-        output.valueType = Color;                                                                       \
-        output.payload.colorValue.r = input.payload.colorValue.r OPERATOR operand.payload.colorValue.r; \
-        output.payload.colorValue.g = input.payload.colorValue.g OPERATOR operand.payload.colorValue.g; \
-        output.payload.colorValue.b = input.payload.colorValue.b OPERATOR operand.payload.colorValue.b; \
-        output.payload.colorValue.a = input.payload.colorValue.a OPERATOR operand.payload.colorValue.a; \
-        break;                                                                                          \
-      default:                                                                                          \
-        throw ActivationError(#NAME " operation not supported between given types!");                   \
-      }                                                                                                 \
-    }                                                                                                   \
-  };                                                                                                    \
-  using NAME = BinaryOperation<NAME##Op>;                                                               \
+template <typename TOp> struct ApplyUnary {
+  template <SHType ValueType> void apply(SHVarPayload &out, const SHVarPayload &a) {
+    typename PayloadTraits<ValueType>::ApplyUnary unary{};
+    unary.template apply<TOp>(getPayloadContents<ValueType>(out), getPayloadContents<ValueType>(a));
+  }
+};
+
+template <typename TOp, DispatchType DispatchType = DispatchType::NumberTypes> struct BasicUnaryOperation {
+  ApplyUnary<TOp> apply;
+
+  OpType validateTypes(const SHTypeInfo &a, SHTypeInfo &resultType) {
+    OpType opType = OpType::Invalid;
+    return opType;
+  }
+
+  void operateDirect(SHVar &output, const SHVar &a) {
+    output.valueType = a.valueType;
+    dispatchType<DispatchType>(a.valueType, apply, output.payload, a.payload);
+  }
+};
+
+///  The Op class has the following interface:
+///
+///  struct Op {
+///    // Return the OpType based on the input types
+///    // when OpType::Invalid is results, will fall back to BinaryOperation behaviour
+///    // resultType needs to be set when OpType is not OpType::Invalid
+///    OpType validateTypes(const SHTypeInfo &a, SHTypeInfo &resultType);
+///    // Apply OpType::Direct
+///    void operateDirect(SHVar &output, const SHVar &a);
+///  };
+template <class TOp> struct UnaryOperation : public UnaryBase {
+  TOp op;
+
+  void destroy() { destroyVar(_result); }
+
+  void validateTypes(const SHTypeInfo &ti, SHTypeInfo &resultType) {
+    _opType = op.validateTypes(ti, resultType);
+    if (_opType == OpType::Invalid)
+      UnaryBase::validateTypes(ti);
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    SHTypeInfo resultType = data.inputType;
+    validateTypes(data.inputType, resultType);
+    return data.inputType;
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("Applies the unary operation on the input value and returns the result (or a sequence of results if the input "
+                   "and the operand are sequences).");
+  }
+
+  ALWAYS_INLINE void operate(SHVar &output, const SHVar &a) {
+    if (likely(_opType == OpType::Direct)) {
+      op.operateDirect(output, a);
+    } else if (_opType == OpType::Seq1) {
+      if (output.valueType != Seq) {
+        destroyVar(output);
+        output.valueType = Seq;
+      }
+
+      shards::arrayResize(output.payload.seqValue, 0);
+      for (uint32_t i = 0; i < a.payload.seqValue.len; i++) {
+        // notice, we use scratch _output here
+        SHVar scratch;
+        op.operateDirect(scratch, a.payload.seqValue.elements[i]);
+        shards::arrayPush(output.payload.seqValue, scratch);
+      }
+    } else {
+      throw std::logic_error("Invalid operation type for unary operation");
+    }
+  }
+
+  ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {
+    operate(_result, input);
+    return _result;
+  }
+};
+
+template <class TOp> struct UnaryVarOperation final : public UnaryOperation<TOp> {
+  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
+
+  ExposedInfo _requiredInfo{};
+  ParamVar _value{};
+
+  static inline Parameters params{
+      {"Value",
+       SHCCSTR("The value to apply the operation to."),
+       {CoreInfo::IntVarType, CoreInfo::Int2VarType, CoreInfo::Int3VarType, CoreInfo::Int4VarType, CoreInfo::Int8VarType,
+        CoreInfo::Int16VarType, CoreInfo::FloatVarType, CoreInfo::Float2VarType, CoreInfo::Float3VarType, CoreInfo::Float4VarType,
+        CoreInfo::ColorVarType, CoreInfo::AnyVarSeqType}}};
+
+  static SHParametersInfo parameters() { return params; }
+
+  void setParam(int index, const SHVar &value) { _value = value; }
+
+  SHVar getParam(int index) { return _value; }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    SHTypeInfo resultType = data.inputType;
+
+    if (!_value.isVariable()) {
+      throw ComposeError("UnaryVarOperation Expected a variable");
+    }
+
+    for (const auto &share : data.shared) {
+      if (!strcmp(share.name, _value->payload.stringValue)) {
+        if (share.isProtected)
+          throw ComposeError("UnaryVarOperation cannot write protected variables");
+        if (!share.isMutable)
+          throw ComposeError("UnaryVarOperation attempt to write immutable variable");
+
+        this->validateTypes(share.exposedType, resultType);
+        assert(resultType == data.inputType);
+
+        return resultType;
+      }
+    }
+
+    throw ComposeError("Math.Inc/Dec variable not found");
+  }
+
+  SHExposedTypesInfo requiredVariables() {
+    if (_value.isVariable()) {
+      _requiredInfo =
+          ExposedInfo(ExposedInfo::Variable(_value.variableName(), SHCCSTR("The required operand."), CoreInfo::AnyType));
+      return SHExposedTypesInfo(_requiredInfo);
+    }
+    return {};
+  }
+
+  void warmup(SHContext *context) { _value.warmup(context); }
+
+  void cleanup() { _value.cleanup(); }
+
+  ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {
+    this->operate(_value.get(), _value.get());
+    return input;
+  }
+};
+
+#define MATH_BINARY_OPERATION(NAME, OPERATOR, DIV_BY_ZERO)      \
+  using NAME = BinaryOperation<BasicBinaryOperation<NAME##Op>>; \
   RUNTIME_SHARD_TYPE(Math, NAME);
 
-#define MATH_BINARY_INT_OPERATION(NAME, OPERATOR)                                                       \
-  struct NAME##Op final {                                                                               \
-    ALWAYS_INLINE void operator()(SHVar &output, const SHVar &input, const SHVar &operand, void *) {    \
-      switch (input.valueType) {                                                                        \
-      case Int:                                                                                         \
-        output.valueType = Int;                                                                         \
-        output.payload.intValue = input.payload.intValue OPERATOR operand.payload.intValue;             \
-        break;                                                                                          \
-      case Int2:                                                                                        \
-        output.valueType = Int2;                                                                        \
-        output.payload.int2Value = input.payload.int2Value OPERATOR operand.payload.int2Value;          \
-        break;                                                                                          \
-      case Int3:                                                                                        \
-        output.valueType = Int3;                                                                        \
-        output.payload.int3Value = input.payload.int3Value OPERATOR operand.payload.int3Value;          \
-        break;                                                                                          \
-      case Int4:                                                                                        \
-        output.valueType = Int4;                                                                        \
-        output.payload.int4Value = input.payload.int4Value OPERATOR operand.payload.int4Value;          \
-        break;                                                                                          \
-      case Int8:                                                                                        \
-        output.valueType = Int8;                                                                        \
-        output.payload.int8Value = input.payload.int8Value OPERATOR operand.payload.int8Value;          \
-        break;                                                                                          \
-      case Int16:                                                                                       \
-        output.valueType = Int16;                                                                       \
-        output.payload.int16Value = input.payload.int16Value OPERATOR operand.payload.int16Value;       \
-        break;                                                                                          \
-      case Color:                                                                                       \
-        output.valueType = Color;                                                                       \
-        output.payload.colorValue.r = input.payload.colorValue.r OPERATOR operand.payload.colorValue.r; \
-        output.payload.colorValue.g = input.payload.colorValue.g OPERATOR operand.payload.colorValue.g; \
-        output.payload.colorValue.b = input.payload.colorValue.b OPERATOR operand.payload.colorValue.b; \
-        output.payload.colorValue.a = input.payload.colorValue.a OPERATOR operand.payload.colorValue.a; \
-        break;                                                                                          \
-      default:                                                                                          \
-        throw ActivationError(#NAME " operation not supported between given types!");                   \
-      }                                                                                                 \
-    }                                                                                                   \
-  };                                                                                                    \
-  using NAME = BinaryIntOperation<NAME##Op>;                                                            \
+#define MATH_BINARY_INT_OPERATION(NAME, OPERATOR)                                          \
+  using NAME = BinaryIntOperation<BasicBinaryOperation<NAME##Op, DispatchType::IntTypes>>; \
   RUNTIME_SHARD_TYPE(Math, NAME);
 
 MATH_BINARY_OPERATION(Add, +, 0);
@@ -419,145 +511,11 @@ MATH_BINARY_INT_OPERATION(Mod, %);
 MATH_BINARY_INT_OPERATION(LShift, <<);
 MATH_BINARY_INT_OPERATION(RShift, >>);
 
-#if 0
-// Not used for now...
-
-#define MATH_UNARY_FUNCTOR(NAME, FUNCD, FUNCF)                     \
-  struct NAME##UnaryFuncD {                                        \
-    ALWAYS_INLINE double operator()(double x) { return FUNCD(x); } \
-  };                                                               \
-  struct NAME##UnaryFuncF {                                        \
-    ALWAYS_INLINE float operator()(float x) { return FUNCF(x); }   \
-  };
-
-MATH_UNARY_FUNCTOR(Abs, __builtin_fabs, __builtin_fabsf);
-MATH_UNARY_FUNCTOR(Exp, __builtin_exp, __builtin_expf);
-MATH_UNARY_FUNCTOR(Exp2, __builtin_exp2, __builtin_exp2f);
-MATH_UNARY_FUNCTOR(Expm1, __builtin_expm1, __builtin_expm1f);
-MATH_UNARY_FUNCTOR(Log, __builtin_log, __builtin_logf);
-MATH_UNARY_FUNCTOR(Log10, __builtin_log10, __builtin_log10f);
-MATH_UNARY_FUNCTOR(Log2, __builtin_log2, __builtin_log2f);
-MATH_UNARY_FUNCTOR(Log1p, __builtin_log1p, __builtin_log1pf);
-MATH_UNARY_FUNCTOR(Sqrt, __builtin_sqrt, __builtin_sqrtf);
-MATH_UNARY_FUNCTOR(Cbrt, __builtin_cbrt, __builtin_cbrt);
-MATH_UNARY_FUNCTOR(Sin, __builtin_sin, __builtin_sinf);
-MATH_UNARY_FUNCTOR(Cos, __builtin_cos, __builtin_cosf);
-MATH_UNARY_FUNCTOR(Tan, __builtin_tan, __builtin_tanf);
-MATH_UNARY_FUNCTOR(Asin, __builtin_asin, __builtin_asinf);
-MATH_UNARY_FUNCTOR(Acos, __builtin_acos, __builtin_acosf);
-MATH_UNARY_FUNCTOR(Atan, __builtin_atan, __builtin_atanf);
-MATH_UNARY_FUNCTOR(Sinh, __builtin_sinh, __builtin_sinhf);
-MATH_UNARY_FUNCTOR(Cosh, __builtin_cosh, __builtin_coshf);
-MATH_UNARY_FUNCTOR(Tanh, __builtin_tanh, __builtin_tanhf);
-MATH_UNARY_FUNCTOR(Asinh, __builtin_asinh, __builtin_asinhf);
-MATH_UNARY_FUNCTOR(Acosh, __builtin_acosh, __builtin_acoshf);
-MATH_UNARY_FUNCTOR(Atanh, __builtin_atanh, __builtin_atanhf);
-MATH_UNARY_FUNCTOR(Erf, __builtin_erf, __builtin_erff);
-MATH_UNARY_FUNCTOR(Erfc, __builtin_erfc, __builtin_erfcf);
-MATH_UNARY_FUNCTOR(TGamma, __builtin_tgamma, __builtin_tgammaf);
-MATH_UNARY_FUNCTOR(LGamma, __builtin_lgamma, __builtin_lgammaf);
-MATH_UNARY_FUNCTOR(Ceil, __builtin_ceil, __builtin_ceilf);
-MATH_UNARY_FUNCTOR(Floor, __builtin_floor, __builtin_floorf);
-MATH_UNARY_FUNCTOR(Trunc, __builtin_trunc, __builtin_truncf);
-MATH_UNARY_FUNCTOR(Round, __builtin_round, __builtin_roundf);
-
-template <SHType SHT, typename FuncD, typename FuncF> struct UnaryOperation {
-  ALWAYS_INLINE void operate(SHVar &output, const SHVar &input) {
-    FuncD fd;
-    FuncF ff;
-    if constexpr (SHT == SHType::Float) {
-      output.valueType = Float;
-      output.payload.floatValue = fd(input.payload.floatValue);
-    } else if constexpr (SHT == SHType::Float2) {
-      output.valueType = Float2;
-      output.payload.float2Value[0] = fd(input.payload.float2Value[0]);
-      output.payload.float2Value[1] = fd(input.payload.float2Value[1]);
-    } else if constexpr (SHT == SHType::Float3) {
-      output.valueType = Float3;
-      output.payload.float3Value[0] = ff(input.payload.float3Value[0]);
-      output.payload.float3Value[1] = ff(input.payload.float3Value[1]);
-      output.payload.float3Value[2] = ff(input.payload.float3Value[2]);
-    } else if constexpr (SHT == SHType::Float4) {
-      output.valueType = Float4;
-      output.payload.float4Value[0] = ff(input.payload.float4Value[0]);
-      output.payload.float4Value[1] = ff(input.payload.float4Value[1]);
-      output.payload.float4Value[2] = ff(input.payload.float4Value[2]);
-      output.payload.float4Value[3] = ff(input.payload.float4Value[3]);
-    }
-  }
-};
-// End of not used for now
-
-#endif
-
-#define MATH_UNARY_OPERATION(NAME, FUNC, FUNCF)                                                  \
-  struct NAME : public UnaryBase {                                                               \
-    static SHOptionalString help() {                                                             \
-      return SHCCSTR("Calculates `" #NAME "()` on the input value and returns its result, or a " \
-                     "sequence of results if input is a sequence.");                             \
-    }                                                                                            \
-                                                                                                 \
-    SHTypeInfo compose(const SHInstanceData &data) {                                             \
-      if (data.inputType.basicType == SHType::Seq) {                                             \
-        OVERRIDE_ACTIVATE(data, activateSeq);                                                    \
-        static_cast<Shard *>(data.shard)->inlineShardId = NotInline;                             \
-      } else {                                                                                   \
-        OVERRIDE_ACTIVATE(data, activateSingle);                                                 \
-        static_cast<Shard *>(data.shard)->inlineShardId = SHInlineShards::Math##NAME;            \
-      }                                                                                          \
-      return data.inputType;                                                                     \
-    }                                                                                            \
-                                                                                                 \
-    ALWAYS_INLINE void operate(SHVar &output, const SHVar &input) {                              \
-      switch (input.valueType) {                                                                 \
-      case Float:                                                                                \
-        output.valueType = Float;                                                                \
-        output.payload.floatValue = FUNC(input.payload.floatValue);                              \
-        break;                                                                                   \
-      case Float2:                                                                               \
-        output.valueType = Float2;                                                               \
-        output.payload.float2Value[0] = FUNC(input.payload.float2Value[0]);                      \
-        output.payload.float2Value[1] = FUNC(input.payload.float2Value[1]);                      \
-        break;                                                                                   \
-      case Float3:                                                                               \
-        output.valueType = Float3;                                                               \
-        output.payload.float3Value[0] = FUNCF(input.payload.float3Value[0]);                     \
-        output.payload.float3Value[1] = FUNCF(input.payload.float3Value[1]);                     \
-        output.payload.float3Value[2] = FUNCF(input.payload.float3Value[2]);                     \
-        break;                                                                                   \
-      case Float4:                                                                               \
-        output.valueType = Float4;                                                               \
-        output.payload.float4Value[0] = FUNCF(input.payload.float4Value[0]);                     \
-        output.payload.float4Value[1] = FUNCF(input.payload.float4Value[1]);                     \
-        output.payload.float4Value[2] = FUNCF(input.payload.float4Value[2]);                     \
-        output.payload.float4Value[3] = FUNCF(input.payload.float4Value[3]);                     \
-        break;                                                                                   \
-      default:                                                                                   \
-        throw ActivationError(#NAME " operation not supported on given types!");                 \
-      }                                                                                          \
-    }                                                                                            \
-                                                                                                 \
-    ALWAYS_INLINE SHVar activateSeq(SHContext *context, const SHVar &input) {                    \
-      _result.valueType = Seq;                                                                   \
-      shards::arrayResize(_result.payload.seqValue, 0);                                          \
-      for (uint32_t i = 0; i < input.payload.seqValue.len; i++) {                                \
-        SHVar scratch;                                                                           \
-        operate(scratch, input.payload.seqValue.elements[i]);                                    \
-        shards::arrayPush(_result.payload.seqValue, scratch);                                    \
-      }                                                                                          \
-      return _result;                                                                            \
-    }                                                                                            \
-                                                                                                 \
-    ALWAYS_INLINE SHVar activateSingle(SHContext *context, const SHVar &input) {                 \
-      SHVar scratch;                                                                             \
-      operate(scratch, input);                                                                   \
-      return scratch;                                                                            \
-    }                                                                                            \
-                                                                                                 \
-    ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {                       \
-      throw ActivationError("Invalid activation function");                                      \
-    }                                                                                            \
-  };                                                                                             \
+#define MATH_UNARY_OPERATION(NAME, FUNC, FUNCF)                                         \
+  struct NAME##Op final {                                                               \
+    template <typename T> T apply(const T &lhs) { return FUNC(lhs); }                   \
+  };                                                                                    \
+  using NAME = UnaryOperation<BasicUnaryOperation<NAME##Op, DispatchType::FloatTypes>>; \
   RUNTIME_SHARD_TYPE(Math, NAME);
 
 MATH_UNARY_OPERATION(Abs, __builtin_fabs, __builtin_fabsf);
@@ -674,164 +632,35 @@ struct Mean {
   MeanKind mean{MeanKind::Arithmetic};
 };
 
-template <class T> struct UnaryBin : public T {
-  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
-  static SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
-
-  ParamVar _value{};
-
-  static inline Parameters params{
-      {"Value",
-       SHCCSTR("The value to increase/decrease."),
-       {CoreInfo::IntVarType, CoreInfo::Int2VarType, CoreInfo::Int3VarType, CoreInfo::Int4VarType, CoreInfo::Int8VarType,
-        CoreInfo::Int16VarType, CoreInfo::FloatVarType, CoreInfo::Float2VarType, CoreInfo::Float3VarType, CoreInfo::Float4VarType,
-        CoreInfo::ColorVarType, CoreInfo::AnyVarSeqType}}};
-
-  static SHParametersInfo parameters() { return params; }
-
-  void setParam(int index, const SHVar &value) { _value = value; }
-
-  SHVar getParam(int index) { return _value; }
-
-  void setOperand(SHType type) {
-    switch (type) {
-    case SHType::Int:
-      T::_operand = shards::Var(1);
-      break;
-    case SHType::Int2:
-      T::_operand = shards::Var(1, 1);
-      break;
-    case SHType::Int3:
-      T::_operand = shards::Var(1, 1, 1);
-      break;
-    case SHType::Int4:
-      T::_operand = shards::Var(1, 1, 1, 1);
-      break;
-    case SHType::Float:
-      T::_operand = shards::Var(1.0);
-      break;
-    case SHType::Float2:
-      T::_operand = shards::Var(1.0, 1.0);
-      break;
-    case SHType::Float3:
-      T::_operand = shards::Var(1.0, 1.0, 1.0);
-      break;
-    case SHType::Float4:
-      T::_operand = shards::Var(1.0, 1.0, 1.0, 1.0);
-      break;
-    default:
-      throw ActivationError("Type not supported for unary math operation");
-    }
-  }
-
-  SHTypeInfo compose(const SHInstanceData &data) {
-    if (!_value.isVariable()) {
-      throw ComposeError("Math.Inc/Dec Expected a variable");
-    }
-
-    for (const auto &share : data.shared) {
-      if (!strcmp(share.name, _value->payload.stringValue)) {
-        if (share.isProtected)
-          throw ComposeError("Math.Inc/Dec cannot write protected variables");
-        if (!share.isMutable)
-          throw ComposeError("Math.Inc/Dec attempt to write immutable variable");
-        switch (share.exposedType.basicType) {
-        case Seq: {
-          if (share.exposedType.seqTypes.len != 1)
-            throw ComposeError("Math.Inc/Dec expected a Seq with just one type as input");
-          setOperand(share.exposedType.seqTypes.elements[0].basicType);
-        } break;
-        default:
-          setOperand(share.exposedType.basicType);
-        }
-        SHInstanceData data2 = data;
-        data2.inputType = share.exposedType;
-        return T::compose(data2);
-      }
-    }
-
-    throw ComposeError("Math.Inc/Dec variable not found");
-  }
-
-  SHExposedTypesInfo requiredVariables() {
-    if (_value.isVariable()) {
-      _requiredInfo =
-          ExposedInfo(ExposedInfo::Variable(_value.variableName(), SHCCSTR("The required operand."), CoreInfo::AnyType));
-      return SHExposedTypesInfo(_requiredInfo);
-    }
-    return {};
-  }
-
-  void warmup(SHContext *context) { _value.warmup(context); }
-
-  void cleanup() { _value.cleanup(); }
-
-  SHVar activate(SHContext *context, const SHVar &input) {
-    T::operateFast(T::_opType, _value.get(), _value.get(), T::_operand);
-    return input;
-  }
-
-  ExposedInfo _requiredInfo{};
+struct IncOp final {
+  template <typename T> T apply(const T &a) { return a + 1; }
 };
+using Inc = UnaryVarOperation<BasicUnaryOperation<IncOp>>;
 
-using Inc = UnaryBin<Add>;
-using Dec = UnaryBin<Subtract>;
+struct DecOp final {
+  template <typename T> T apply(const T &a) { return a - 1; }
+};
+using Dec = UnaryVarOperation<BasicUnaryOperation<DecOp>>;
 
 struct MaxOp final {
-  static constexpr bool hasApply{};
-  template <typename T> T apply(const T &lhs, const T &rhs) { return std::max<T>(lhs, rhs); }
-  ALWAYS_INLINE void operator()(SHVar &output, const SHVar &input, const SHVar &operand, void *) {
-    output = std::max(input, operand);
-  }
+  template <typename T> T apply(const T &lhs, const T &rhs) { return std::max(lhs, rhs); }
 };
-using Max = BinaryOperation<MaxOp>;
+using Max = BinaryOperation<BasicBinaryOperation<MaxOp>>;
 
 struct MinOp final {
-  static constexpr bool hasApply{};
-  template <typename T> T apply(const T &lhs, const T &rhs) { return std::min<T>(lhs, rhs); }
-  ALWAYS_INLINE void operator()(SHVar &output, const SHVar &input, const SHVar &operand, void *) {
-    output = std::min(input, operand);
-  }
+  template <typename T> T apply(const T &lhs, const T &rhs) { return std::min(lhs, rhs); }
 };
-using Min = BinaryOperation<MinOp>;
+using Min = BinaryOperation<BasicBinaryOperation<MinOp>>;
 
-#define MATH_BINARY_FLOAT_PROC(NAME, PROC)                                                                  \
-  struct NAME##Op final {                                                                                   \
-    ALWAYS_INLINE void operator()(SHVar &output, const SHVar &input, const SHVar &operand, void *) {        \
-      switch (input.valueType) {                                                                            \
-      case Float:                                                                                           \
-        output.valueType = Float;                                                                           \
-        output.payload.floatValue = PROC(input.payload.floatValue, operand.payload.floatValue);             \
-        break;                                                                                              \
-      case Float2:                                                                                          \
-        output.valueType = Float2;                                                                          \
-        output.payload.float2Value[0] = PROC(input.payload.float2Value[0], operand.payload.float2Value[0]); \
-        output.payload.float2Value[1] = PROC(input.payload.float2Value[1], operand.payload.float2Value[1]); \
-        break;                                                                                              \
-      case Float3:                                                                                          \
-        output.valueType = Float3;                                                                          \
-        output.payload.float3Value[0] = PROC(input.payload.float3Value[0], operand.payload.float3Value[0]); \
-        output.payload.float3Value[1] = PROC(input.payload.float3Value[1], operand.payload.float3Value[1]); \
-        output.payload.float3Value[2] = PROC(input.payload.float3Value[2], operand.payload.float3Value[2]); \
-        break;                                                                                              \
-      case Float4:                                                                                          \
-        output.valueType = Float4;                                                                          \
-        output.payload.float4Value[0] = PROC(input.payload.float4Value[0], operand.payload.float4Value[0]); \
-        output.payload.float4Value[1] = PROC(input.payload.float4Value[1], operand.payload.float4Value[1]); \
-        output.payload.float4Value[2] = PROC(input.payload.float4Value[2], operand.payload.float4Value[2]); \
-        output.payload.float4Value[3] = PROC(input.payload.float4Value[3], operand.payload.float4Value[3]); \
-        break;                                                                                              \
-      default:                                                                                              \
-        throw ActivationError(#NAME " operation not supported between given types!");                       \
-      }                                                                                                     \
-    }                                                                                                       \
-  };                                                                                                        \
-  using NAME = BinaryOperation<NAME##Op>;
+struct PowOp final {
+  template <typename T> T apply(const T &lhs, const T &rhs) { return std::pow(lhs, rhs); }
+};
+using Pow = BinaryOperation<BasicBinaryOperation<PowOp>>;
 
-MATH_BINARY_FLOAT_PROC(Pow, std::pow);
-using Pow = BinaryOperation<PowOp>;
-MATH_BINARY_FLOAT_PROC(FMod, std::fmod);
-using FMod = BinaryOperation<FModOp>;
+struct FModOp final {
+  template <typename T> T apply(const T &lhs, const T &rhs) { return std::fmod(lhs, rhs); }
+};
+using FMod = BinaryOperation<BasicBinaryOperation<FModOp>>;
 
 inline void registerShards() {
   REGISTER_SHARD("Math.Add", Add);

--- a/src/core/shards/math.hpp
+++ b/src/core/shards/math.hpp
@@ -190,8 +190,7 @@ template <typename TOp, DispatchType DispatchType = DispatchType::NumberTypes> s
           throw ComposeError("Unsupported type to Math.Multiply");
 
         bool sameDimension = _lhsVecType->dimension == _rhsVecType->dimension;
-        // Don't check number type here because we have to convert Float64 -> Float32 for broadcasting
-        if (!_lhsVecType->isInteger && !sameDimension && (_lhsVecType->dimension == 1 || _rhsVecType->dimension == 1)) {
+        if (!sameDimension && (_lhsVecType->dimension == 1 || _rhsVecType->dimension == 1)) {
           opType = Broadcast;
           // Result is the vector type
           if (_rhsVecType->dimension == 1) {
@@ -511,45 +510,45 @@ MATH_BINARY_INT_OPERATION(Mod, %);
 MATH_BINARY_INT_OPERATION(LShift, <<);
 MATH_BINARY_INT_OPERATION(RShift, >>);
 
-#define MATH_UNARY_OPERATION(NAME, FUNC, FUNCF)                                         \
+#define MATH_UNARY_FLOAT_OPERATION(NAME, FUNC, FUNCF)                                         \
   struct NAME##Op final {                                                               \
     template <typename T> T apply(const T &lhs) { return FUNC(lhs); }                   \
   };                                                                                    \
   using NAME = UnaryOperation<BasicUnaryOperation<NAME##Op, DispatchType::FloatTypes>>; \
   RUNTIME_SHARD_TYPE(Math, NAME);
 
-MATH_UNARY_OPERATION(Abs, __builtin_fabs, __builtin_fabsf);
-MATH_UNARY_OPERATION(Exp, __builtin_exp, __builtin_expf);
-MATH_UNARY_OPERATION(Exp2, __builtin_exp2, __builtin_exp2f);
-MATH_UNARY_OPERATION(Expm1, __builtin_expm1, __builtin_expm1f);
-MATH_UNARY_OPERATION(Log, __builtin_log, __builtin_logf);
-MATH_UNARY_OPERATION(Log10, __builtin_log10, __builtin_log10f);
-MATH_UNARY_OPERATION(Log2, __builtin_log2, __builtin_log2f);
-MATH_UNARY_OPERATION(Log1p, __builtin_log1p, __builtin_log1pf);
-MATH_UNARY_OPERATION(Sqrt, __builtin_sqrt, __builtin_sqrtf);
-MATH_UNARY_OPERATION(FastSqrt, fastSqrtNR2, fastSqrtNR2);
-MATH_UNARY_OPERATION(FastInvSqrt, fastRcpSqrtNR2, fastRcpSqrtNR2);
-MATH_UNARY_OPERATION(Cbrt, __builtin_cbrt, __builtin_cbrt);
-MATH_UNARY_OPERATION(Sin, __builtin_sin, __builtin_sinf);
-MATH_UNARY_OPERATION(Cos, __builtin_cos, __builtin_cosf);
-MATH_UNARY_OPERATION(Tan, __builtin_tan, __builtin_tanf);
-MATH_UNARY_OPERATION(Asin, __builtin_asin, __builtin_asinf);
-MATH_UNARY_OPERATION(Acos, __builtin_acos, __builtin_acosf);
-MATH_UNARY_OPERATION(Atan, __builtin_atan, __builtin_atanf);
-MATH_UNARY_OPERATION(Sinh, __builtin_sinh, __builtin_sinhf);
-MATH_UNARY_OPERATION(Cosh, __builtin_cosh, __builtin_coshf);
-MATH_UNARY_OPERATION(Tanh, __builtin_tanh, __builtin_tanhf);
-MATH_UNARY_OPERATION(Asinh, __builtin_asinh, __builtin_asinhf);
-MATH_UNARY_OPERATION(Acosh, __builtin_acosh, __builtin_acoshf);
-MATH_UNARY_OPERATION(Atanh, __builtin_atanh, __builtin_atanhf);
-MATH_UNARY_OPERATION(Erf, __builtin_erf, __builtin_erff);
-MATH_UNARY_OPERATION(Erfc, __builtin_erfc, __builtin_erfcf);
-MATH_UNARY_OPERATION(TGamma, __builtin_tgamma, __builtin_tgammaf);
-MATH_UNARY_OPERATION(LGamma, __builtin_lgamma, __builtin_lgammaf);
-MATH_UNARY_OPERATION(Ceil, __builtin_ceil, __builtin_ceilf);
-MATH_UNARY_OPERATION(Floor, __builtin_floor, __builtin_floorf);
-MATH_UNARY_OPERATION(Trunc, __builtin_trunc, __builtin_truncf);
-MATH_UNARY_OPERATION(Round, __builtin_round, __builtin_roundf);
+MATH_UNARY_FLOAT_OPERATION(Abs, __builtin_fabs, __builtin_fabsf);
+MATH_UNARY_FLOAT_OPERATION(Exp, __builtin_exp, __builtin_expf);
+MATH_UNARY_FLOAT_OPERATION(Exp2, __builtin_exp2, __builtin_exp2f);
+MATH_UNARY_FLOAT_OPERATION(Expm1, __builtin_expm1, __builtin_expm1f);
+MATH_UNARY_FLOAT_OPERATION(Log, __builtin_log, __builtin_logf);
+MATH_UNARY_FLOAT_OPERATION(Log10, __builtin_log10, __builtin_log10f);
+MATH_UNARY_FLOAT_OPERATION(Log2, __builtin_log2, __builtin_log2f);
+MATH_UNARY_FLOAT_OPERATION(Log1p, __builtin_log1p, __builtin_log1pf);
+MATH_UNARY_FLOAT_OPERATION(Sqrt, __builtin_sqrt, __builtin_sqrtf);
+MATH_UNARY_FLOAT_OPERATION(FastSqrt, fastSqrtNR2, fastSqrtNR2);
+MATH_UNARY_FLOAT_OPERATION(FastInvSqrt, fastRcpSqrtNR2, fastRcpSqrtNR2);
+MATH_UNARY_FLOAT_OPERATION(Cbrt, __builtin_cbrt, __builtin_cbrt);
+MATH_UNARY_FLOAT_OPERATION(Sin, __builtin_sin, __builtin_sinf);
+MATH_UNARY_FLOAT_OPERATION(Cos, __builtin_cos, __builtin_cosf);
+MATH_UNARY_FLOAT_OPERATION(Tan, __builtin_tan, __builtin_tanf);
+MATH_UNARY_FLOAT_OPERATION(Asin, __builtin_asin, __builtin_asinf);
+MATH_UNARY_FLOAT_OPERATION(Acos, __builtin_acos, __builtin_acosf);
+MATH_UNARY_FLOAT_OPERATION(Atan, __builtin_atan, __builtin_atanf);
+MATH_UNARY_FLOAT_OPERATION(Sinh, __builtin_sinh, __builtin_sinhf);
+MATH_UNARY_FLOAT_OPERATION(Cosh, __builtin_cosh, __builtin_coshf);
+MATH_UNARY_FLOAT_OPERATION(Tanh, __builtin_tanh, __builtin_tanhf);
+MATH_UNARY_FLOAT_OPERATION(Asinh, __builtin_asinh, __builtin_asinhf);
+MATH_UNARY_FLOAT_OPERATION(Acosh, __builtin_acosh, __builtin_acoshf);
+MATH_UNARY_FLOAT_OPERATION(Atanh, __builtin_atanh, __builtin_atanhf);
+MATH_UNARY_FLOAT_OPERATION(Erf, __builtin_erf, __builtin_erff);
+MATH_UNARY_FLOAT_OPERATION(Erfc, __builtin_erfc, __builtin_erfcf);
+MATH_UNARY_FLOAT_OPERATION(TGamma, __builtin_tgamma, __builtin_tgammaf);
+MATH_UNARY_FLOAT_OPERATION(LGamma, __builtin_lgamma, __builtin_lgammaf);
+MATH_UNARY_FLOAT_OPERATION(Ceil, __builtin_ceil, __builtin_ceilf);
+MATH_UNARY_FLOAT_OPERATION(Floor, __builtin_floor, __builtin_floorf);
+MATH_UNARY_FLOAT_OPERATION(Trunc, __builtin_trunc, __builtin_truncf);
+MATH_UNARY_FLOAT_OPERATION(Round, __builtin_round, __builtin_roundf);
 
 struct Mean {
   struct ArithMean {
@@ -642,6 +641,11 @@ struct DecOp final {
 };
 using Dec = UnaryVarOperation<BasicUnaryOperation<DecOp>>;
 
+struct NegateOp final {
+  template <typename T> T apply(const T &a) { return -a; }
+};
+using Negate = UnaryOperation<BasicUnaryOperation<NegateOp>>;
+
 struct MaxOp final {
   template <typename T> T apply(const T &lhs, const T &rhs) { return std::max(lhs, rhs); }
 };
@@ -710,6 +714,7 @@ inline void registerShards() {
   REGISTER_SHARD("Math.Mean", Mean);
   REGISTER_SHARD("Math.Inc", Inc);
   REGISTER_SHARD("Math.Dec", Dec);
+  REGISTER_SHARD("Math.Negate", Negate);
 
   REGISTER_SHARD("Max", Max);
   REGISTER_SHARD("Min", Min);

--- a/src/core/shards/math_ops.hpp
+++ b/src/core/shards/math_ops.hpp
@@ -1,0 +1,263 @@
+#ifndef C0C58AE8_8145_4443_B0B5_9D739E8256FE
+#define C0C58AE8_8145_4443_B0B5_9D739E8256FE
+
+#include "magic_enum.hpp"
+#include "shards.h"
+#include <stdexcept>
+#include <spdlog/fmt/fmt.h>
+#include <magic_enum.hpp>
+
+namespace shards::Math {
+
+template <size_t Length> struct ApplyUnaryVector {
+  template <typename TOp, typename T> void apply(T &out, const T &a) {
+    TOp op{};
+
+    for (size_t i = 0; i < Length; i++)
+      out[i] = op.template apply(a[i]);
+  }
+};
+
+template <> struct ApplyUnaryVector<1> {
+  template <typename TOp, typename T> void apply(T &out, const T &a) {
+    TOp op{};
+    out = op.template apply(a);
+  }
+};
+
+struct ApplyUnaryColor {
+  template <typename TOp, typename T> void apply(T &out, const T &a) {
+    TOp op{};
+    out.r = op.template apply(a.r);
+    out.g = op.template apply(a.g);
+    out.b = op.template apply(a.b);
+    out.a = op.template apply(a.a);
+  }
+};
+
+template <size_t Length> struct ApplyBinaryVector {
+  template <typename TOp, typename T> void apply(T &out, const T &a, const T &b) {
+    TOp op{};
+
+    for (size_t i = 0; i < Length; i++)
+      out[i] = op.template apply(a[i], b[i]);
+  }
+};
+
+template <> struct ApplyBinaryVector<1> {
+  template <typename TOp, typename T> void apply(T &out, const T &a, const T &b) {
+    TOp op{};
+    out = op.template apply(a, b);
+  }
+};
+
+struct ApplyBinaryColor {
+  template <typename TOp, typename T> void apply(T &out, const T &a, const T &b) {
+    TOp op{};
+    out.r = op.template apply(a.r, b.r);
+    out.g = op.template apply(a.g, b.g);
+    out.b = op.template apply(a.b, b.b);
+    out.a = op.template apply(a.a, b.a);
+  }
+};
+
+template <size_t Length> struct BroadcastVector {
+  template <typename T, typename T1> void apply(T &out, const T1 &a) {
+    for (size_t i = 0; i < Length; i++)
+      out[i] = a;
+  }
+};
+
+template <> struct BroadcastVector<1> {
+  template <typename T, typename T1> void apply(T &out, const T1 &a) { out = a; };
+};
+
+struct BroadcastColor {
+  template <typename T, typename T1> void apply(T &out, const T1 &a) {
+    out.r = a;
+    out.g = a;
+    out.b = a;
+    out.a = a;
+  };
+};
+
+template <SHType BasicType> struct PayloadTraits {};
+
+template <> struct PayloadTraits<SHType::Float> {
+  using Type = SHFloat;
+  using ApplyBinary = ApplyBinaryVector<1>;
+  using ApplyUnary = ApplyUnaryVector<1>;
+  using Broadcast = BroadcastVector<1>;
+  using UnitType = PayloadTraits<SHType::Float>;
+  auto &getContents(SHVarPayload &payload) { return payload.floatValue; }
+};
+template <> struct PayloadTraits<SHType::Float2> {
+  using Type = SHFloat2;
+  using ApplyBinary = ApplyBinaryVector<2>;
+  using ApplyUnary = ApplyUnaryVector<2>;
+  using Broadcast = BroadcastVector<2>;
+  using UnitType = PayloadTraits<SHType::Float>;
+  auto &getContents(SHVarPayload &payload) { return payload.float2Value; }
+};
+template <> struct PayloadTraits<SHType::Float3> {
+  using Type = SHFloat3;
+  using ApplyBinary = ApplyBinaryVector<3>;
+  using ApplyUnary = ApplyUnaryVector<3>;
+  using Broadcast = BroadcastVector<3>;
+  using UnitType = PayloadTraits<SHType::Float>;
+  auto &getContents(SHVarPayload &payload) { return payload.float3Value; }
+};
+template <> struct PayloadTraits<SHType::Float4> {
+  using Type = SHFloat4;
+  using ApplyBinary = ApplyBinaryVector<4>;
+  using ApplyUnary = ApplyUnaryVector<4>;
+  using Broadcast = BroadcastVector<4>;
+  using UnitType = PayloadTraits<SHType::Float>;
+  auto &getContents(SHVarPayload &payload) { return payload.float4Value; }
+};
+template <> struct PayloadTraits<SHType::Int> {
+  using Type = SHInt;
+  using ApplyBinary = ApplyBinaryVector<1>;
+  using ApplyUnary = ApplyUnaryVector<1>;
+  using Broadcast = BroadcastVector<1>;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.intValue; }
+};
+template <> struct PayloadTraits<SHType::Int2> {
+  using Type = SHInt2;
+  using ApplyBinary = ApplyBinaryVector<2>;
+  using ApplyUnary = ApplyUnaryVector<2>;
+  using Broadcast = BroadcastVector<2>;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.int2Value; }
+};
+template <> struct PayloadTraits<SHType::Int3> {
+  using Type = SHInt3;
+  using ApplyBinary = ApplyBinaryVector<3>;
+  using ApplyUnary = ApplyUnaryVector<3>;
+  using Broadcast = BroadcastVector<3>;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.int3Value; }
+};
+template <> struct PayloadTraits<SHType::Int4> {
+  using Type = SHInt4;
+  using ApplyBinary = ApplyBinaryVector<4>;
+  using ApplyUnary = ApplyUnaryVector<4>;
+  using Broadcast = BroadcastVector<4>;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.int4Value; }
+};
+template <> struct PayloadTraits<SHType::Int8> {
+  using Type = SHInt8;
+  using ApplyBinary = ApplyBinaryVector<8>;
+  using ApplyUnary = ApplyUnaryVector<8>;
+  using Broadcast = BroadcastVector<8>;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.int8Value; }
+};
+template <> struct PayloadTraits<SHType::Int16> {
+  using Type = SHInt16;
+  using ApplyBinary = ApplyBinaryVector<16>;
+  using ApplyUnary = ApplyUnaryVector<16>;
+  using Broadcast = BroadcastVector<16>;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.int16Value; }
+};
+template <> struct PayloadTraits<SHType::Color> {
+  using Type = SHColor;
+  using ApplyBinary = ApplyBinaryColor;
+  using ApplyUnary = ApplyUnaryColor;
+  using Broadcast = BroadcastColor;
+  using UnitType = PayloadTraits<SHType::Int>;
+  auto &getContents(SHVarPayload &payload) { return payload.colorValue; }
+};
+
+template <SHType ValueType> auto &getPayloadContents(SHVarPayload &payload) {
+  PayloadTraits<ValueType> traits;
+  return traits.getContents(payload);
+}
+
+template <SHType ValueType> const auto &getPayloadContents(const SHVarPayload &payload) {
+  PayloadTraits<ValueType> traits;
+  return traits.getContents(const_cast<SHVarPayload &>(payload));
+}
+
+enum class DispatchType : uint8_t {
+  FloatTypes = 0x1,
+  IntTypes = 0x2,
+  NumberTypes = FloatTypes | IntTypes,
+};
+
+constexpr bool hasDispatchType(DispatchType a, DispatchType b) { return (uint8_t(a) & uint8_t(b)) != 0; }
+
+template <DispatchType DispatchType, typename T, typename... TArgs> void dispatchType(SHType type, T v, TArgs &&...args) {
+  if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes)) {
+    switch (type) {
+    case Int:
+      return v.template apply<SHType::Int>(std::forward<TArgs>(args)...);
+      break;
+    case Int2:
+      return v.template apply<SHType::Int2>(std::forward<TArgs>(args)...);
+      break;
+    case Int3:
+      return v.template apply<SHType::Int3>(std::forward<TArgs>(args)...);
+      break;
+    case Int4:
+      return v.template apply<SHType::Int4>(std::forward<TArgs>(args)...);
+      break;
+    case Int8:
+      return v.template apply<SHType::Int8>(std::forward<TArgs>(args)...);
+      break;
+    case Int16:
+      return v.template apply<SHType::Int16>(std::forward<TArgs>(args)...);
+      break;
+    case Color:
+      return v.template apply<SHType::Color>(std::forward<TArgs>(args)...);
+      break;
+    default:
+      break;
+    }
+  }
+  if constexpr (hasDispatchType(DispatchType, DispatchType::FloatTypes)) {
+    switch (type) {
+    case Float:
+      return v.template apply<SHType::Float>(std::forward<TArgs>(args)...);
+      break;
+    case Float2:
+      return v.template apply<SHType::Float2>(std::forward<TArgs>(args)...);
+      break;
+    case Float3:
+      return v.template apply<SHType::Float3>(std::forward<TArgs>(args)...);
+      break;
+    case Float4:
+      return v.template apply<SHType::Float4>(std::forward<TArgs>(args)...);
+      break;
+    default:
+      break;
+    }
+  }
+  throw std::out_of_range(
+      fmt::format("dispatchType<{}>({})", magic_enum::flags::enum_name(DispatchType), magic_enum::enum_name(type)));
+}
+
+#define MATH_BINARY_OPERATION(__name, __op)                                            \
+  struct __name##Op final {                                                            \
+    template <typename T> T apply(const T &lhs, const T &rhs) { return lhs __op rhs; } \
+  };
+
+MATH_BINARY_OPERATION(Add, +);
+MATH_BINARY_OPERATION(Subtract, -);
+MATH_BINARY_OPERATION(Multiply, *);
+MATH_BINARY_OPERATION(Divide, /);
+MATH_BINARY_OPERATION(Xor, ^);
+MATH_BINARY_OPERATION(And, &);
+MATH_BINARY_OPERATION(Or, |);
+MATH_BINARY_OPERATION(Mod, %);
+MATH_BINARY_OPERATION(LShift, <<);
+MATH_BINARY_OPERATION(RShift, >>);
+
+#undef MATH_BINARY_OPERATION
+
+} // namespace shards::Math
+
+#endif /* C0C58AE8_8145_4443_B0B5_9D739E8256FE */

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -1882,6 +1882,73 @@ BUILTIN("color") {
   return malValuePtr(new malSHVar(var, false));
 }
 
+template <size_t VectorSize, SHType Type>
+malValuePtr makeVector(const MalString &name, malValueIter argsBegin, malValueIter argsEnd, const char *shardName) {
+  size_t numArgs = std::distance(argsBegin, argsEnd);
+  bool broadcast = false;
+  if (numArgs == 1) {
+    broadcast = true;
+  } else {
+    if (numArgs != VectorSize)
+      throw STRF("Vector requires {} arguments", VectorSize);
+  }
+  size_t inputSize = broadcast ? 1 : VectorSize;
+
+  bool containsVariables = false;
+  auto it = argsBegin;
+  for (size_t i = 0; i < inputSize; ++i, ++it) {
+    if (malNumber *number = dynamic_cast<malNumber *>(it->ptr())) {
+      // ignore
+    } else if (malSHVar *number = dynamic_cast<malSHVar *>(it->ptr())) {
+      containsVariables = true;
+    } else {
+      throw STRF("vector constructor expects a number or a symbol");
+    }
+  }
+
+  if (containsVariables) {
+    auto b = shards::createShard(shardName);
+    b->setup(b);
+
+    auto it = argsBegin;
+    for (size_t i = 0; i < inputSize; ++i, ++it) {
+      SHVar var{};
+      if (malNumber *number = dynamic_cast<malNumber *>(it->ptr())) {
+        var.valueType = SHType::Float;
+        var.payload.floatValue = number->value();
+      } else if (malSHVar *inVar = dynamic_cast<malSHVar *>(it->ptr())) {
+        var = inVar->value();
+      } else {
+        throw STRF("vector constructor expects a number or a symbol");
+      }
+      b->setParam(b, i, &var);
+    }
+
+    auto blk = new malShard(b);
+    return blk;
+  } else {
+    typedef typename std::conditional<VectorSize <= 2, double, float>::type ValueType;
+
+    SHVar var{};
+    var.valueType = Type;
+    ValueType *out = (ValueType *)&var.payload.floatValue;
+
+    it = argsBegin;
+    for (size_t i = 0; i < inputSize; ++i, ++it) {
+      auto v = VALUE_CAST(malNumber, it->ptr());
+      out[i] = (ValueType)v->value();
+    }
+
+    if (broadcast) {
+      for (size_t i = 1; i < VectorSize; ++i) {
+        out[i] = out[0];
+      }
+    }
+
+    return malValuePtr(new malSHVar(var, false));
+  }
+}
+
 BUILTIN("float") {
   CHECK_ARGS_IS(1);
   ARG(malNumber, value);
@@ -1891,62 +1958,11 @@ BUILTIN("float") {
   return malValuePtr(new malSHVar(var, false));
 }
 
-BUILTIN("float2") {
-  CHECK_ARGS_BETWEEN(1, 2);
-  ARG(malNumber, value0);
-  SHVar var{};
-  var.valueType = Float2;
-  var.payload.float2Value[0] = value0->value();
-  if (argsBegin != argsEnd) {
-    CHECK_ARGS_IS(1);
-    ARG(malNumber, value1);
-    var.payload.float2Value[1] = value1->value();
-  } else {
-    var.payload.float2Value[1] = value0->value();
-  }
-  return malValuePtr(new malSHVar(var, false));
-}
+BUILTIN("float2") { return makeVector<2, SHType::Float2>(name, argsBegin, argsEnd, "MakeFloat2"); }
 
-BUILTIN("float3") {
-  CHECK_ARGS_BETWEEN(1, 3);
-  ARG(malNumber, value0);
-  SHVar var{};
-  var.valueType = Float3;
-  var.payload.float3Value[0] = value0->value();
-  if (argsBegin != argsEnd) {
-    CHECK_ARGS_IS(2);
-    ARG(malNumber, value1);
-    ARG(malNumber, value2);
-    var.payload.float3Value[1] = value1->value();
-    var.payload.float3Value[2] = value2->value();
-  } else {
-    var.payload.float3Value[1] = value0->value();
-    var.payload.float3Value[2] = value0->value();
-  }
-  return malValuePtr(new malSHVar(var, false));
-}
+BUILTIN("float3") { return makeVector<3, SHType::Float3>(name, argsBegin, argsEnd, "MakeFloat3"); }
 
-BUILTIN("float4") {
-  CHECK_ARGS_BETWEEN(1, 4);
-  ARG(malNumber, value0);
-  SHVar var{};
-  var.valueType = Float4;
-  var.payload.float4Value[0] = value0->value();
-  if (argsBegin != argsEnd) {
-    CHECK_ARGS_IS(3);
-    ARG(malNumber, value1);
-    ARG(malNumber, value2);
-    ARG(malNumber, value3);
-    var.payload.float4Value[1] = value1->value();
-    var.payload.float4Value[2] = value2->value();
-    var.payload.float4Value[3] = value3->value();
-  } else {
-    var.payload.float4Value[1] = value0->value();
-    var.payload.float4Value[2] = value0->value();
-    var.payload.float4Value[3] = value0->value();
-  }
-  return malValuePtr(new malSHVar(var, false));
-}
+BUILTIN("float4") { return makeVector<4, SHType::Float4>(name, argsBegin, argsEnd, "MakeFloat4"); }
 
 BUILTIN("import") {
   CHECK_ARGS_IS(1);

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -1828,11 +1828,11 @@ malValuePtr makeVector(const MalString &name, malValueIter argsBegin, malValueIt
   } else {
     if constexpr (AllowDefaultComponents) {
       if (numArgs > VectorSize) {
-        throw STRF("Too many arguments to vector constructor: {}, {} required", numArgs, VectorSize);
+        throw STRF("Too many arguments to vector constructor: %zu, %zu required", numArgs, VectorSize);
       }
     } else {
       if (numArgs != VectorSize)
-        throw STRF("Not enough arguments to vector constructor: {}, {} required", numArgs, VectorSize);
+        throw STRF("Not enough arguments to vector constructor: %zu, %zu required", numArgs, VectorSize);
     }
   }
   size_t inputSize = broadcast ? 1 : numArgs;

--- a/src/tests/bigint.clj
+++ b/src/tests/bigint.clj
@@ -38,6 +38,33 @@
 
    "4e2" (HexToBytes) (BigInt) (BigInt.ToString) (Assert.Is "1250" true) (Log "Returned")
 
+   ; Comparisons
+   .500x1e18 (BigInt.Is .500x1e18) (Assert.Is true)
+   .1000x1e18 (BigInt.Is .500x1e18) (Assert.Is false)
+
+   .500x1e18 (BigInt.IsNot .500x1e18) (Assert.Is false)
+   .1000x1e18 (BigInt.IsNot .500x1e18) (Assert.Is true)
+
+   .1000x1e18 (BigInt.IsMore .500x1e18) (Assert.Is true)
+   .500x1e18 (BigInt.IsMore .1000x1e18) (Assert.Is false)
+   .500x1e18 (BigInt.IsMore .500x1e18) (Assert.Is false)
+
+   .1000x1e18 (BigInt.IsLess .500x1e18) (Assert.Is false)
+   .500x1e18 (BigInt.IsLess .1000x1e18) (Assert.Is true)
+   .500x1e18 (BigInt.IsLess .500x1e18) (Assert.Is false)
+
+   .1000x1e18 (BigInt.IsMoreEqual .500x1e18) (Assert.Is true)
+   .500x1e18 (BigInt.IsMoreEqual .1000x1e18) (Assert.Is false)
+   .500x1e18 (BigInt.IsMoreEqual .500x1e18) (Assert.Is true)
+
+   .1000x1e18 (BigInt.IsLessEqual .500x1e18) (Assert.Is false)
+   .500x1e18 (BigInt.IsLessEqual .1000x1e18) (Assert.Is true)
+   .500x1e18 (BigInt.IsLessEqual .500x1e18) (Assert.Is true)
+
+   100 (BigInt) (BigInt.Pow 20) (Log "100^20")
+   (| (BigInt.ToString) (Assert.Is "10000000000000000000000000000000000000000" true) (Log "Result"))
+   (| (BigInt.Sqrt) (BigInt.ToString) (Assert.Is "100000000000000000000" true) (Log "Sqrt"))
+
    ;
    ))
 

--- a/src/tests/casting-numbers.edn
+++ b/src/tests/casting-numbers.edn
@@ -3,27 +3,34 @@
 (schedule
  Root
  (Wire "test"
-        (Float3 1 2 3) >= .vec3
-        (Float 2.0) >= .flt
+       (Float3 1 2 3) >= .vec3
+       (Float 2.0) >= .flt
 
-        .vec3 (ToFloat2) (Assert.Is (Float2 1 2) true) (Log "Float2")
-        .vec3 (ToFloat4) (Assert.Is (Float4 1 2 3 0) true) (Log "Float4")
-        .vec3 (ToFloat) (Assert.Is (Float 1) true) (Log "Float")
-        .vec3 (ToInt) (Assert.Is (Int 1) true) (Log "Int")
-        .vec3 (ToInt4) (Assert.Is (Int4 1 2 3 0) true) (Log "Int4")
+       .vec3 (ToFloat2) (Assert.Is (Float2 1 2) true) (Log "Float2")
+       .vec3 (ToFloat4) (Assert.Is (Float4 1 2 3 0) true) (Log "Float4")
+       .vec3 (ToFloat) (Assert.Is (Float 1) true) (Log "Float")
+       .vec3 (ToInt) (Assert.Is (Int 1) true) (Log "Int")
+       .vec3 (ToInt4) (Assert.Is (Int4 1 2 3 0) true) (Log "Int4")
 
-        .vec3 (ToString) >= .vec3str (Log "Float3 to string")
-        .vec3str (ToFloat3) (Assert.Is (Float3 1 2 3) true) (Log "Float3 from string")
+       .vec3 (ToString) >= .vec3str (Log "Float3 to string")
+       .vec3str (ToFloat3) (Assert.Is (Float3 1 2 3) true) (Log "Float3 from string")
 
-        .vec3 (ToInt3) (ToString) >= .int3Str (Log "Int3 to string")
-        .int3Str (ToInt3) (Assert.Is (Int3 1 2 3) true) (Log "Int3 from string")
-        
-        [3.0 4.0 5.0] >= .vec3seqFixed (Log "Float3 seq (fixed)")
-        .vec3seqFixed (ToFloat3) (Assert.Is (Float3 3 4 5) true) (Log "Float3 from seq (fixed)")
-        
-        3.0 >> .vec3seqVariable
-        4 >> .vec3seqVariable
-        5 >> .vec3seqVariable
-        .vec3seqVariable (ToFloat3) (Assert.Is (Float3 3 4 5) true) (Log "Float3 from seq (variable)")
-        ))
+       .vec3 (ToInt3) (ToString) >= .int3Str (Log "Int3 to string")
+       .int3Str (ToInt3) (Assert.Is (Int3 1 2 3) true) (Log "Int3 from string")
+
+       [3.0 4.0 5.0] >= .vec3seqFixed (Log "Float3 seq (fixed)")
+       .vec3seqFixed (ToFloat3) (Assert.Is (Float3 3 4 5) true) (Log "Float3 from seq (fixed)")
+
+       3.0 >> .vec3seqVariable
+       4 >> .vec3seqVariable
+       5 >> .vec3seqVariable
+       .vec3seqVariable (ToFloat3) (Assert.Is (Float3 3 4 5) true) (Log "Float3 from seq (variable)")
+
+       (MakeFloat3 0.0 1.0 2.0) (Assert.Is (Float3 0.0 1.0 2.0)) (Log "MakeFloat3")
+       (MakeFloat2 2.0 3.0) (Assert.Is (Float2 2.0 3.0)) (Log "MakeFloat2")
+
+       1.0 >= .x
+       4.0 = .y
+       (MakeFloat2 .x .y) (Assert.Is (Float2 1.0 4.0)) (Log "MakeFloat2 (variables)")
+       (MakeFloat4 .x .y .y .x) (Assert.Is (Float4 1.0 4.0 4.0 1.0)) (Log "MakeFloat4 (variables)")))
 (tick Root)

--- a/src/tests/casting-numbers.edn
+++ b/src/tests/casting-numbers.edn
@@ -69,6 +69,12 @@
        (Color 0) (Assert.Is (Color 0 0 0 0)) (Log "MakeColor (broadcast)")
        (Color .i2 255 100) (Assert.Is (Color 2 255 100 255)) (Log "MakeColor (variable/mixed/extended)")
        (Color .i2) (Assert.Is (Color 2 2 2 2)) (Log "MakeColor (variable/broadcast)")
+
+       ; Enum conversion
+       Type.None (ToInt) (Assert.Is 0)
+       Type.Any (ToInt) (Assert.Is 1)
+       Type.Float (ToInt) (Assert.Is 9)
+
        ;
        ))
 (tick Root)

--- a/src/tests/casting-numbers.edn
+++ b/src/tests/casting-numbers.edn
@@ -41,13 +41,34 @@
        (Float2 -1.0 .y) (Assert.Is (Float2 -1.0 4.0)) (Log "MakeFloat2 (variables/mixed)")
        (Float3 .x .y -1.0) (Assert.Is (Float3 1.0 4.0 -1.0)) (Log "MakeFloat3 (variables/mixed)")
        (Float4 .x -1.0 .z .x) (Assert.Is (Float4 1.0 -1.0 3.0 1.0)) (Log "MakeFloat4 (variables/mixed)")
-       
+
        (Float2 -1.0) (Assert.Is (Float2 -1.0 -1.0)) (Log "MakeFloat2 (broadcast)")
        (Float3 -1.0) (Assert.Is (Float3 -1.0 -1.0 -1.0)) (Log "MakeFloat3 (broadcast)")
        (Float4 -1.0) (Assert.Is (Float4 -1.0 -1.0 -1.0 -1.0)) (Log "MakeFloat4 (broadcast)")
-       
+
        (Float2 .x) (Assert.Is (Float2 1.0 1.0)) (Log "MakeFloat2 (variable/broadcast)")
        (Float3 .x) (Assert.Is (Float3 1.0 1.0 1.0)) (Log "MakeFloat3 (variable/broadcast)")
        (Float4 .x) (Assert.Is (Float4 1.0 1.0 1.0 1.0)) (Log "MakeFloat4 (variable/broadcast)")
+
+       2 >= .i2
+       (Int2 .i2 .i2) (Assert.Is (Int2 2 2)) (Log "MakeInt2 (variable)")
+       (Int3 .i2 .i2 .i2) (Assert.Is (Int3 2 2 2)) (Log "MakeInt3 (variable)")
+       (Int4 .i2 .i2 .i2 .i2) (Assert.Is (Int4 2 2 2 2)) (Log "MakeInt4 (variable)")
+       (Int8 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2) (Assert.Is (Int8 2 2 2 2 2 2 2 2)) (Log "MakeInt8 (variable)")
+       (Int16 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2 .i2) (Assert.Is (Int16 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2)) (Log "MakeInt16 (variable)")
+
+       (Int2 .i2 1) (Assert.Is (Int2 2 1)) (Log "MakeInt2 (variable/mixed)")
+       (Int3 .i2 1 .i2) (Assert.Is (Int3 2 1 2)) (Log "MakeInt3 (variable/mixed)")
+       (Int4 .i2 1 .i2 .i2) (Assert.Is (Int4 2 1 2 2)) (Log "MakeInt4 (variable/mixed)")
+
+       (Int2 .i2) (Assert.Is (Int2 2 2)) (Log "MakeInt2 (variable/broadcast)")
+       (Int3 .i2) (Assert.Is (Int3 2 2 2)) (Log "MakeInt3 (variable/broadcast)")
+       (Int4 .i2) (Assert.Is (Int4 2 2 2 2)) (Log "MakeInt4 (variable/broadcast)")
+
+       (Color 255 255 255) (Assert.Is (Color 255 255 255 255)) (Log "MakeColor (extended)")
+       (Color 0) (Assert.Is (Color 0 0 0 0)) (Log "MakeColor (broadcast)")
+       (Color .i2 255 100) (Assert.Is (Color 2 255 100 255)) (Log "MakeColor (variable/mixed/extended)")
+       (Color .i2) (Assert.Is (Color 2 2 2 2)) (Log "MakeColor (variable/broadcast)")
+       ;
        ))
 (tick Root)

--- a/src/tests/casting-numbers.edn
+++ b/src/tests/casting-numbers.edn
@@ -26,11 +26,28 @@
        5 >> .vec3seqVariable
        .vec3seqVariable (ToFloat3) (Assert.Is (Float3 3 4 5) true) (Log "Float3 from seq (variable)")
 
-       (MakeFloat3 0.0 1.0 2.0) (Assert.Is (Float3 0.0 1.0 2.0)) (Log "MakeFloat3")
-       (MakeFloat2 2.0 3.0) (Assert.Is (Float2 2.0 3.0)) (Log "MakeFloat2")
+       (Float3 0.0 1.0 2.0) (Assert.Is (Float3 0.0 1.0 2.0)) (Log "MakeFloat3")
+       (Float2 2.0 3.0) (Assert.Is (Float2 2.0 3.0)) (Log "MakeFloat2")
 
        1.0 >= .x
        4.0 = .y
-       (MakeFloat2 .x .y) (Assert.Is (Float2 1.0 4.0)) (Log "MakeFloat2 (variables)")
-       (MakeFloat4 .x .y .y .x) (Assert.Is (Float4 1.0 4.0 4.0 1.0)) (Log "MakeFloat4 (variables)")))
+       3.0 = .z
+       (Float 4.0) (Assert.Is 4.0) (Log "Float (reference)")
+
+       (Float2 .x .y) (Assert.Is (Float2 1.0 4.0)) (Log "MakeFloat2 (variables)")
+       (Float3 .x .y .z) (Assert.Is (Float3 1.0 4.0 3.0)) (Log "MakeFloat3 (variables)")
+       (Float4 .x .y .z .x) (Assert.Is (Float4 1.0 4.0 3.0 1.0)) (Log "MakeFloat4 (variables)")
+
+       (Float2 -1.0 .y) (Assert.Is (Float2 -1.0 4.0)) (Log "MakeFloat2 (variables/mixed)")
+       (Float3 .x .y -1.0) (Assert.Is (Float3 1.0 4.0 -1.0)) (Log "MakeFloat3 (variables/mixed)")
+       (Float4 .x -1.0 .z .x) (Assert.Is (Float4 1.0 -1.0 3.0 1.0)) (Log "MakeFloat4 (variables/mixed)")
+       
+       (Float2 -1.0) (Assert.Is (Float2 -1.0 -1.0)) (Log "MakeFloat2 (broadcast)")
+       (Float3 -1.0) (Assert.Is (Float3 -1.0 -1.0 -1.0)) (Log "MakeFloat3 (broadcast)")
+       (Float4 -1.0) (Assert.Is (Float4 -1.0 -1.0 -1.0 -1.0)) (Log "MakeFloat4 (broadcast)")
+       
+       (Float2 .x) (Assert.Is (Float2 1.0 1.0)) (Log "MakeFloat2 (variable/broadcast)")
+       (Float3 .x) (Assert.Is (Float3 1.0 1.0 1.0)) (Log "MakeFloat3 (variable/broadcast)")
+       (Float4 .x) (Assert.Is (Float4 1.0 1.0 1.0 1.0)) (Log "MakeFloat4 (variable/broadcast)")
+       ))
 (tick Root)

--- a/src/tests/general.edn
+++ b/src/tests/general.edn
@@ -198,6 +198,19 @@
    .v-2 (Min .f) (Assert.Is (Float2 0.5 0.5) true) (Log "Min Float2 broadcast")
    .v-2 (Max .f) (Assert.Is (Float2 2.0 1.0) true) (Log "Max Float2 broadcast")
 
+   (Int2 1 2) (Math.Multiply 2) (Log "Int2 Multiply") (Assert.Is (Int2 2 4))
+   (Math.Divide 2) (Assert.Is (Int2 1 2))
+   (Int3 1 2 3) (Math.Multiply 2) (Log "Int3 Multiply") (Assert.Is (Int3 2 4 6))
+   (Math.Divide 2) (Assert.Is (Int3 1 2 3))
+   (Int4 1 2 3 4) (Math.Multiply 2) (Log "Int4 Multiply") (Assert.Is (Int4 2 4 6 8))
+   (Math.Divide 2) (Assert.Is (Int4 1 2 3 4))
+   (Int8 1 2 3 4 4 3 2 1) (Math.Multiply 2) (Log "Int8 Multiply") (Assert.Is (Int8 2 4 6 8 8 6 4 2))
+   (Math.Divide 2) (Assert.Is (Int8 1 2 3 4 4 3 2 1))
+   (Int16 1 2 3 4 4 3 2 1 4 3 2 1 1 2 3 4) (Math.Multiply 2) (Log "Int16 Multiply") (Assert.Is (Int16 2 4 6 8 8 6 4 2 8 6 4 2 2 4 6 8))
+   (Math.Divide 2) (Assert.Is (Int16 1 2 3 4 4 3 2 1 4 3 2 1 1 2 3 4))
+
+   (Int4 3 8 9 11) (Math.Mod 4) (Assert.Is (Int4 3 0 1 3))
+   
    (Float4 4 4 4 4)
    (Math.FastSqrt)
    (| (ToString)
@@ -325,9 +338,19 @@
    (Get "x")
    (Log)
 
-   (Color 2 2 2 255)
+   (Color 2 2 2 255) >= .color
    (Log)
 
+   .color (Math.Add (Color 1 1 1 0)) (Log "color") (Assert.Is (Color 3 3 3 255))
+
+   (Color 1 2 3 4) > .color
+   (Math.Inc .color) 
+   .color (Log) (Assert.Is (Color 2 3 4 5))
+
+   .color (Math.Multiply 2) (Log) (Assert.Is (Color 4 6 8 10))
+
+    9.0 (Math.FMod 4.0) (Log) (Assert.Is 1.0)
+   
    [(Float 1) (Float 2) (Float 3) (Float 4)]
    (Math.Multiply (Float 2.0))
    (Log)


### PR DESCRIPTION
Some changes I needed while working on the shader translator.

This make Float2/3/4 accept variables, e.g.:
```clojure
(Float4 0.0 0.0 .z .w) >= .my-float-4
(Float4 .all-4-values) >= .my-float-4-2
```

Some internal changes to make more combinations of math operations possible and remove duplication of applying operations between sequences

Performance note: everything is templated and the result is the same as when writing out the switch statements as done previously.