### PR TITLE
Fix RandomInt/Float requiring the variable to be initialized

### DIFF
--- a/src/core/shards/random.cpp
+++ b/src/core/shards/random.cpp
@@ -26,6 +26,16 @@ template <Type &OUTTYPE, SHType SHTYPE> struct Rand : public RandBase {
 
   void warmup(SHContext *context) { _max.warmup(context); }
 
+  SHExposedTypesInfo requiredVariables() {
+    SHVar variable = _max;
+    if (variable.valueType == ContextVar) {
+      _requiredInfo = ExposedInfo(
+          ExposedInfo::Variable(variable.payload.stringValue, SHCCSTR("The required variable."), OUTTYPE));
+      return SHExposedTypesInfo(_requiredInfo);
+    }
+    return {};
+  }
+
   SHVar activate(SHContext *context, const SHVar &input) {
     SHVar res{};
     res.valueType = SHTYPE;
@@ -50,6 +60,7 @@ private:
                                     SHCCSTR("The maximum (if integer, not including) value to output."),
                                     {CoreInfo::NoneType, OUTTYPE, Type::VariableOf(OUTTYPE)}}};
   ParamVar _max{};
+  ExposedInfo _requiredInfo{};
 };
 
 using RandomInt = Rand<CoreInfo::IntType, SHType::Int>;


### PR DESCRIPTION
**Summary**
The variable given to the `:Max` parameter could be uninitialized and produce garbage results.

**Details**
Consider this code:
```clj
(defwire test-wire
  (RandomInt :Max .total) >= .left-index (Log "left")
  (RandomInt :Max .total) >= .right-index (Log "right"))
```

This compiles, executes but produces arbitrary values.

Another case, where the variable does exist in the parent wire but is not explicitly required also produced arbitrary values, despite the max being (apparently defined):

```clj
(defwire test-wire
  ;; .total ;; uncomment this to get it to work 
  (RandomInt :Max .total) >= .left-index (Log "left")
  (RandomInt :Max .total) >= .right-index (Log "right"))

(defwire base-wire
  10 >= .total
  (Branch [test-wire]))

(defmesh main)
(schedule main base-wire)
(run main)
```

**Proposed solution**
Properly require the variable to be initialized and to be of the right type.