### PR TITLE
Allow to set log level on Msg and Log

### DIFF
--- a/docs/samples/shards/General/Log/2.edn
+++ b/docs/samples/shards/General/Log/2.edn
@@ -1,0 +1,4 @@
+"I am a var" = .var
+(* 2 4) (Log :Level LogLevel.Info) ;; log previous shard output
+.var (Log :Level LogLevel.Warning)  ;; log a variable value
+(+ 3 9) (Log :Prefix "String" :Level LogLevel.Error) ;; prefix a string to the logged output

--- a/docs/samples/shards/General/Maybe/1.edn
+++ b/docs/samples/shards/General/Maybe/1.edn
@@ -6,3 +6,4 @@
  (Take 0)
  ;:Silent
  true)
+(Log "result")

--- a/docs/samples/shards/General/Maybe/2.edn
+++ b/docs/samples/shards/General/Maybe/2.edn
@@ -1,0 +1,11 @@
+[1 2]
+(Maybe
+ ;:Shards
+ (Take 3)
+ ;:Else
+ (->
+  (Msg "Invalid, default to 42" LogLevel.Warning)
+  42)
+ ;:Silent
+ true)
+(Log "result")

--- a/docs/samples/shards/General/Msg/2.edn
+++ b/docs/samples/shards/General/Msg/2.edn
@@ -1,0 +1,6 @@
+(defshards msgshard [a b]
+  (Msg a LogLevel.Warning)  ;; print value of 1st arg passed
+  (Msg b LogLevel.Error)) ;; print value of 2nd arg passed
+
+(Msg "Hello World" LogLevel.Info) ;; prints string
+(msgshard "Bye" "Universe") ;; prints args passed

--- a/include/shardwrapper.hpp
+++ b/include/shardwrapper.hpp
@@ -104,13 +104,13 @@ template <class T> struct ShardWrapper {
         auto bw = reinterpret_cast<ShardWrapper<T> *>(b);
         bw->shard.destroy();
         bw->ShardWrapper<T>::~ShardWrapper<T>();
-        ::operator delete (bw, std::align_val_t{16});
+        ::operator delete(bw, std::align_val_t{16});
       });
     } else {
       result->destroy = static_cast<SHDestroyProc>([](Shard *b) {
         auto bw = reinterpret_cast<ShardWrapper<T> *>(b);
         bw->ShardWrapper<T>::~ShardWrapper<T>();
-        ::operator delete (bw, std::align_val_t{16});
+        ::operator delete(bw, std::align_val_t{16});
       });
     }
 

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -56,7 +56,9 @@ constexpr uint32_t crc32(std::string_view str) {
   return crc ^ 0xffffffff;
 }
 
-template <auto V> struct constant { constexpr static decltype(V) value = V; };
+template <auto V> struct constant {
+  constexpr static decltype(V) value = V;
+};
 
 inline SHOptionalString operator"" _optional(const char *s, size_t) { return SHOptionalString{s}; }
 

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -28,7 +28,11 @@ static COLOR_VAR_OR_NONE_SLICE: &[Type] = &[
   common_type::none,
 ];
 static FLOAT_VAR_SLICE: &[Type] = &[common_type::float, common_type::float_var];
-static FLOAT_VAR_OR_NONE_SLICE: &[Type] = &[common_type::float, common_type::float_var, common_type::none];
+static FLOAT_VAR_OR_NONE_SLICE: &[Type] = &[
+  common_type::float,
+  common_type::float_var,
+  common_type::none,
+];
 static FLOAT2_VAR_SLICE: &[Type] = &[common_type::float2, common_type::float2_var];
 static INT_VAR_OR_NONE_SLICE: &[Type] =
   &[common_type::int, common_type::int_var, common_type::none];

--- a/rust/src/shards/gui/widgets/mod.rs
+++ b/rust/src/shards/gui/widgets/mod.rs
@@ -74,7 +74,7 @@ struct Console {
   requiring: ExposedTypes,
   show_filters: ParamVar,
   style: ParamVar,
-  filters: (bool, bool, bool, bool, bool)
+  filters: (bool, bool, bool, bool, bool),
 }
 
 #[cfg(feature = "hex_viewer")]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -553,11 +553,11 @@ pub mod common_type {
   use crate::shardsc::SHType_Float4;
   use crate::shardsc::SHType_Image;
   use crate::shardsc::SHType_Int;
+  use crate::shardsc::SHType_Int16;
   use crate::shardsc::SHType_Int2;
   use crate::shardsc::SHType_Int3;
   use crate::shardsc::SHType_Int4;
   use crate::shardsc::SHType_Int8;
-  use crate::shardsc::SHType_Int16;
   use crate::shardsc::SHType_None;
   use crate::shardsc::SHType_Object;
   use crate::shardsc::SHType_Path;
