### PR TITLE
Propagate Do failures

### DIFF
--- a/src/tests/failures.clj
+++ b/src/tests/failures.clj
@@ -139,3 +139,12 @@
 
 (schedule Root short-wire)
 (if (run Root 0.2 25) (throw "Failure expected") nil)
+
+; Failure from Do should propagate to main wire
+(defwire do-inner
+  "Intentional fail" (Fail))
+(defwire do-outer
+  (Do do-inner)
+  true (Assert.Is false))
+(schedule Root do-outer)
+(if (run Root 0.2 25) (throw "Failure expected from Do") nil)

--- a/src/tests/flows.edn
+++ b/src/tests/flows.edn
@@ -258,38 +258,6 @@
 
 (if (run Root 0.1) nil (throw "Root tick failed"))
 
-(if (hasShard? "Http.Post")
-  (do
-    (defwire upload-to-ipfs
-      (let [boundary "----SH-IPFS-Upload-0xC0FFEE"
-            gateways ["https://ipfs.infura.io:5001"
-                      "https://ipfs.komputing.org"
-                      "http://hasten-ipfs.local:5001"
-                      "http://127.0.0.1:5001"]]
-        (->
-         >= .payload
-         (str "--" boundary "\r\nContent-Disposition: form-data; name=\"path\"\r\nContent-Type: application/octet-stream\r\n\r\n")
-         (PrependTo .payload)
-         (str "\r\n--" boundary "--")
-         (AppendTo .payload)
-         gateways
-         (TryMany (Wire "IPFS-Upload"
-                        >= .gateway
-                        "/api/v0/add?pin=true" (AppendTo .gateway)
-                        .payload
-                        (Http.Post .gateway
-                                   :Headers {"Content-Type" (str "multipart/form-data; boundary=" boundary)}))
-                  :Policy WaitUntil.SomeSuccess)
-         (Take 0) (FromJson) (ExpectTable)
-         (Take "Hash") (ExpectString)
-         (Assert.Is "QmNRCQWfgze6AbBCaT1rkrkV5tJ2aP4oTNPb5JZcXYywve" true))))
-
-    (defwire test-ipfs
-      "Hello world" (Do upload-to-ipfs) (Log "ipfs hash"))
-
-    (schedule Root test-ipfs)
-    (if (run Root 0.1) nil (throw "Root tick failed"))))
-
 (defwire hashed
   10
   (|#

--- a/src/tests/ipfs.edn
+++ b/src/tests/ipfs.edn
@@ -1,0 +1,33 @@
+(defmesh Root)
+
+(if (hasShard? "Http.Post")
+  (do
+    (defwire upload-to-ipfs
+      (let [boundary "----SH-IPFS-Upload-0xC0FFEE"
+            gateways ["https://ipfs.infura.io:5001"
+                      "https://ipfs.komputing.org"
+                      "http://hasten-ipfs.local:5001"
+                      "http://127.0.0.1:5001"]]
+        (->
+         >= .payload
+         (str "--" boundary "\r\nContent-Disposition: form-data; name=\"path\"\r\nContent-Type: application/octet-stream\r\n\r\n")
+         (PrependTo .payload)
+         (str "\r\n--" boundary "--")
+         (AppendTo .payload)
+         gateways
+         (TryMany (Wire "IPFS-Upload"
+                        >= .gateway
+                        "/api/v0/add?pin=true" (AppendTo .gateway)
+                        .payload
+                        (Http.Post .gateway
+                                   :Headers {"Content-Type" (str "multipart/form-data; boundary=" boundary)}))
+                  :Policy WaitUntil.SomeSuccess)
+         (Take 0) (FromJson) (ExpectTable)
+         (Take "Hash") (ExpectString)
+         (Assert.Is "QmNRCQWfgze6AbBCaT1rkrkV5tJ2aP4oTNPb5JZcXYywve" true))))
+
+    (defwire test-ipfs
+      "Hello world" (Do upload-to-ipfs) (Log "ipfs hash"))
+
+    (schedule Root test-ipfs)
+    (if (run Root 0.1) nil (throw "Root tick failed"))))


### PR DESCRIPTION
Changed Do behaviour to propagate failures to the parent wire

Due to this I uncovered a failure in an IPFS upload in flows.edn, moved it out of there for now.