### PR TITLE
Documentation: enums

### DIFF
--- a/docs/generate.edn
+++ b/docs/generate.edn
@@ -30,6 +30,33 @@
     .f (ToString))
    true))
 
+(defn print-type-info [buffer]
+  (-> (ExpectTable)
+      (| (Take "name") (ExpectString) >= .p_type_name)
+      (| (Take "type") (ExpectInt) >= .p_type_type)
+      "[`" >> buffer .p_type_name >> buffer "`](" >> buffer
+      .p_type_type
+      (Match
+       [2; Enum
+        (-> "../../../enums/" >> buffer
+            .p_type_name >> buffer)
+        15 ; ShardRef
+        (-> "../../types/#shard" >> buffer)
+        54 ; ContextVar
+        (-> "../../types/#contextvar" >> buffer)
+        56 ; Seq
+        (-> "../../types/#seq" >> buffer)
+        57 ; Table
+        (-> "../../types/#table" >> buffer)
+        59 ; Object
+        (-> "../../types/#object" >> buffer)
+        61 ; Set
+        (-> "../../types/#set" >> buffer)
+        nil
+        (-> "../../types/#" >> buffer
+            .p_type_name (String.ToLower) >> buffer)])
+      ")" >> buffer))
+
 ;; dumps the generated content to the final file
 (defn dump-shard [name]
   (Wire
@@ -62,12 +89,14 @@
    "|------|---------------------|-------------|---------|------|\r\n" >> .o
 
    "| `<input>` ||" >> .o
-   .inputHelp >> .o " | " >> .o "| `" >> .o
-   .inputTypes >> .o "` |\r\n" >> .o
+   .inputHelp >> .o " | " >> .o "| " >> .o
+   .inputTypes (ForEach (print-type-info .o))
+   " |\r\n" >> .o
 
    "| `<output>` ||" >> .o
-   .outputHelp >> .o " | " >> .o "| `" >> .o
-   .outputTypes >> .o "` |\r\n" >> .o
+   .outputHelp >> .o " | " >> .o "| " >> .o
+   .outputTypes (ForEach (print-type-info .o))
+   " |\r\n" >> .o
 
    (When
     (-> (Count .parameters) (IsMore 0))
@@ -76,7 +105,7 @@
      (ForEach
       (-> (ExpectTable)
           (| (Take "name") >= .p_name)
-          (| (Take "types") >= .p_types)
+          (| (Take "types") >= (ExpectSeq) .p_types)
           (| (Take "help") >= .p_help)
           (| (Take "default") >= .p_default)
           (| (Take "optional") (ExpectBool) >= .p_optional)
@@ -86,8 +115,9 @@
                           (-> "` | " >> .o))
           " | " >> .o .p_help >> .o
           " | `" >> .o .p_default >> .o
-          "` | `" >> .o .p_types >> .o
-          "` |\r\n" >> .o))))
+          "` | " >> .o
+          .p_types (ForEach (print-type-info .o))
+          " |\r\n" >> .o))))
 
    "\r\n</div>\r\n" >> .o
    "\r\n" >> .o

