### PR TITLE
UI tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_dock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37e5eba9330fb607e0fcb8dae0b6ed0ea23d3645841cc53b8ead5d544600486"
+dependencies = [
+ "egui",
+]
+
+[[package]]
 name = "egui_extras"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3340,7 @@ dependencies = [
  "egui",
  "egui-gfx",
  "egui_commonmark",
+ "egui_dock",
  "egui_extras",
  "egui_memory_editor",
  "enum-map",

--- a/docs/samples/shards/UI/DockArea/1.edn
+++ b/docs/samples/shards/UI/DockArea/1.edn
@@ -1,0 +1,23 @@
+(GFX.MainWindow
+ :Contents
+ (->
+  (Setup
+   (GFX.DrawQueue) >= .ui-draw-queue
+   (GFX.UIPass .ui-draw-queue) >> .render-steps)
+  .ui-draw-queue (GFX.ClearQueue)
+
+  (UI
+   .ui-draw-queue
+   (UI.DockArea
+    :Contents
+    (->
+     (UI.Tab
+      :Title "Tab 1"
+      :Contents
+      (-> "Tab 1 contents" (UI.Label)))
+     (UI.Tab
+      :Title "Tab 2"
+      :Contents
+      (-> "Tab 2 contents" (UI.Label))))))
+
+  (GFX.Render :Steps .render-steps)))

--- a/docs/samples/shards/UI/Tab/1.edn
+++ b/docs/samples/shards/UI/Tab/1.edn
@@ -1,0 +1,23 @@
+(GFX.MainWindow
+ :Contents
+ (->
+  (Setup
+   (GFX.DrawQueue) >= .ui-draw-queue
+   (GFX.UIPass .ui-draw-queue) >> .render-steps)
+  .ui-draw-queue (GFX.ClearQueue)
+
+  (UI
+   .ui-draw-queue
+   (UI.DockArea
+    :Contents
+    (->
+     (UI.Tab
+      :Title "Tab 1"
+      :Contents
+      (-> "Tab 1 contents" (UI.Label)))
+     (UI.Tab
+      :Title "Tab 2"
+      :Contents
+      (-> "Tab 2 contents" (UI.Label))))))
+
+  (GFX.Render :Steps .render-steps)))

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,6 +43,7 @@ chrono = { version = "0.4", optional = true }
 chacha20poly1305 = { version = "0.9.0", optional = true }
 egui = { version = "0.20.1", optional = true }
 egui_commonmark = { version = "0.6.0", optional = true }
+egui_dock = { version = "0.3.0", optional = true }
 egui_extras = { version = "0.20.0", optional = true }
 egui-gfx = { path = "../src/gfx/egui", optional = true }
 egui_memory_editor = { version = "0.2.2", optional = true }
@@ -89,13 +90,14 @@ shards = ["reqwest",
           "chacha20poly1305",
           "chrono",
           "egui",
+          "egui_commonmark",
+          "egui_dock",
           "egui_extras",
           "egui-gfx",
           "code_editor",
           "hex_viewer",
           "tract-onnx",
-          "enum-map",
-          "egui_commonmark"]
+          "enum-map"]
 code_editor = ["syntect", "egui_commonmark/syntax_highlighting"]
 hex_viewer = ["egui_memory_editor"]
 dllshard = ["dlopen"]

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -171,10 +171,12 @@ pub fn logLevel(level: i32, s: &str) {
 #[cfg(debug_assertions)]
 macro_rules! shlog_debug {
   ($text:expr, $($arg:expr),*) => {
+    {
       use std::io::Write as __stdWrite;
       let mut buf = vec![];
       ::std::write!(&mut buf, concat!($text, "\0"), $($arg),*).unwrap();
       $crate::core::logLevel(1, ::std::str::from_utf8(&buf).unwrap());
+    }
   };
 
   ($text:expr) => {
@@ -193,10 +195,12 @@ macro_rules! shlog_debug {
 #[macro_export]
 macro_rules! shlog {
     ($text:expr, $($arg:expr),*) => {
+      {
         use std::io::Write as __stdWrite;
         let mut buf = vec![];
         ::std::write!(&mut buf, concat!($text, "\0"), $($arg),*).unwrap();
         $crate::core::log(::std::str::from_utf8(&buf).unwrap());
+      }
     };
 
     ($text:expr) => {
@@ -207,10 +211,12 @@ macro_rules! shlog {
 #[macro_export]
 macro_rules! shlog_error {
   ($text:expr, $($arg:expr),*) => {
-    use std::io::Write as __stdWrite;
-    let mut buf = vec![];
-    ::std::write!(&mut buf, concat!($text, "\0"), $($arg),*).unwrap();
-    $crate::core::logLevel(4, ::std::str::from_utf8(&buf).unwrap());
+    {
+      use std::io::Write as __stdWrite;
+      let mut buf = vec![];
+      ::std::write!(&mut buf, concat!($text, "\0"), $($arg),*).unwrap();
+      $crate::core::logLevel(4, ::std::str::from_utf8(&buf).unwrap());
+    }
   };
 
   ($text:expr) => {

--- a/rust/src/shards/gui/containers/docking.rs
+++ b/rust/src/shards/gui/containers/docking.rs
@@ -1,0 +1,460 @@
+use super::DockArea;
+use super::Tab;
+use crate::core::registerShard;
+use crate::shard::Shard;
+use crate::shards::gui::util;
+use crate::shards::gui::CONTEXTS_NAME;
+use crate::shards::gui::EGUI_CTX_TYPE;
+use crate::shards::gui::PARENTS_UI_NAME;
+use crate::types::Context;
+use crate::types::ExposedInfo;
+use crate::types::ExposedTypes;
+use crate::types::InstanceData;
+use crate::types::OptionalString;
+use crate::types::ParamVar;
+use crate::types::Parameters;
+use crate::types::Seq;
+use crate::types::ShardRef;
+use crate::types::ShardsVar;
+use crate::types::Type;
+use crate::types::Types;
+use crate::types::Var;
+use crate::types::ANY_TYPES;
+use crate::types::SEQ_OF_SHARDS_TYPES;
+use crate::types::SHARDS_OR_NONE_TYPES;
+use crate::types::STRING_TYPES;
+
+const TAB_NAME: &'static str = "UI.Tab";
+
+lazy_static! {
+  static ref TAB_PARAMETERS: Parameters = vec![
+    (
+      cstr!("Title"),
+      cstr!("The title of the tab."),
+      &STRING_TYPES[..],
+    )
+      .into(),
+    (
+      cstr!("Contents"),
+      cstr!("The UI contents."),
+      &SHARDS_OR_NONE_TYPES[..],
+    )
+      .into(),
+  ];
+  static ref DOCKAREA_PARAMETERS: Parameters = vec![
+    (
+      cstr!("Contents"),
+      cstr!("The UI contents containing tabs."),
+      &SHARDS_OR_NONE_TYPES[..],
+    )
+      .into(),
+  ];
+}
+
+impl Default for Tab {
+  fn default() -> Self {
+    let mut parents = ParamVar::default();
+    parents.set_name(PARENTS_UI_NAME);
+    Self {
+      parents,
+      requiring: Vec::new(),
+      title: ParamVar::default(),
+      contents: ShardsVar::default(),
+      exposing: Vec::new(),
+    }
+  }
+}
+
+impl Shard for Tab {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.Tab")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.Tab-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    TAB_NAME
+  }
+
+  fn help(&mut self) -> OptionalString {
+    OptionalString(shccstr!("Represents a tab inside a DockArea."))
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn inputHelp(&mut self) -> OptionalString {
+    OptionalString(shccstr!(
+      "The value that will be passed to the Contents shards of the tab."
+    ))
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn outputHelp(&mut self) -> OptionalString {
+    OptionalString(shccstr!("The output of this shard will be its input."))
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&TAB_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => Ok(self.title.set_param(value)),
+      1 => self.contents.set_param(value),
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.title.get_param(),
+      1 => self.contents.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.Parents to the list of required variables
+    util::require_parents(&mut self.requiring, &self.parents);
+
+    Some(&self.requiring)
+  }
+
+  fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
+    self.exposing.clear();
+
+    if util::expose_contents_variables(&mut self.exposing, &self.contents) {
+      Some(&self.exposing)
+    } else {
+      None
+    }
+  }
+
+  fn hasCompose() -> bool {
+    true
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    if !self.contents.is_empty() {
+      self.contents.compose(&data)?;
+    }
+
+    // Always passthrough the input
+    Ok(data.inputType)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.parents.warmup(ctx);
+    self.title.warmup(ctx);
+    if !self.contents.is_empty() {
+      self.contents.warmup(ctx)?;
+    }
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    if !self.contents.is_empty() {
+      self.contents.cleanup();
+    }
+    self.title.cleanup();
+    self.parents.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
+    if self.contents.is_empty() {
+      // no contents, same as inactive
+      return Ok(false.into());
+    }
+
+    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+      util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)?;
+
+      // Always passthrough the input
+      Ok(*input)
+    } else {
+      Err("No UI parent")
+    }
+  }
+}
+
+impl Default for DockArea {
+  fn default() -> Self {
+    let mut ctx = ParamVar::default();
+    ctx.set_name(CONTEXTS_NAME);
+    let mut parents = ParamVar::default();
+    parents.set_name(PARENTS_UI_NAME);
+    Self {
+      instance: ctx,
+      requiring: Vec::new(),
+      contents: ParamVar::default(),
+      parents,
+      exposing: Vec::new(),
+      headers: Vec::new(),
+      shards: Vec::new(),
+      tabs: egui_dock::Tree::new(Vec::new()),
+    }
+  }
+}
+
+impl Shard for DockArea {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.DockArea")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.DockArea-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "UI.DockArea"
+  }
+
+  fn help(&mut self) -> OptionalString {
+    OptionalString(shccstr!("TODO."))
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn inputHelp(&mut self) -> OptionalString {
+    OptionalString(shccstr!("TODO."))
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn outputHelp(&mut self) -> OptionalString {
+    OptionalString(shccstr!("TODO."))
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&DOCKAREA_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => {
+        let seq = Seq::try_from(value)?;
+        for tab_spec in seq.iter().rev().filter_map(|s| {
+          if let Ok(r) = ShardRef::try_from(s) {
+            if r.name() == TAB_NAME {
+              let mut title = ParamVar::default();
+              title.set_param(&r.get_parameter(0));
+              let mut shard = ShardsVar::default();
+              match shard.set_param(&s) {
+                Ok(_) => Some(Ok((title, shard))),
+                Err(err) => Some(Err(err)),
+              }
+            } else {
+              None
+            }
+          } else {
+            None
+          }
+        }) {
+          let (title, contents) = tab_spec?;
+          self.headers.push(title);
+          self.shards.push(contents);
+        }
+
+        Ok(self.contents.set_param(value))
+      }
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.contents.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.Contexts to the list of required variables
+    let exp_info = ExposedInfo {
+      exposedType: EGUI_CTX_TYPE,
+      name: self.instance.get_name(),
+      help: cstr!("The exposed UI context.").into(),
+      ..ExposedInfo::default()
+    };
+    self.requiring.push(exp_info);
+
+    Some(&self.requiring)
+  }
+
+  fn exposedVariables(&mut self) -> Option<&ExposedTypes> {
+    self.exposing.clear();
+
+    let mut exposed = false;
+    for s in &self.shards {
+      exposed |= util::expose_contents_variables(&mut self.exposing, s);
+    }
+    if exposed {
+      Some(&self.exposing)
+    } else {
+      None
+    }
+  }
+
+  fn hasCompose() -> bool {
+    true
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    for s in &mut self.shards {
+      s.compose(data)?;
+    }
+
+    // Always passthrough the input
+    Ok(data.inputType)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.instance.warmup(ctx);
+    self.parents.warmup(ctx);
+    self.contents.warmup(ctx);
+
+    for s in &self.shards {
+      s.warmup(ctx).unwrap();
+    }
+    for s in self.headers.as_mut_slice() {
+      s.warmup(ctx);
+    }
+
+    for _ in 0..self.shards.len() {
+      if let (Some(h), Some(s)) = (self.headers.pop(), self.shards.pop()) {
+        self.tabs.push_to_first_leaf((h, s));
+      }
+    }
+
+    // Focus on first tab
+    if !self.tabs.is_empty() {
+      self.tabs.set_active_tab(0.into(), 0.into());
+    }
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self
+      .tabs
+      .iter_mut()
+      .filter_map(|node| match node {
+        egui_dock::Node::Leaf {
+          rect: _,
+          viewport: _,
+          tabs,
+          active: _,
+        } => Some(tabs),
+        _ => None,
+      })
+      .flatten()
+      .for_each(|(title, contents)| {
+        title.cleanup();
+        contents.cleanup();
+      });
+
+    self.contents.cleanup();
+    self.parents.cleanup();
+    self.instance.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
+    if self.tabs.is_empty() {
+      return Ok(*input);
+    }
+
+    let gui_ctx = util::get_current_context(&self.instance)?;
+    let mut style = egui_dock::Style::from_egui(gui_ctx.style().as_ref());
+    style.show_close_buttons = false;
+
+    let dock = egui_dock::DockArea::new(&mut self.tabs).style(style);
+
+    let parents_stack_var = *self.parents.get();
+    let mut viewer = MyTabViewer::new(context, input);
+    viewer.warmup();
+    if let Some(ui) = util::get_current_parent(parents_stack_var)? {
+      dock.show_inside(ui, &mut viewer);
+    } else {
+      dock.show(gui_ctx, &mut viewer);
+    }
+    viewer.cleanup();
+
+    // Always passthrough the input
+    Ok(*input)
+  }
+}
+
+pub fn registerShards() {
+  registerShard::<DockArea>();
+  registerShard::<Tab>();
+}
+
+struct MyTabViewer<'a> {
+  context: &'a Context,
+  input: &'a Var,
+  parents: ParamVar,
+}
+
+impl<'a> MyTabViewer<'a> {
+  pub fn new(context: &'a Context, input: &'a Var) -> MyTabViewer<'a> {
+    let mut parents = ParamVar::default();
+    parents.set_name(PARENTS_UI_NAME);
+    Self {
+      context,
+      input,
+      parents,
+    }
+  }
+
+  pub fn warmup(&mut self) {
+    self.parents.warmup(self.context);
+  }
+
+  pub fn cleanup(&mut self) {
+    self.parents.cleanup();
+  }
+}
+
+impl<'a> egui_dock::TabViewer for MyTabViewer<'a> {
+  type Tab = (ParamVar, ShardsVar);
+
+  fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+    util::activate_ui_contents(self.context, self.input, ui, &mut self.parents, &tab.1).unwrap();
+  }
+
+  fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+    tab.0.get().try_into().unwrap_or("").into()
+  }
+}

--- a/rust/src/shards/gui/containers/docking.rs
+++ b/rust/src/shards/gui/containers/docking.rs
@@ -41,14 +41,12 @@ lazy_static! {
     )
       .into(),
   ];
-  static ref DOCKAREA_PARAMETERS: Parameters = vec![
-    (
-      cstr!("Contents"),
-      cstr!("The UI contents containing tabs."),
-      &SHARDS_OR_NONE_TYPES[..],
-    )
-      .into(),
-  ];
+  static ref DOCKAREA_PARAMETERS: Parameters = vec![(
+    cstr!("Contents"),
+    cstr!("The UI contents containing tabs."),
+    &SHARDS_OR_NONE_TYPES[..],
+  )
+    .into(),];
 }
 
 impl Default for Tab {
@@ -261,14 +259,14 @@ impl Shard for DockArea {
     match index {
       0 => {
         let seq = Seq::try_from(value)?;
-        for tab_spec in seq.iter().rev().filter_map(|s| {
+        let tab_specs = seq.iter().rev().filter_map(|s| {
           if let Ok(r) = ShardRef::try_from(s) {
             if r.name() == TAB_NAME {
               let mut title = ParamVar::default();
               title.set_param(&r.get_parameter(0));
-              let mut shard = ShardsVar::default();
-              match shard.set_param(&s) {
-                Ok(_) => Some(Ok((title, shard))),
+              let mut contents = ShardsVar::default();
+              match contents.set_param(&s) {
+                Ok(_) => Some(Ok((title, contents))),
                 Err(err) => Some(Err(err)),
               }
             } else {
@@ -277,7 +275,8 @@ impl Shard for DockArea {
           } else {
             None
           }
-        }) {
+        });
+        for tab_spec in tab_specs {
           let (title, contents) = tab_spec?;
           self.headers.push(title);
           self.shards.push(contents);

--- a/rust/src/shards/gui/containers/mod.rs
+++ b/rust/src/shards/gui/containers/mod.rs
@@ -8,6 +8,7 @@ use crate::types::ExposedTypes;
 use crate::types::ParamVar;
 use crate::types::ShardsVar;
 use crate::types::Type;
+use crate::types::Var;
 use crate::types::FRAG_CC;
 
 struct Area {
@@ -46,9 +47,28 @@ shenum_types! {
   static ref SEQ_OF_ANCHOR_TYPES: Vec<Type>;
 }
 
+struct DockArea {
+  instance: ParamVar,
+  requiring: ExposedTypes,
+  contents: ParamVar,
+  parents: ParamVar,
+  exposing: ExposedTypes,
+  headers: Vec<ParamVar>,
+  shards: Vec<ShardsVar>,
+  tabs: egui_dock::Tree<(ParamVar, ShardsVar)>
+}
+
 struct Scope {
   parents: ParamVar,
   requiring: ExposedTypes,
+  contents: ShardsVar,
+  exposing: ExposedTypes,
+}
+
+struct Tab {
+  parents: ParamVar,
+  requiring: ExposedTypes,
+  title: ParamVar,
   contents: ShardsVar,
   exposing: ExposedTypes,
 }
@@ -117,6 +137,7 @@ struct CentralPanel {
 }
 
 mod area;
+mod docking;
 mod panels;
 mod scope;
 mod window;
@@ -124,6 +145,7 @@ mod window;
 pub fn registerShards() {
   registerShard::<Area>();
   registerEnumType(FRAG_CC, AnchorCC, AnchorEnumInfo.as_ref().into());
+  docking::registerShards();
   registerShard::<Scope>();
   registerShard::<Window>();
   registerEnumType(FRAG_CC, WindowFlagsCC, WindowFlagsEnumInfo.as_ref().into());

--- a/rust/src/shards/gui/containers/mod.rs
+++ b/rust/src/shards/gui/containers/mod.rs
@@ -55,7 +55,7 @@ struct DockArea {
   exposing: ExposedTypes,
   headers: Vec<ParamVar>,
   shards: Vec<ShardsVar>,
-  tabs: egui_dock::Tree<(ParamVar, ShardsVar)>
+  tabs: egui_dock::Tree<(ParamVar, ShardsVar)>,
 }
 
 struct Scope {

--- a/rust/src/shards/gui/layouts/columns.rs
+++ b/rust/src/shards/gui/layouts/columns.rs
@@ -94,7 +94,7 @@ impl Shard for Columns {
         let seq = Seq::try_from(value)?;
         for shard in seq.iter() {
           let mut s = ShardsVar::default();
-          s.set_param(&shard).unwrap();
+          s.set_param(&shard)?;
           self.shards.push(s);
         }
         Ok(self.contents.set_param(value))

--- a/rust/src/shards/gui/layouts/table.rs
+++ b/rust/src/shards/gui/layouts/table.rs
@@ -141,7 +141,7 @@ impl Shard for Table {
         let seq = Seq::try_from(value)?;
         for shard in seq.iter() {
           let mut s = ShardsVar::default();
-          s.set_param(&shard).unwrap();
+          s.set_param(&shard)?;
           self.shards.push(s);
         }
         Ok(self.rows.set_param(value))
@@ -157,7 +157,7 @@ impl Shard for Table {
               }
               SHType_ShardRef | SHType_Seq => {
                 let mut s = ShardsVar::default();
-                s.set_param(&header).unwrap();
+                s.set_param(&header)?;
                 self.header_shards.push(Some(s));
               }
               _ => unreachable!(),

--- a/rust/src/shards/gui/util.rs
+++ b/rust/src/shards/gui/util.rs
@@ -58,7 +58,7 @@ pub(crate) fn activate_ui_contents<'a>(
   input: &Var,
   ui: &mut egui::Ui,
   parents_stack_var: &mut ParamVar,
-  contents: &mut ShardsVar,
+  contents: &ShardsVar,
 ) -> Result<Var, &'a str> {
   let mut output = Var::default();
 


### PR DESCRIPTION
Adds `(UI.DockArea)` and `(UI.Tab)`.

It works a bit differently than other UI shards: it is the parent (i.e. `UI.DockArea`) that collects the tabs so that they are all known before the first activate. This design is due to how the underlying `egui_dock` library works. It might change later if we add more layouting options ; for now, all tabs start aligned on a single tab row.

**Example**

```clj
(UI.DockArea
 :Contents
 (->
  (UI.Tab
   :Title "Tab 1"
   :Contents (-> "Tab 1 contents" (UI.Label)))
  (UI.Tab
   :Title "Tab 2"
   :Contents (-> "Tab 2 contents" (UI.Label)))
  (UI.Tab
   :Title "Tab 3"
   :Contents (-> "Tab 3 contents" (UI.Label)))
  (UI.Tab
   :Title "Tab 4"
   :Contents (-> "Tab 4 contents" (UI.Label)))))
```

![tabs_2](https://user-images.githubusercontent.com/3006525/210363873-701f2443-c755-442d-844d-1764751a5a56.gif)
