### PR TITLE
Fix D3D12 warp performance

### DIFF
--- a/src/gfx/drawable_processors/mesh_drawable_processor.hpp
+++ b/src/gfx/drawable_processors/mesh_drawable_processor.hpp
@@ -283,7 +283,7 @@ struct MeshDrawableProcessor final : public IDrawableProcessor {
   void waitForBufferMap(Context &context, PrepareData *prepareData) {
     do {
       bool everythingMapped = true;
-      auto check = [&](auto buffers) {
+      auto check = [&](auto& buffers) {
         for (auto &drawBuffer : buffers) {
           if (drawBuffer.mappingStatus == WGPUBufferMapAsyncStatus_Unknown)
             everythingMapped = false;


### PR DESCRIPTION
Performance for running the windows tests in the software rasterizer seems to have degraded after #500 (Vulkan seems unaffected)
Comparing job [6658454962](https://github.com/fragcolor-xyz/shards/actions/runs/3898687960/jobs/6658454962) to [6669771237](https://github.com/fragcolor-xyz/shards/actions/runs/3903338722/jobs/6669771237)