@@ -4208,7 +4208,8 @@ pub static STRING_VAR_OR_NONE_SLICE: &[Type] = &[
 lazy_static! {
   pub static ref ANY_TYPES: Vec<Type> = vec![common_type::any];
   pub static ref ANYS_TYPES: Vec<Type> = vec![common_type::anys];
-  pub static ref ANY_TABLE_VAR_TYPES: Vec<Type> = vec![common_type::any_table, common_type::any_table_var];
+  pub static ref ANY_TABLE_VAR_TYPES: Vec<Type> =
+    vec![common_type::any_table, common_type::any_table_var];
   pub static ref NONE_TYPES: Vec<Type> = vec![common_type::none];
   pub static ref STRING_TYPES: Vec<Type> = vec![common_type::string];
   pub static ref STRINGS_TYPES: Vec<Type> = vec![common_type::strings];

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -2807,12 +2807,12 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
   sh_current_interface_loaded = true;
 
   result->alloc = [](uint32_t size) -> void * {
-    auto mem = ::operator new (size, std::align_val_t{16});
+    auto mem = ::operator new(size, std::align_val_t{16});
     memset(mem, 0, size);
     return mem;
   };
 
-  result->free = [](void *ptr) { ::operator delete (ptr, std::align_val_t{16}); };
+  result->free = [](void *ptr) { ::operator delete(ptr, std::align_val_t{16}); };
 
   result->registerShard = [](const char *fullName, SHShardConstructor constructor) noexcept {
     API_TRY_CALL(registerShard, shards::registerShard(fullName, constructor);)
@@ -2873,7 +2873,7 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
     auto sc = SHWire::sharedFromRef(wire);
     auto var = sc->externalVariables[name];
     if (var) {
-      ::operator delete (var, std::align_val_t{16});
+      ::operator delete(var, std::align_val_t{16});
     }
     sc->externalVariables.erase(name);
   };

--- a/src/core/shards/flow.cpp
+++ b/src/core/shards/flow.cpp
@@ -453,23 +453,14 @@ struct Maybe : public BaseSubFlow {
   SHVar activate(SHContext *context, const SHVar &input) {
     SHVar output = input;
     if (likely(_shards)) {
+      auto prev_level = spdlog::get_level();
       if (_silent) {
         spdlog::set_level(spdlog::level::off);
       }
-      DEFER({
-        if (_silent) {
-#ifdef NDEBUG
-#if (SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_DEBUG)
-          spdlog::set_level(spdlog::level::debug);
-#else
-          spdlog::set_level(spdlog::level::info);
-#endif
-#else
-          spdlog::set_level(spdlog::level::trace);
-#endif
-        }
-      });
       auto state = _shards.activate(context, input, output);
+      if (_silent) {
+        spdlog::set_level(prev_level);
+      }
       if (state == SHWireState::Error) {
         if (likely(!context->onLastResume)) {
           if (!_silent) {

--- a/src/core/shards/logging.hpp
+++ b/src/core/shards/logging.hpp
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+
+#ifndef SH_CORE_SHARDS_LOGGING
+#define SH_CORE_SHARDS_LOGGING
+
+#include "shared.hpp"
+
+namespace shards {
+struct Enums {
+  enum class LogLevel { Trace, Debug, Info, Warning, Error };
+  REGISTER_ENUM(LogLevel, 'logL'); // FourCC = 0x6C6F674C
+};
+}; // namespace shards
+
+#endif // SH_CORE_SHARDS_LOGGING

--- a/src/core/shards/math.hpp
+++ b/src/core/shards/math.hpp
@@ -510,7 +510,7 @@ MATH_BINARY_INT_OPERATION(Mod, %);
 MATH_BINARY_INT_OPERATION(LShift, <<);
 MATH_BINARY_INT_OPERATION(RShift, >>);
 
-#define MATH_UNARY_FLOAT_OPERATION(NAME, FUNC, FUNCF)                                         \
+#define MATH_UNARY_FLOAT_OPERATION(NAME, FUNC, FUNCF)                                   \
   struct NAME##Op final {                                                               \
     template <typename T> T apply(const T &lhs) { return FUNC(lhs); }                   \
   };                                                                                    \

--- a/src/core/shards/random.cpp
+++ b/src/core/shards/random.cpp
@@ -29,8 +29,8 @@ template <Type &OUTTYPE, SHType SHTYPE> struct Rand : public RandBase {
   SHExposedTypesInfo requiredVariables() {
     SHVar variable = _max;
     if (variable.valueType == ContextVar) {
-      _requiredInfo = ExposedInfo(
-          ExposedInfo::Variable(variable.payload.stringValue, SHCCSTR("The required variable."), OUTTYPE));
+      _requiredInfo =
+          ExposedInfo(ExposedInfo::Variable(variable.payload.stringValue, SHCCSTR("The required variable."), OUTTYPE));
       return SHExposedTypesInfo(_requiredInfo);
     }
     return {};

--- a/src/core/shards_macros.hpp
+++ b/src/core/shards_macros.hpp
@@ -23,7 +23,7 @@
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
       blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+      ::operator delete((_name_##Runtime *)shard, std::align_val_t{16});                                                 \
     });                                                                                                                  \
     result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
@@ -58,7 +58,7 @@
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
       blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+      ::operator delete((_name_##Runtime *)shard, std::align_val_t{16});                                                 \
     });                                                                                                                  \
     result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
@@ -95,7 +95,7 @@
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
       blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+      ::operator delete((_name_##Runtime *)shard, std::align_val_t{16});                                                 \
     });                                                                                                                  \
     result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
@@ -131,7 +131,7 @@
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
       blk->_name_##Runtime::~_name_##Runtime();                                                                          \
-      ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16});                                                \
+      ::operator delete((_name_##Runtime *)shard, std::align_val_t{16});                                                 \
     });                                                                                                                  \
     result->inputTypes = static_cast<SHInputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                      \
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
@@ -165,12 +165,12 @@
 
 #define RUNTIME_SHARD_setup(_name_) \
   result->setup = static_cast<SHSetupProc>([](Shard *shard) { reinterpret_cast<_name_##Runtime *>(shard)->core.setup(); });
-#define RUNTIME_SHARD_destroy(_name_)                                   \
-  result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {       \
-    auto blk = (_name_##Runtime *)shard;                                \
-    reinterpret_cast<_name_##Runtime *>(shard)->core.destroy();         \
-    blk->_name_##Runtime::~_name_##Runtime();                           \
-    ::operator delete ((_name_##Runtime *)shard, std::align_val_t{16}); \
+#define RUNTIME_SHARD_destroy(_name_)                                  \
+  result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {      \
+    auto blk = (_name_##Runtime *)shard;                               \
+    reinterpret_cast<_name_##Runtime *>(shard)->core.destroy();        \
+    blk->_name_##Runtime::~_name_##Runtime();                          \
+    ::operator delete((_name_##Runtime *)shard, std::align_val_t{16}); \
   });
 
 #define RUNTIME_SHARD_inputTypes(_name_) \

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -1800,14 +1800,30 @@ BUILTIN("context-var") {
 }
 
 template <SHType T> struct GetComponentType {};
-template <> struct GetComponentType<SHType::Float2> { typedef double Type; };
-template <> struct GetComponentType<SHType::Float3> { typedef float Type; };
-template <> struct GetComponentType<SHType::Float4> { typedef float Type; };
-template <> struct GetComponentType<SHType::Int2> { typedef int64_t Type; };
-template <> struct GetComponentType<SHType::Int3> { typedef int32_t Type; };
-template <> struct GetComponentType<SHType::Int4> { typedef int32_t Type; };
-template <> struct GetComponentType<SHType::Int8> { typedef int16_t Type; };
-template <> struct GetComponentType<SHType::Int16> { typedef int8_t Type; };
+template <> struct GetComponentType<SHType::Float2> {
+  typedef double Type;
+};
+template <> struct GetComponentType<SHType::Float3> {
+  typedef float Type;
+};
+template <> struct GetComponentType<SHType::Float4> {
+  typedef float Type;
+};
+template <> struct GetComponentType<SHType::Int2> {
+  typedef int64_t Type;
+};
+template <> struct GetComponentType<SHType::Int3> {
+  typedef int32_t Type;
+};
+template <> struct GetComponentType<SHType::Int4> {
+  typedef int32_t Type;
+};
+template <> struct GetComponentType<SHType::Int8> {
+  typedef int16_t Type;
+};
+template <> struct GetComponentType<SHType::Int16> {
+  typedef int8_t Type;
+};
 template <> struct GetComponentType<SHType::Color> {
   typedef uint8_t Type;
   static constexpr uint8_t getDefaultValue(size_t index) { return index == 3 ? 255 : 0; }


### PR DESCRIPTION
```clj
42 (Log "prefix") ; default LogLevel.Info
-1 (Log "ERROR" LogLevel.Error)

(Msg "Trace me" LogLevel.Trace)
(Msg "TODO" LogLevel.Debug)
(Msg "That's incorrect" :Level LogLevel.Warning)
```

In addition, logs are now displayed from `Maybe` else clause when silent:
```clj
; before
[0]
(Maybe
   (-> (Take 1))
   (-> (Msg "Cannot retrieve item at index 1"))
  :Silent true)
;; nothing displayed

; after
[0]
(Maybe
   (-> (Take 1))
   (-> (Msg "Cannot retrieve item at index 1" :Level LogLevel.Error)
  :Silent true)
;; [error] [2022-11-18 14:48:26.889] [T-33400] [logging.cpp::101] [main-wire] Cannot retrieve item at index 1
```