--- a/rust/src/shards/gui/containers/mod.rs
+++ b/rust/src/shards/gui/containers/mod.rs
@@ -23,23 +23,23 @@ struct Area {
 
 shenum! {
   struct Anchor {
-    [description("")]
+    [description("Top left corner.")]
     const TopLeft = 0x00;
-    [description("")]
+    [description("Middle left.")]
     const Left = 0x10;
-    [description("")]
+    [description("Bottom left corner.")]
     const BottomLeft = 0x20;
-    [description("")]
+    [description("Top middle.")]
     const Top = 0x01;
-    [description("")]
+    [description("Center.")]
     const Center = 0x11;
-    [description("")]
+    [description("Bottom middle.")]
     const Bottom = 0x21;
-    [description("")]
+    [description("Top right corner.")]
     const TopRight = 0x02;
-    [description("")]
+    [description("Middle right.")]
     const Right = 0x12;
-    [description("")]
+    [description("Bottom right corner.")]
     const BottomRight = 0x22;
   }
 
@@ -98,13 +98,13 @@ struct Window {
 
 shenum! {
   struct WindowFlags {
-    [description("")]
+    [description("Do not display the title bar.")]
     const NoTitleBar = 1 << 0;
-    [description("")]
+    [description("Do not allow resizing the window.")]
     const NoResize = 1 << 1;
-    [description("")]
+    [description("Do not display scrollbars.")]
     const NoScrollbars = 1 << 2;
-    [description("")]
+    [description("Do not display the collapse button.")]
     const NoCollapse = 1 << 3;
   }
   struct WindowFlagsInfo {}

--- a/rust/src/shards/gui/containers/mod.rs
+++ b/rust/src/shards/gui/containers/mod.rs
@@ -23,14 +23,23 @@ struct Area {
 
 shenum! {
   struct Anchor {
+    [description("")]
     const TopLeft = 0x00;
+    [description("")]
     const Left = 0x10;
+    [description("")]
     const BottomLeft = 0x20;
+    [description("")]
     const Top = 0x01;
+    [description("")]
     const Center = 0x11;
+    [description("")]
     const Bottom = 0x21;
+    [description("")]
     const TopRight = 0x02;
+    [description("")]
     const Right = 0x12;
+    [description("")]
     const BottomRight = 0x22;
   }
 
@@ -89,9 +98,13 @@ struct Window {
 
 shenum! {
   struct WindowFlags {
+    [description("")]
     const NoTitleBar = 1 << 0;
+    [description("")]
     const NoResize = 1 << 1;
+    [description("")]
     const NoScrollbars = 1 << 2;
+    [description("")]
     const NoCollapse = 1 << 3;
   }
   struct WindowFlagsInfo {}

--- a/rust/src/shards/gui/properties.rs
+++ b/rust/src/shards/gui/properties.rs
@@ -27,6 +27,7 @@ use crate::SHType_Enum;
 
 shenum! {
   struct UIProperty {
+    [description("")]
     const RemainingSpace = 0x0;
   }
   struct UIPropertyInfo {}

--- a/rust/src/shards/gui/properties.rs
+++ b/rust/src/shards/gui/properties.rs
@@ -27,7 +27,7 @@ use crate::SHType_Enum;
 
 shenum! {
   struct UIProperty {
-    [description("")]
+    [description("Return the remaining space within an UI widget.")]
     const RemainingSpace = 0x0;
   }
   struct UIPropertyInfo {}

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -49,25 +49,25 @@ struct PlotLine {
 
 shenum! {
   struct MarkerShape {
-    [description("")]
+    [description("Display a point as a circle.")]
     const Circle = 0;
-    [description("")]
+    [description("Display a point as a diamond.")]
     const Diamond = 1;
-    [description("")]
+    [description("Display a point as a square.")]
     const Square = 2;
-    [description("")]
+    [description("Display a point as a cross.")]
     const Cross = 3;
-    [description("")]
+    [description("Display a point as a plus sign.")]
     const Plus = 4;
-    [description("")]
+    [description("Display a point as an arrow pointing upwards.")]
     const Up = 5;
-    [description("")]
+    [description("Display a point as an arrow pointing downwards.")]
     const Down = 6;
-    [description("")]
+    [description("Display a point as an arrow pointing to the left.")]
     const Left = 7;
-    [description("")]
+    [description("Display a point as an arrow pointing to the right.")]
     const Right = 8;
-    [description("")]
+    [description("Display a point as an asterisk.")]
     const Asterisk = 9;
   }
   struct MarkerShapeInfo {}

--- a/rust/src/shards/gui/widgets/plots/mod.rs
+++ b/rust/src/shards/gui/widgets/plots/mod.rs
@@ -49,15 +49,25 @@ struct PlotLine {
 
 shenum! {
   struct MarkerShape {
+    [description("")]
     const Circle = 0;
+    [description("")]
     const Diamond = 1;
+    [description("")]
     const Square = 2;
+    [description("")]
     const Cross = 3;
+    [description("")]
     const Plus = 4;
+    [description("")]
     const Up = 5;
+    [description("")]
     const Down = 6;
+    [description("")]
     const Left = 7;
+    [description("")]
     const Right = 8;
+    [description("")]
     const Asterisk = 9;
   }
   struct MarkerShapeInfo {}

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3460,6 +3460,7 @@ macro_rules! shenum {
     $(#[$outer:meta])*
     $vis:vis struct $SHEnum:ident {
       $(
+        [description($desc:literal)]
         $(#[$inner:ident $($args:tt)*])*
         const $EnumValue:ident = $value:expr;
       )+
@@ -3484,6 +3485,7 @@ macro_rules! shenum {
     __impl_shenuminfo! {
       $SHEnum {
         $(
+          [description($desc)]
           $(#[$inner $($args)*])*
           $EnumValue = $value;
         )*
@@ -3536,6 +3538,7 @@ macro_rules! __impl_shenuminfo {
   (
     $SHEnum:ident {
       $(
+        [description($desc:literal)]
         $(#[$attr:ident $($args:tt)*])*
         $EnumValue:ident = $value:expr;
       )*
@@ -3560,11 +3563,9 @@ macro_rules! __impl_shenuminfo {
         )*
 
         let mut descriptions = $crate::types::OptionalStrings::new();
-        for _ in 0..labels.len() {
-          descriptions.push($crate::types::OptionalString(shccstr!("")));
-        }
-        // $(
-        // )*
+        $(
+          descriptions.push($crate::types::OptionalString(shccstr!($desc)));
+        )*
 
         Self {
           name: cstr!(std::stringify!($SHEnum)),

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -2109,10 +2109,8 @@ BUILTIN("shard-info") {
     for (uint32_t i = 0; i < params.len; i++) {
       malHash::Map pmap;
       pmap[":name"] = mal::string(params.elements[i].name);
-      if (params.elements[i].help.string)
-        pmap[":help"] = mal::string(params.elements[i].help.string);
-      else
-        pmap[":help"] = mal::string(getString(params.elements[i].help.crc));
+      auto &help = params.elements[i].help;
+      pmap[":help"] = mal::string(help.string ? help.string : getString(help.crc));
       std::stringstream ss;
       docsFormatter.format(ss, params.elements[i].valueTypes);
       pmap[":types"] = mal::string(ss.str());


### PR DESCRIPTION
**Description**
Automatically create links to the corresponding enum description page from the API pages.

Also support writing the enum description in rust code.

**Syntax**
```rust
shenum! {
  struct UIProperty {
    [description("Returns the remaining space")]
    const RemainingSpace = 0x0;
  }
  struct UIPropertyInfo {}
}
```

It resembles the macro syntax but without the `#`. This has two advantages:
- clearly show that it is not a dedicated macro: it is just a syntax sugar interpreted by the `shenum!` macro itself
- allow to still attach other macros individually to enum values if needed:
  ```rust
  shenum! {
    struct UIProperty {
      [description("Returns the remaining space")]
      #[MyMacro)]
      const RemainingSpace = 0x0;
    }
    struct UIPropertyInfo {}
  }
  ```

Note: it is also mandatory on all enum values. So at the very least, it needs to have an empty string:

```rust
shenum! {
  struct UIProperty {
    [description("")]
    const RemainingSpace = 0x0;
  }
  struct UIPropertyInfo {}
}
```