### PR TITLE
MainWindow compose stack size

### DIFF
--- a/src/extra/gfx/main_window.cpp
+++ b/src/extra/gfx/main_window.cpp
@@ -85,6 +85,9 @@ struct MainWindow : public Base {
   }
 
   SHTypeInfo compose(SHInstanceData &data) {
+    // Require extra stack space for the wire containing the main window
+    data.wire->stackSize = std::max<size_t>(data.wire->stackSize, 4 * 1024 * 1024);
+
     if (data.onWorkerThread) {
       throw ComposeError("GFX Shards cannot be used on a worker thread (e.g. "
                          "within an Await shard)");


### PR DESCRIPTION
Easy enough, since wire is already exposed during compose, I can just extend the stack size.