### PR TITLE
Don't use oldtime feature with chrono crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,6 @@ source = "git+https://github.com/shards-lang/chrono?rev=b1d74aef688c27fccc738c64
 dependencies = [
  "num-integer",
  "num-traits",
- "time 0.1.44",
  "winapi",
 ]
 
@@ -1820,7 +1819,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
- "time 0.3.14",
+ "time",
 ]
 
 [[package]]
@@ -1845,7 +1844,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time 0.3.14",
+ "time",
  "unicode-segmentation",
 ]
 
@@ -2533,7 +2532,7 @@ dependencies = [
  "indexmap",
  "line-wrap",
  "serde",
- "time 0.3.14",
+ "time",
  "xml-rs",
 ]
 
@@ -3749,17 +3748,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
@@ -4306,12 +4294,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,7 +38,7 @@ ext-csv = {  package = "csv", version = "1.1", optional = true }
 sp-core = { version = "4.1.0-dev", git = "https://github.com/fragcolor-xyz/substrate.git", tag = 'monthly-2022-01', optional = true }
 parity-scale-codec = { version = "2.3.1", default-features = false, optional = true }
 
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"], optional = true }
 
 chacha20poly1305 = { version = "0.9.0", optional = true }
 egui = { version = "0.20.1", optional = true }


### PR DESCRIPTION
Following the dependabot alert, don't use the old version of `time` as a dependency for `chrono`.

References
- https://github.com/fragcolor-xyz/shards/security/dependabot/4
- https://github.com/chronotope/chrono/issues/876
- https://docs.rs/crate/chrono/0.4.20/features (page is not available for 0.4.19).