### PR TITLE
Fixup output type during compose

### DIFF
--- a/src/core/shards/casting.hpp
+++ b/src/core/shards/casting.hpp
@@ -17,11 +17,7 @@ template <SHType ToType> struct ToNumber {
   const NumberConversion *_numberConversion{nullptr};
 
   SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
-  SHTypesInfo outputTypes() {
-    if (!_outputVectorType)
-      return CoreInfo::AnyType;
-    return _outputVectorType->type;
-  }
+  SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
 
   static const NumberTypeTraits *getEnumNumberType() {
     static const NumberTypeTraits *result = nullptr;
@@ -219,11 +215,7 @@ template <SHType ToType> struct MakeVector {
   }
 
   SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
-  SHTypesInfo outputTypes() {
-    if (!_outputVectorType)
-      return CoreInfo::AnyType;
-    return _outputVectorType->type;
-  }
+  SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
 
   void setParam(int index, const SHVar &value) {
     if (index >= (int)params.size())

--- a/src/core/shards/flow.hpp
+++ b/src/core/shards/flow.hpp
@@ -318,24 +318,10 @@ struct Cond {
 };
 
 struct BaseSubFlow {
-  SHTypesInfo inputTypes() {
-    if (_shards) {
-      auto blks = _shards.shards();
-      return blks.elements[0]->inputTypes(blks.elements[0]);
-    } else {
-      return CoreInfo::AnyType;
-    }
-  }
+  SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
   static SHOptionalString inputHelp() { return SHCCSTR("Must match the input types of the first shard in the sequence."); }
 
-  SHTypesInfo outputTypes() {
-    if (_shards) {
-      auto blks = _shards.shards();
-      return blks.elements[0]->outputTypes(blks.elements[0]);
-    } else {
-      return CoreInfo::AnyType;
-    }
-  }
+  SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
   static SHOptionalString outputHelp() { return SHCCSTR("Will match the output types of the first shard of the sequence."); }
 
   static SHParametersInfo parameters() { return _params; }

--- a/src/core/shards/fs.cpp
+++ b/src/core/shards/fs.cpp
@@ -183,12 +183,7 @@ struct Read {
   bool _binary = false;
 
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
-  SHTypesInfo outputTypes() {
-    if (_binary)
-      return CoreInfo::BytesType;
-    else
-      return CoreInfo::StringType;
-  }
+  SHTypesInfo outputTypes() { return Types{CoreInfo::BytesType, CoreInfo::StringType}; }
 
   static inline ParamsInfo params = ParamsInfo(ParamsInfo::Param(
       "Bytes", SHCCSTR("If the output should be SHType::Bytes instead of SHType::String."), CoreInfo::BoolType));
@@ -210,6 +205,8 @@ struct Read {
       return Var::Empty;
     }
   }
+
+  SHTypeInfo compose(const SHInstanceData &data) { return _binary ? CoreInfo::BytesType : CoreInfo::StringType; }
 
   SHVar activate(SHContext *context, const SHVar &input) {
     _buffer.clear();

--- a/src/core/shards/genetic.hpp
+++ b/src/core/shards/genetic.hpp
@@ -594,23 +594,9 @@ private:
 };
 
 struct Mutant {
-  SHTypesInfo inputTypes() {
-    if (_shard) {
-      auto blks = _shard.shards();
-      return blks.elements[0]->inputTypes(blks.elements[0]);
-    } else {
-      return CoreInfo::AnyType;
-    }
-  }
+  SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
 
-  SHTypesInfo outputTypes() {
-    if (_shard) {
-      auto blks = _shard.shards();
-      return blks.elements[0]->outputTypes(blks.elements[0]);
-    } else {
-      return CoreInfo::AnyType;
-    }
-  }
+  SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
 
   static SHParametersInfo parameters() { return _params; }
 

--- a/src/core/shards/http.cpp
+++ b/src/core/shards/http.cpp
@@ -91,6 +91,7 @@ struct Base {
   static inline std::array<SHString, 3> FullOutputKeys{"status", "headers", "body"};
   static inline Type FullStrOutputType = Type::TableOf(FullStrOutputTypes, FullOutputKeys);
   static inline Type FullBytesOutputType = Type::TableOf(FullBytesOutputTypes, FullOutputKeys);
+  static inline Types AllOutputTypes{{FullBytesOutputType, CoreInfo::BytesType, FullStrOutputType, CoreInfo::StringType}};
 
   static inline Parameters params{
       {"URL", SHCCSTR("The url to request to"), {CoreInfo::StringType, CoreInfo::StringVarType}},
@@ -105,21 +106,7 @@ struct Base {
        {CoreInfo::BoolType}}};
   static SHParametersInfo parameters() { return params; }
 
-  SHTypesInfo outputTypes() {
-    if (fullResponse) {
-      if (asBytes) {
-        return FullBytesOutputType;
-      } else {
-        return FullStrOutputType;
-      }
-    } else {
-      if (asBytes) {
-        return CoreInfo::BytesType;
-      } else {
-        return CoreInfo::StringType;
-      }
-    }
-  }
+  SHTypesInfo outputTypes() { return AllOutputTypes; }
 
   void setParam(int index, const SHVar &value) {
     switch (index) {
@@ -177,6 +164,22 @@ struct Base {
   void cleanup() {
     url.cleanup();
     headers.cleanup();
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    if (fullResponse) {
+      if (asBytes) {
+        return FullBytesOutputType;
+      } else {
+        return FullStrOutputType;
+      }
+    } else {
+      if (asBytes) {
+        return CoreInfo::BytesType;
+      } else {
+        return CoreInfo::StringType;
+      }
+    }
   }
 
   static void fetchSucceeded(emscripten_fetch_t *fetch) {

--- a/src/core/shards/seqs.cpp
+++ b/src/core/shards/seqs.cpp
@@ -186,6 +186,8 @@ struct Flatten {
 };
 
 struct IndexOf {
+  static inline Types OutputTypes = {{CoreInfo::IntSeqType, CoreInfo::IntType}};
+
   ParamVar _item{};
   SHSeq _results = {};
   bool _all = false;
@@ -200,12 +202,7 @@ struct IndexOf {
   void warmup(SHContext *context) { _item.warmup(context); }
 
   static SHTypesInfo inputTypes() { return CoreInfo::AnySeqType; }
-  SHTypesInfo outputTypes() {
-    if (_all)
-      return CoreInfo::IntSeqType;
-    else
-      return CoreInfo::IntType;
-  }
+  SHTypesInfo outputTypes() { return OutputTypes; }
 
   static inline ParamsInfo params = ParamsInfo(ParamsInfo::Param("Item",
                                                                  SHCCSTR("The item to find the index of from the input, "
@@ -231,6 +228,13 @@ struct IndexOf {
       return _item;
     else
       return Var(_all);
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    if (_all)
+      return CoreInfo::IntSeqType;
+    else
+      return CoreInfo::IntType;
   }
 
   SHVar activate(SHContext *context, const SHVar &input) {

--- a/src/core/shards/serialization.cpp
+++ b/src/core/shards/serialization.cpp
@@ -364,23 +364,26 @@ struct LoadImage : public FileBase {
 };
 
 struct WritePNG : public FileBase {
+  static inline Types OutputTypes = {{CoreInfo::BytesType, CoreInfo::ImageType}};
   std::vector<uint8_t> _scratch;
   std::vector<uint8_t> _output;
 
   static SHTypesInfo inputTypes() { return CoreInfo::ImageType; }
-  SHTypesInfo outputTypes() {
+  SHTypesInfo outputTypes() { return OutputTypes; }
+
+  static void write_func(void *context, void *data, int size) {
+    auto self = reinterpret_cast<WritePNG *>(context);
+    self->_output.resize(size);
+    memcpy(self->_output.data(), data, size);
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
     // If param is none we output the bytes directly
     if (_filename->valueType == SHType::None) {
       return CoreInfo::BytesType;
     } else {
       return CoreInfo::ImageType;
     }
-  }
-
-  static void write_func(void *context, void *data, int size) {
-    auto self = reinterpret_cast<WritePNG *>(context);
-    self->_output.resize(size);
-    memcpy(self->_output.data(), data, size);
   }
 
   SHVar activate(SHContext *context, const SHVar &input) {


### PR DESCRIPTION
Let's the shard declare both as potential output types.

I think this should be the idiomatic way to declare input/output types, list all potential types and only fixup during compose if necessary. And as a bonus, it makes introspection easier (for generating the doc as well as with the new shard editor).