### PR TITLE
2d shard representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
+ "slotmap",
  "sp-core",
  "syntect",
  "tiny-keccak",
@@ -3327,6 +3328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/include/ops.hpp
+++ b/include/ops.hpp
@@ -10,99 +10,72 @@
 #include <string>
 #include <string_view>
 
-inline std::string type2Name(SHType type) {
-  std::string name = "";
+static const char *type2Name_raw(SHType type) {
   switch (type) {
   case SHType::EndOfBlittableTypes:
     // this should never happen
     throw shards::SHException("EndOfBlittableTypes and Error are invalid types");
   case SHType::None:
-    name = "None";
-    break;
+    return "None";
   case SHType::Any:
-    name = "Any";
-    break;
+    return "Any";
   case SHType::Object:
-    name = "Object";
-    break;
+    return "Object";
   case SHType::Enum:
-    name = "Enum";
-    break;
+    return "Enum";
   case SHType::Bool:
-    name = "Bool";
-    break;
+    return "Bool";
   case SHType::Bytes:
-    name = "Bytes";
-    break;
+    return "Bytes";
   case SHType::Int:
-    name = "Int";
-    break;
+    return "Int";
   case SHType::Int2:
-    name = "Int2";
-    break;
+    return "Int2";
   case SHType::Int3:
-    name = "Int3";
-    break;
+    return "Int3";
   case SHType::Int4:
-    name = "Int4";
-    break;
+    return "Int4";
   case SHType::Int8:
-    name = "Int8";
-    break;
+    return "Int8";
   case SHType::Int16:
-    name = "Int16";
-    break;
+    return "Int16";
   case SHType::Float:
-    name = "Float";
-    break;
+    return "Float";
   case SHType::Float2:
-    name = "Float2";
-    break;
+    return "Float2";
   case SHType::Float3:
-    name = "Float3";
-    break;
+    return "Float3";
   case SHType::Float4:
-    name = "Float4";
-    break;
+    return "Float4";
   case SHType::Color:
-    name = "Color";
-    break;
+    return "Color";
   case SHType::Wire:
-    name = "Wire";
-    break;
+    return "Wire";
   case SHType::ShardRef:
-    name = "Shard";
-    break;
+    return "Shard";
   case SHType::String:
-    name = "String";
-    break;
+    return "String";
   case SHType::ContextVar:
-    name = "ContextVar";
-    break;
+    return "ContextVar";
   case SHType::Path:
-    name = "Path";
-    break;
+    return "Path";
   case SHType::Image:
-    name = "Image";
-    break;
+    return "Image";
   case SHType::Audio:
-    name = "Audio";
-    break;
+    return "Audio";
   case SHType::Seq:
-    name = "Seq";
-    break;
+    return "Seq";
   case SHType::Table:
-    name = "Table";
-    break;
+    return "Table";
   case SHType::Set:
-    name = "Set";
-    break;
+    return "Set";
   case SHType::Array:
-    name = "Array";
-    break;
+    return "Array";
   }
-  return name;
+  return "";
 }
+
+inline std::string type2Name(SHType type) { return type2Name_raw(type); }
 
 ALWAYS_INLINE inline bool operator!=(const SHVar &a, const SHVar &b);
 ALWAYS_INLINE inline bool operator<(const SHVar &a, const SHVar &b);

--- a/include/shards.h
+++ b/include/shards.h
@@ -25,17 +25,17 @@ enum SH_ENUM_CLASS SHType : uint8_t {
   Any,
   Enum,
   Bool,
-  Int,      // A 64bits int
-  Int2,     // A vector of 2 64bits ints
-  Int3,     // A vector of 3 32bits ints
-  Int4,     // A vector of 4 32bits ints
-  Int8,     // A vector of 8 16bits ints
-  Int16,    // A vector of 16 8bits ints
-  Float,    // A 64bits float
-  Float2,   // A vector of 2 64bits floats
-  Float3,   // A vector of 3 32bits floats
-  Float4,   // A vector of 4 32bits floats
-  Color,    // A vector of 4 uint8
+  Int,    // A 64bits int
+  Int2,   // A vector of 2 64bits ints
+  Int3,   // A vector of 3 32bits ints
+  Int4,   // A vector of 4 32bits ints
+  Int8,   // A vector of 8 16bits ints
+  Int16,  // A vector of 16 8bits ints
+  Float,  // A 64bits float
+  Float2, // A vector of 2 64bits floats
+  Float3, // A vector of 3 32bits floats
+  Float4, // A vector of 4 32bits floats
+  Color,  // A vector of 4 uint8
 
   // Internal use only
   EndOfBlittableTypes = 50, // anything below this is not blittable (ish)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ egui_dock = { version = "0.3.0", optional = true }
 egui_extras = { version = "0.20.0", optional = true }
 egui-gfx = { path = "../src/gfx/egui", optional = true }
 egui_memory_editor = { version = "0.2.2", optional = true }
+slotmap = { version = "1.0", optional = true }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"], optional = true }
 half = { version = "2.0.0" }
 tract-onnx = { version = "0.19.2", optional = true }
@@ -91,6 +92,7 @@ shards = ["reqwest",
           "egui_dock",
           "egui_extras",
           "egui-gfx",
+          "slotmap",
           "code_editor",
           "hex_viewer",
           "tract-onnx",

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -29,6 +29,7 @@ fn generate_shardsc() {
     .allowlist_type("SH.*")
     .allowlist_var("SH.*")
     .allowlist_function("SH.*")
+    .allowlist_function("util_.*")
     .clang_arg(format!("-I{}", shards_include_dir))
     .clang_arg(format!("-I{}/src", shards_dir))
     .derive_default(true)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -619,3 +619,45 @@ impl Drop for ShardInstance {
     }
   }
 }
+
+impl ShardInstance {
+  pub fn name(&self) -> SHString {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).name.unwrap()(self.ptr) }
+  }
+
+  pub fn help(&self) -> SHOptionalString {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).help.unwrap()(self.ptr) }
+  }
+
+  pub fn inputHelp(&self) -> SHOptionalString {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).inputHelp.unwrap()(self.ptr) }
+  }
+
+  pub fn outputHelp(&self) -> SHOptionalString {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).outputHelp.unwrap()(self.ptr) }
+  }
+
+  pub fn inputTypes(&self) -> SHTypesInfo {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).inputTypes.unwrap()(self.ptr) }
+  }
+
+  pub fn outputTypes(&self) -> SHTypesInfo {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).outputTypes.unwrap()(self.ptr) }
+  }
+
+  pub fn parameters(&self) -> SHParametersInfo {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).parameters.unwrap()(self.ptr) }
+  }
+
+  pub fn getParam(&self, index: i32) -> SHVar {
+    assert_ne!(self.ptr, std::ptr::null_mut());
+    unsafe { (*self.ptr).getParam.unwrap()(self.ptr, index) }
+  }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -272,7 +272,7 @@ mod dummy_shard {
   lazy_static! {
     static ref PROPERTIES: Table = {
       let mut table = Table::default();
-      table.insert_fast_static(cstr!("experimental"), true.into());
+      table.insert_fast_static(cstr!("experimental"), &true.into());
       table
     };
   }

--- a/rust/src/shards/csv.rs
+++ b/rust/src/shards/csv.rs
@@ -136,9 +136,9 @@ impl Shard for CSVRead {
           shlog!("{}", e);
           "Failed to parse CSV record string"
         })?;
-        output.push(field.as_ref().into());
+        output.push(&field.as_ref().into());
       }
-      self.output.push(output.as_ref().into());
+      self.output.push(&output.as_ref().into());
     }
     Ok(self.output.as_ref().into())
   }

--- a/rust/src/shards/csv.rs
+++ b/rust/src/shards/csv.rs
@@ -222,7 +222,7 @@ impl Shard for CSVWrite {
       .from_writer(Vec::new());
     let input: Seq = input.try_into()?;
     for row in input.iter() {
-      let row: Seq = row.try_into()?;
+      let row: Seq = row.as_ref().try_into()?;
       let mut record = Vec::new();
       for field in row.iter() {
         let field: &str = field.as_ref().try_into()?;

--- a/rust/src/shards/editor/graph.rs
+++ b/rust/src/shards/editor/graph.rs
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use super::id_types::*;
+use slotmap::SlotMap;
+
+pub(crate) struct Graph<NodeData> {
+  pub nodes: SlotMap<NodeId, Node<NodeData>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct Node<NodeData> {
+  pub id: NodeId,
+  pub label: String,
+  pub data: NodeData,
+}
+
+impl<NodeData> Default for Graph<NodeData> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<NodeData> Graph<NodeData> {
+  pub fn new() -> Self {
+    Self {
+      nodes: SlotMap::default(),
+    }
+  }
+
+  pub fn add_node(&mut self, label: String, data: NodeData) -> NodeId {
+    self.nodes.insert_with_key(|id| Node::new(id, label, data))
+  }
+}
+
+impl<Data> Node<Data> {
+  pub fn new(id: NodeId, label: String, data: Data) -> Self {
+    Self {
+      id,
+      label,
+      data,
+    }
+  }
+}

--- a/rust/src/shards/editor/graph.rs
+++ b/rust/src/shards/editor/graph.rs
@@ -41,8 +41,8 @@ impl<NodeData> Graph<NodeData> {
   }
 }
 
-impl<Data> Node<Data> {
-  pub fn new(id: NodeId, label: String, data: Data) -> Self {
+impl<NodeData> Node<NodeData> {
+  pub fn new(id: NodeId, label: String, data: NodeData) -> Self {
     Self { id, label, data }
   }
 }

--- a/rust/src/shards/editor/graph.rs
+++ b/rust/src/shards/editor/graph.rs
@@ -39,10 +39,6 @@ impl<NodeData> Graph<NodeData> {
 
 impl<Data> Node<Data> {
   pub fn new(id: NodeId, label: String, data: Data) -> Self {
-    Self {
-      id,
-      label,
-      data,
-    }
+    Self { id, label, data }
   }
 }

--- a/rust/src/shards/editor/graph.rs
+++ b/rust/src/shards/editor/graph.rs
@@ -35,6 +35,10 @@ impl<NodeData> Graph<NodeData> {
   pub fn add_node(&mut self, label: String, data: NodeData) -> NodeId {
     self.nodes.insert_with_key(|id| Node::new(id, label, data))
   }
+
+  pub fn remove_node(&mut self, node_id: NodeId) -> Node<NodeData> {
+    self.nodes.remove(node_id).expect("Node should exist")
+  }
 }
 
 impl<Data> Node<Data> {

--- a/rust/src/shards/editor/graph_ui.rs
+++ b/rust/src/shards/editor/graph_ui.rs
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use super::graph::*;
+use super::id_types::*;
+use super::util::ColorUtils;
+use egui::{
+  epaint::RectShape, style::Margin, Area, Color32, Frame, Id, InnerResponse, Order, Pos2, Rect,
+  Rounding, Shape, Ui, Vec2,
+};
+
+pub(crate) struct GraphNodeWidget<'a, NodeData> {
+  pub position: &'a mut Pos2,
+  pub graph: &'a mut Graph<NodeData>,
+  pub node_id: NodeId,
+  pub pan: Vec2,
+  pub selected: bool,
+}
+
+impl<'a, NodeData> GraphNodeWidget<'a, NodeData>
+where
+  NodeData: UIRenderer,
+{
+  pub fn show(self, ui: &mut Ui) -> Vec<NodeResponse> {
+    let node_id = self.node_id;
+    let area = Area::new(Id::new(node_id))
+      .order(Order::Middle)
+      .current_pos(*self.position + self.pan);
+
+    let InnerResponse {
+      inner: mut node_responses,
+      response,
+    } = area.show(ui.ctx(), |ui| self.show_graph_node(ui));
+
+    // Movement
+    let drag_delta = response.drag_delta();
+    if drag_delta.length_sq() > 0.0 {
+      node_responses.push(NodeResponse::MoveNode {
+        node: node_id,
+        drag_delta,
+      });
+      node_responses.push(NodeResponse::RaiseNode(node_id));
+    }
+
+    // Node selection
+    //
+    // HACK: Only set the select response when no other response is active.
+    // This prevents some issues.
+    if node_responses.is_empty() && response.clicked_by(egui::PointerButton::Primary) {
+      node_responses.push(NodeResponse::SelectNode(node_id));
+      node_responses.push(NodeResponse::RaiseNode(node_id));
+    }
+
+    node_responses
+  }
+
+  fn show_graph_node(self, ui: &mut Ui) -> Vec<NodeResponse> {
+    let margin = Margin::symmetric(15.0, 5.0);
+    let responses = Vec::new();
+
+    let (background_color, text_color) = if ui.visuals().dark_mode {
+      (
+        Color32::from_hex("#3f3f3f").unwrap(),
+        Color32::from_hex("#fefefe").unwrap(),
+      )
+    } else {
+      (
+        Color32::from_hex("#ffffff").unwrap(),
+        Color32::from_hex("#505050").unwrap(),
+      )
+    };
+
+    ui.visuals_mut().widgets.noninteractive.fg_stroke = egui::Stroke::new(2.0, text_color);
+
+    // Preallocate shapes to paint below contents
+    let outline_shape = ui.painter().add(egui::Shape::Noop);
+    let background_shape = ui.painter().add(egui::Shape::Noop);
+
+    let mut title_height = 0.0;
+
+    let node = &mut self.graph[self.node_id];
+
+    Frame::none().inner_margin(margin).show(ui, |ui| {
+      ui.vertical(|ui| {
+        ui.horizontal(|ui| {
+          ui.add(egui::Label::new(
+            egui::RichText::new(&node.label)
+              .text_style(egui::TextStyle::Button)
+              .color(text_color),
+          ));
+          ui.add_space(8.0); // The size of the little cross icon
+        });
+        title_height = ui.min_size().y;
+        ui.add_space(margin.top);
+
+        // First pass: Draw the inner fields. Compute port heights
+        node.data.ui(ui);
+      })
+    });
+
+    // Second pass, iterate again to draw the ports. This happens outside
+    // the child_ui because we want ports to overflow the node background.
+    let outer_rect = ui.min_rect();
+
+    // Draw the background shape.
+    // NOTE: This code is a bit more involved than it needs to be because egui
+    // does not support drawing rectangles with asymmetrical round corners.
+    let (shape, outline) = {
+      let rounding_radius = 4.0;
+
+      let titlebar_height = title_height + margin.top * 2.0;
+      let titlebar_rect = Rect::from_min_size(
+        outer_rect.min,
+        egui::vec2(outer_rect.width(), titlebar_height),
+      );
+      let titlebar = egui::Shape::Rect(egui::epaint::RectShape {
+        rect: titlebar_rect,
+        rounding: Rounding {
+          nw: rounding_radius,
+          ne: rounding_radius,
+          sw: 0.0,
+          se: 0.0,
+        },
+        fill: background_color.lighten(0.8),
+        stroke: egui::Stroke::NONE,
+      });
+
+      let body_rect = Rect::from_min_size(
+        outer_rect.min + egui::vec2(0.0, titlebar_height),
+        egui::vec2(outer_rect.width(), outer_rect.height() - titlebar_height),
+      );
+      let body = Shape::Rect(RectShape {
+        rect: body_rect,
+        rounding: Rounding {
+          nw: 0.0,
+          ne: 0.0,
+          sw: rounding_radius,
+          se: rounding_radius,
+        },
+        fill: background_color,
+        stroke: egui::Stroke::NONE,
+      });
+
+      let node_rect = titlebar_rect.union(body_rect);
+      let outline = if self.selected {
+        egui::Shape::Rect(egui::epaint::RectShape {
+          rect: node_rect.expand(1.0),
+          rounding: Rounding::same(rounding_radius),
+          fill: Color32::WHITE.lighten(0.8),
+          stroke: egui::Stroke::NONE,
+        })
+      } else {
+        egui::Shape::Noop
+      };
+
+      // Take note of the node rect, so the editor can use it later to compute intersections.
+      // self.node_rects.insert(self.node_id, node_rect);
+
+      (egui::Shape::Vec(vec![titlebar, body]), outline)
+    };
+
+    ui.painter().set(background_shape, shape);
+    ui.painter().set(outline_shape, outline);
+
+    responses
+  }
+}
+
+pub(crate) enum NodeResponse {
+  MoveNode {
+    node: NodeId,
+    drag_delta: Vec2,
+  },
+  /// Emitted when a node is interacted with, and should be raised
+  RaiseNode(NodeId),
+  SelectNode(NodeId),
+}
+
+pub(crate) trait UIRenderer {
+  fn ui(&mut self, ui: &mut Ui);
+}

--- a/rust/src/shards/editor/graph_ui.rs
+++ b/rust/src/shards/editor/graph_ui.rs
@@ -10,7 +10,7 @@ use super::id_types::*;
 use super::util::ColorUtils;
 use egui::{
   epaint::RectShape, style::Margin, Area, Color32, Frame, Id, InnerResponse, Order, Pos2, Rect,
-  Rounding, Shape, Ui, Vec2,
+  Response, Rounding, Shape, Ui, Vec2,
 };
 
 pub(crate) struct GraphNodeWidget<'a, NodeData> {
@@ -181,5 +181,5 @@ pub(crate) enum NodeResponse {
 }
 
 pub(crate) trait UIRenderer {
-  fn ui(&mut self, ui: &mut Ui);
+  fn ui(&mut self, ui: &mut Ui) -> Response;
 }

--- a/rust/src/shards/editor/graph_ui.rs
+++ b/rust/src/shards/editor/graph_ui.rs
@@ -31,6 +31,7 @@ where
     let node_id = self.node_id;
     let area = Area::new(Id::new(node_id))
       .order(Order::Middle)
+      .constrain(false) // FIXME egui BUG, this is not taken into account if the Area is movable
       .current_pos(*self.position + self.pan);
 
     let InnerResponse {

--- a/rust/src/shards/editor/graph_ui.rs
+++ b/rust/src/shards/editor/graph_ui.rs
@@ -12,10 +12,12 @@ use egui::{
   epaint::RectShape, style::Margin, Area, Color32, Frame, Id, InnerResponse, Order, Pos2, Rect,
   Response, Rounding, Sense, Shape, Stroke, Ui, Vec2,
 };
+use std::collections::HashMap;
 
 pub(crate) struct GraphNodeWidget<'a, NodeData> {
   pub position: &'a mut Pos2,
   pub graph: &'a mut Graph<NodeData>,
+  pub node_rects: &'a mut HashMap<NodeId, Rect>,
   pub node_id: NodeId,
   pub pan: Vec2,
   pub selected: bool,
@@ -40,7 +42,7 @@ where
     let drag_delta = response.drag_delta();
     if drag_delta.length_sq() > 0.0 {
       node_responses.push(NodeResponse::MoveNode {
-        node: node_id,
+        node_id,
         drag_delta,
       });
       node_responses.push(NodeResponse::RaiseNode(node_id));
@@ -158,7 +160,7 @@ where
       };
 
       // Take note of the node rect, so the editor can use it later to compute intersections.
-      // self.node_rects.insert(self.node_id, node_rect);
+      self.node_rects.insert(self.node_id, node_rect);
 
       (egui::Shape::Vec(vec![titlebar, body]), outline)
     };
@@ -225,7 +227,7 @@ where
 pub(crate) enum NodeResponse {
   DeleteNodeUi(NodeId),
   MoveNode {
-    node: NodeId,
+    node_id: NodeId,
     drag_delta: Vec2,
   },
   /// Emitted when a node is interacted with, and should be raised

--- a/rust/src/shards/editor/id_types.rs
+++ b/rust/src/shards/editor/id_types.rs
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+slotmap::new_key_type! { pub(crate) struct NodeId; }

--- a/rust/src/shards/editor/index_impls.rs
+++ b/rust/src/shards/editor/index_impls.rs
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use super::graph::*;
+use super::id_types::*;
+
+macro_rules! impl_index_traits {
+  ($id_type:ty, $output_type:ty, $arena:ident) => {
+    impl<A> std::ops::Index<$id_type> for Graph<A> {
+      type Output = $output_type;
+
+      fn index(&self, index: $id_type) -> &Self::Output {
+        self.$arena.get(index).unwrap_or_else(|| {
+          panic!(
+            "{} index error for {:?}. Has the value been deleted?",
+            stringify!($id_type),
+            index
+          )
+        })
+      }
+    }
+
+    impl<A> std::ops::IndexMut<$id_type> for Graph<A> {
+      fn index_mut(&mut self, index: $id_type) -> &mut Self::Output {
+        self.$arena.get_mut(index).unwrap_or_else(|| {
+          panic!(
+            "{} index error for {:?}. Has the value been deleted?",
+            stringify!($id_type),
+            index
+          )
+        })
+      }
+    }
+  };
+}
+
+impl_index_traits!(NodeId, Node<A>, nodes);

--- a/rust/src/shards/editor/mod.rs
+++ b/rust/src/shards/editor/mod.rs
@@ -15,5 +15,8 @@ mod index_impls;
 /// Implements the different nodes
 pub(crate) mod node_templates;
 pub(crate) use node_templates::*;
+/// Implements the node factory to create new nodes
+pub(crate) mod node_factory;
+pub(crate) use node_factory::*;
 /// Implements some utilities
 mod util;

--- a/rust/src/shards/editor/mod.rs
+++ b/rust/src/shards/editor/mod.rs
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+/// Implements the graph
+pub(crate) mod graph;
+pub(crate) use graph::*;
+/// Implements the graph basic ui
+pub(crate) mod graph_ui;
+pub(crate) use graph_ui::*;
+/// Type declarations for the different id types (node, input, output)
+pub(crate) mod id_types;
+pub(crate) use id_types::*;
+/// Implements the index trait for the Graph type, allowing indexing by all id types
+mod index_impls;
+/// Implements the different nodes
+pub(crate) mod node_templates;
+pub(crate) use node_templates::*;
+/// Implements some utilities
+mod util;

--- a/rust/src/shards/editor/node_factory.rs
+++ b/rust/src/shards/editor/node_factory.rs
@@ -9,6 +9,7 @@ pub(crate) struct NodeFactory<NodeData> {
   pub query: String,
   pub position: Option<Pos2>,
   just_spawned: bool,
+  markdown_cache: egui_commonmark::CommonMarkCache,
   _phantom: PhantomData<NodeData>,
 }
 
@@ -21,6 +22,7 @@ where
       query: "".into(),
       position: Some(pos),
       just_spawned: true,
+      markdown_cache: egui_commonmark::CommonMarkCache::default(),
       _phantom: Default::default(),
     }
   }
@@ -78,7 +80,11 @@ where
             });
         });
         ui.separator();
-        ui.label(description);
+        egui_commonmark::CommonMarkViewer::new("node_factory").show(
+          ui,
+          &mut self.markdown_cache,
+          description,
+        );
       });
 
     ret

--- a/rust/src/shards/editor/node_factory.rs
+++ b/rust/src/shards/editor/node_factory.rs
@@ -5,17 +5,17 @@ use super::util::ColorUtils;
 use egui::{Color32, Frame, Key, Pos2, ScrollArea, Stroke, Ui, Vec2};
 use std::marker::PhantomData;
 
-pub(crate) struct NodeFactory<NodeData> {
+pub(crate) struct NodeFactory<NodeTemplate> {
   pub query: String,
   pub position: Option<Pos2>,
   just_spawned: bool,
   markdown_cache: egui_commonmark::CommonMarkCache,
-  _phantom: PhantomData<NodeData>,
+  _phantom: PhantomData<NodeTemplate>,
 }
 
-impl<NodeData> NodeFactory<NodeData>
+impl<NodeTemplate> NodeFactory<NodeTemplate>
 where
-  NodeData: NodeTemplateTrait,
+  NodeTemplate: NodeTemplateTrait,
 {
   pub fn new_at(pos: Pos2) -> Self {
     Self {
@@ -27,7 +27,7 @@ where
     }
   }
 
-  pub fn show(&mut self, ui: &mut Ui, templates: &Vec<NodeData>) -> Option<NodeData> {
+  pub fn show(&mut self, ui: &mut Ui, templates: &Vec<NodeTemplate>) -> Option<NodeTemplate> {
     let (background_color, text_color) = if ui.visuals().dark_mode {
       (
         Color32::from_hex("#3f3f3f").unwrap(),
@@ -92,11 +92,15 @@ where
 }
 
 pub(crate) trait NodeTemplateTrait: Clone {
+  type NodeData;
+
   fn node_factory_label(&self) -> &str;
 
   fn node_factory_description(&self) -> &str {
     self.node_factory_label()
   }
+
+  fn build_node(&self) -> Self::NodeData;
 }
 
 // FIXME need a display name for each template

--- a/rust/src/shards/editor/node_factory.rs
+++ b/rust/src/shards/editor/node_factory.rs
@@ -8,6 +8,7 @@ use std::marker::PhantomData;
 pub(crate) struct NodeFactory<NodeData> {
   pub query: String,
   pub position: Option<Pos2>,
+  just_spawned: bool,
   _phantom: PhantomData<NodeData>,
 }
 
@@ -19,6 +20,7 @@ where
     Self {
       query: "".into(),
       position: Some(pos),
+      just_spawned: true,
       _phantom: Default::default(),
     }
   }
@@ -45,6 +47,11 @@ where
       .show(ui, |ui| {
         let mut description = "";
         let response = ui.text_edit_singleline(&mut self.query);
+        if self.just_spawned {
+          response.request_focus();
+          self.just_spawned = false;
+        }
+
         let mut query_submit = response.lost_focus() && ui.input().key_down(Key::Enter);
         let max_height = ui.input().screen_rect.height() * 0.5;
         let scroll_area_width = response.rect.width() - 30.0;
@@ -86,5 +93,5 @@ pub(crate) trait NodeTemplateTrait: Clone {
   }
 }
 
-// FIXME: need a display name for each template
-// TODO: might also add a description that be shown below (for instance we could take the result of the help() function on a shard.)
+// FIXME need a display name for each template
+// TODO might also add a description that be shown below (for instance we could take the result of the help() function on a shard.)

--- a/rust/src/shards/editor/node_factory.rs
+++ b/rust/src/shards/editor/node_factory.rs
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use super::util::ColorUtils;
+use egui::{Color32, Frame, Key, Pos2, ScrollArea, Stroke, Ui, Vec2};
+use std::marker::PhantomData;
+
+pub(crate) struct NodeFactory<NodeData> {
+  pub query: String,
+  pub position: Option<Pos2>,
+  _phantom: PhantomData<NodeData>,
+}
+
+impl<NodeData> NodeFactory<NodeData>
+where
+  NodeData: NodeTemplateTrait,
+{
+  pub fn new_at(pos: Pos2) -> Self {
+    Self {
+      query: "".into(),
+      position: Some(pos),
+      _phantom: Default::default(),
+    }
+  }
+
+  pub fn show(&mut self, ui: &mut Ui, templates: &Vec<NodeData>) -> Option<NodeData> {
+    let (background_color, text_color) = if ui.visuals().dark_mode {
+      (
+        Color32::from_hex("#3f3f3f").unwrap(),
+        Color32::from_hex("#fefefe").unwrap(),
+      )
+    } else {
+      (
+        Color32::from_hex("#fefefe").unwrap(),
+        Color32::from_hex("#3f3f3f").unwrap(),
+      )
+    };
+
+    ui.visuals_mut().widgets.noninteractive.fg_stroke = Stroke::new(2.0, text_color);
+
+    let mut ret = None;
+    Frame::dark_canvas(ui.style())
+      .fill(background_color)
+      .inner_margin(Vec2 { x: 5.0, y: 5.0 })
+      .show(ui, |ui| {
+        let mut description = "";
+        let response = ui.text_edit_singleline(&mut self.query);
+        let mut query_submit = response.lost_focus() && ui.input().key_down(Key::Enter);
+        let max_height = ui.input().screen_rect.height() * 0.5;
+        let scroll_area_width = response.rect.width() - 30.0;
+        Frame::default().show(ui, |ui| {
+          ScrollArea::vertical()
+            .max_height(max_height)
+            .show(ui, |ui| {
+              ui.set_width(scroll_area_width);
+              for template in templates.into_iter() {
+                let label = template.node_factory_label();
+                if label.to_lowercase().contains(&self.query.to_lowercase()) {
+                  let response = ui.selectable_label(false, label);
+                  if response.hovered() {
+                    description = template.node_factory_description();
+                  }
+                  if response.clicked() {
+                    ret = Some(template.clone());
+                  } else if query_submit {
+                    ret = Some(template.clone());
+                    query_submit = false;
+                  }
+                }
+              }
+            });
+        });
+        ui.separator();
+        ui.label(description);
+      });
+
+    ret
+  }
+}
+
+pub(crate) trait NodeTemplateTrait: Clone {
+  fn node_factory_label(&self) -> &str;
+
+  fn node_factory_description(&self) -> &str {
+    self.node_factory_label()
+  }
+}
+
+// FIXME: need a display name for each template
+// TODO: might also add a description that be shown below (for instance we could take the result of the help() function on a shard.)

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -1,15 +1,348 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2023 Fragcolor Pte. Ltd. */
 
-use super::graph_ui::UIRenderer;
+use super::{graph_ui::UIRenderer, node_factory::NodeTemplateTrait};
 use egui::Ui;
 
-pub(crate) enum NodeTemplate {}
+#[derive(Clone)]
+pub(crate) enum NodeTemplate {
+  AssertIs(AssertIsNodeData),
+  Const(ConstNodeData),
+  ForRange(ForRangeNodeData),
+  Get(GetNodeData),
+  Log(LogNodeData),
+  MathAdd(MathAddNodeData),
+  MathDivide(MathDivideNodeData),
+  MathMod(MathModNodeData),
+  MathMultiply(MathMultiplyNodeData),
+  MathSubtract(MathSubtractNodeData),
+  Set(SetNodeData),
+}
+
+// note: trait redirection because enum items are not considered types yet
+// FIXME: maybe there is a better way, but all this code will eventually disappear once we "generate" it for each shard.
+
+impl NodeTemplateTrait for NodeTemplate {
+  fn node_factory_description(&self) -> &str {
+    match self {
+      NodeTemplate::AssertIs(x) => x.node_factory_description(),
+      NodeTemplate::Const(x) => x.node_factory_description(),
+      NodeTemplate::ForRange(x) => x.node_factory_description(),
+      NodeTemplate::Get(x) => x.node_factory_description(),
+      NodeTemplate::Log(x) => x.node_factory_description(),
+      NodeTemplate::MathAdd(x) => x.node_factory_description(),
+      NodeTemplate::MathDivide(x) => x.node_factory_description(),
+      NodeTemplate::MathMod(x) => x.node_factory_description(),
+      NodeTemplate::MathMultiply(x) => x.node_factory_description(),
+      NodeTemplate::MathSubtract(x) => x.node_factory_description(),
+      NodeTemplate::Set(x) => x.node_factory_description(),
+    }
+  }
+
+  fn node_factory_label(&self) -> &str {
+    match self {
+      NodeTemplate::AssertIs(x) => x.node_factory_label(),
+      NodeTemplate::Const(x) => x.node_factory_label(),
+      NodeTemplate::ForRange(x) => x.node_factory_label(),
+      NodeTemplate::Get(x) => x.node_factory_label(),
+      NodeTemplate::Log(x) => x.node_factory_label(),
+      NodeTemplate::MathAdd(x) => x.node_factory_label(),
+      NodeTemplate::MathDivide(x) => x.node_factory_label(),
+      NodeTemplate::MathMod(x) => x.node_factory_label(),
+      NodeTemplate::MathMultiply(x) => x.node_factory_label(),
+      NodeTemplate::MathSubtract(x) => x.node_factory_label(),
+      NodeTemplate::Set(x) => x.node_factory_label(),
+    }
+  }
+}
 
 impl UIRenderer for NodeTemplate {
   fn ui(&mut self, ui: &mut Ui) {
     match self {
-      _ => {}
+      NodeTemplate::AssertIs(x) => x.ui(ui),
+      NodeTemplate::Const(x) => x.ui(ui),
+      NodeTemplate::ForRange(x) => x.ui(ui),
+      NodeTemplate::Get(x) => x.ui(ui),
+      NodeTemplate::Log(x) => x.ui(ui),
+      NodeTemplate::MathAdd(MathAddNodeData(x)) => x.ui(ui),
+      NodeTemplate::MathDivide(MathDivideNodeData(x)) => x.ui(ui),
+      NodeTemplate::MathMod(MathModNodeData(x)) => x.ui(ui),
+      NodeTemplate::MathMultiply(MathMultiplyNodeData(x)) => x.ui(ui),
+      NodeTemplate::MathSubtract(MathSubtractNodeData(x)) => x.ui(ui),
+      NodeTemplate::Set(x) => x.ui(ui),
     }
+  }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct AssertIsNodeData {
+  // FIXME: for now only support 64-bit integer
+  pub value: i64,
+  pub abort: bool,
+}
+
+impl NodeTemplateTrait for AssertIsNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Assert.Is"
+  }
+
+  fn node_factory_description(&self) -> &str {
+    "This assertion is used to check whether the input is equal to a given value."
+  }
+}
+
+impl UIRenderer for AssertIsNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.add(egui::DragValue::new(&mut self.value));
+    ui.checkbox(&mut self.abort, "Abort?");
+  }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) enum NodeDataType {
+  #[default]
+  Int,
+  Int2,
+  Int3,
+  Int4,
+  Float,
+  Float2,
+  Float3,
+  Float4,
+  String,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ConstNodeData {
+  // FIXME: all values should be merged into a single Var, with custom conversion rules
+  pub value_i: i64,
+  pub value_i2: [i64; 2],
+  pub value_i3: [i64; 3],
+  pub value_i4: [i64; 4],
+  pub value_f: f64,
+  pub value_f2: [f64; 2],
+  pub value_f3: [f64; 3],
+  pub value_f4: [f64; 4],
+  pub value_s: String,
+
+  // ...
+  pub typ_: NodeDataType,
+}
+
+impl NodeTemplateTrait for ConstNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Const"
+  }
+
+  fn node_factory_description(&self) -> &str {
+    "Declares an un-named constant value."
+  }
+}
+
+// FIXME: refactor. This should be part of some util that can be used wherever there is a value.
+impl UIRenderer for ConstNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.horizontal(|ui| {
+      egui::ComboBox::from_id_source(("ConstNodeData", "type"))
+        .selected_text(format!("{:?}", self.typ_))
+        .show_ui(ui, |ui| {
+          ui.selectable_value(&mut self.typ_, NodeDataType::Int, "Int");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Int2, "Int2");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Int3, "Int3");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Int4, "Int4");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Float, "Float");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Float2, "Float2");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Float3, "Float3");
+          ui.selectable_value(&mut self.typ_, NodeDataType::Float4, "Float4");
+          ui.selectable_value(&mut self.typ_, NodeDataType::String, "String");
+        });
+      // FIXME: use a single backing store (Var) and apply conversion when switching type (when possible)
+      match self.typ_ {
+        NodeDataType::Int => {
+          ui.add(egui::DragValue::new(&mut self.value_i));
+        }
+        NodeDataType::Int2 => {
+          ui.horizontal(|ui| {
+            ui.add(egui::DragValue::new(&mut self.value_i2[0]));
+            ui.add(egui::DragValue::new(&mut self.value_i2[1]));
+          });
+        }
+        NodeDataType::Int3 => {
+          ui.horizontal(|ui| {
+            ui.add(egui::DragValue::new(&mut self.value_i3[0]));
+            ui.add(egui::DragValue::new(&mut self.value_i3[1]));
+            ui.add(egui::DragValue::new(&mut self.value_i3[2]));
+          });
+        }
+        NodeDataType::Int4 => {
+          ui.horizontal(|ui| {
+            ui.add(egui::DragValue::new(&mut self.value_i4[0]));
+            ui.add(egui::DragValue::new(&mut self.value_i4[1]));
+            ui.add(egui::DragValue::new(&mut self.value_i4[2]));
+            ui.add(egui::DragValue::new(&mut self.value_i4[3]));
+          });
+        }
+        NodeDataType::Float => {
+          ui.add(egui::DragValue::new(&mut self.value_f));
+        }
+        NodeDataType::Float2 => {
+          ui.horizontal(|ui| {
+            ui.add(egui::DragValue::new(&mut self.value_f2[0]));
+            ui.add(egui::DragValue::new(&mut self.value_f2[1]));
+          });
+        }
+        NodeDataType::Float3 => {
+          ui.horizontal(|ui| {
+            ui.add(egui::DragValue::new(&mut self.value_f3[0]));
+            ui.add(egui::DragValue::new(&mut self.value_f3[1]));
+            ui.add(egui::DragValue::new(&mut self.value_f3[2]));
+          });
+        }
+        NodeDataType::Float4 => {
+          ui.horizontal(|ui| {
+            ui.add(egui::DragValue::new(&mut self.value_f4[0]));
+            ui.add(egui::DragValue::new(&mut self.value_f4[1]));
+            ui.add(egui::DragValue::new(&mut self.value_f4[2]));
+            ui.add(egui::DragValue::new(&mut self.value_f4[3]));
+          });
+        }
+        NodeDataType::String => {
+          ui.text_edit_singleline(&mut self.value_s);
+        }
+        _ => {}
+      }
+    });
+  }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ForRangeNodeData {
+  // FIXME: for now only support 64-bit integer
+  pub from: i64,
+  pub to: i64,
+}
+
+impl NodeTemplateTrait for ForRangeNodeData {
+  fn node_factory_label(&self) -> &str {
+    "ForRange"
+  }
+}
+
+impl UIRenderer for ForRangeNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.add(egui::DragValue::new(&mut self.from));
+    if self.from > self.to {
+      self.from = self.to;
+    }
+    ui.add(egui::DragValue::new(&mut self.to));
+    if self.to < self.from {
+      self.to = self.from;
+    }
+    // FIXME: inner contents
+    // contents(ui);
+  }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct GetNodeData {
+  pub name: String,
+}
+
+impl NodeTemplateTrait for GetNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Get"
+  }
+}
+
+impl UIRenderer for GetNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.text_edit_singleline(&mut self.name);
+  }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct LogNodeData {
+  pub label: String,
+}
+
+impl NodeTemplateTrait for LogNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Log"
+  }
+}
+
+impl UIRenderer for LogNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.text_edit_singleline(&mut self.label);
+  }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct MathUnaryNodeData {
+  // FIXME: for now only support 64-bit integer
+  pub value: i64,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct MathAddNodeData(pub MathUnaryNodeData);
+#[derive(Clone, Default)]
+pub(crate) struct MathDivideNodeData(pub MathUnaryNodeData);
+#[derive(Clone, Default)]
+pub(crate) struct MathModNodeData(pub MathUnaryNodeData);
+#[derive(Clone, Default)]
+pub(crate) struct MathMultiplyNodeData(pub MathUnaryNodeData);
+#[derive(Clone, Default)]
+pub(crate) struct MathSubtractNodeData(pub MathUnaryNodeData);
+
+impl NodeTemplateTrait for MathAddNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Math.Add"
+  }
+}
+
+impl NodeTemplateTrait for MathDivideNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Math.Divide"
+  }
+}
+
+impl NodeTemplateTrait for MathModNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Math.Mod"
+  }
+}
+
+impl NodeTemplateTrait for MathMultiplyNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Math.Multiply"
+  }
+}
+
+impl NodeTemplateTrait for MathSubtractNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Math.Subtract"
+  }
+}
+
+impl UIRenderer for MathUnaryNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.add(egui::DragValue::new(&mut self.value));
+  }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct SetNodeData {
+  pub name: String,
+}
+
+impl NodeTemplateTrait for SetNodeData {
+  fn node_factory_label(&self) -> &str {
+    "Set"
+  }
+}
+
+impl UIRenderer for SetNodeData {
+  fn ui(&mut self, ui: &mut Ui) {
+    ui.text_edit_singleline(&mut self.name);
   }
 }

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -147,7 +147,9 @@ impl UIRenderer for ConstNodeData {
 
       if self.prev_type != self.value_type {
         self.prev_type = self.value_type;
-        // TODO: conversion or reset the value
+        // FIXME: conversion or reset the value
+        // for now just clear the value
+        self.value.payload = Default::default();
         self.value.valueType = self.value_type;
       }
 

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -172,7 +172,7 @@ fn any_type() -> Vec<SHType> {
     SHType_Float2,
     SHType_Float3,
     SHType_Float4,
-    // SHType_Color, // FIXME add support
+    SHType_Color,
     // SHType_ShardRef, // FIXME add support
     // SHType_EndOfBlittableTypes,
     // SHType_Bytes, // FIXME add support
@@ -303,6 +303,16 @@ impl UIRenderer for VarValue {
               ));
             })
             .response
+          }
+          SHType_Color => {
+            let color = &mut self.value.payload.__bindgen_anon_1.colorValue;
+            let mut srgba = [color.r, color.g, color.b, color.a];
+            let response = ui.color_edit_button_srgba_unmultiplied(&mut srgba);
+            color.r = srgba[0];
+            color.g = srgba[1];
+            color.b = srgba[2];
+            color.a = srgba[3];
+            response
           }
           SHType_String => {
             // FIXME need special care for string here

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -2,79 +2,74 @@
 /* Copyright © 2023 Fragcolor Pte. Ltd. */
 
 use super::{graph_ui::UIRenderer, node_factory::NodeTemplateTrait};
-use crate::core::cloneVar;
+use crate::core::{cloneVar, createShard, ShardInstance};
 use crate::shardsc::*;
 use crate::types::common_type::type2name;
 use crate::types::Var;
 use egui::{Response, Ui};
+use std::ffi::CStr;
+use std::ptr::slice_from_raw_parts;
 
-#[derive(Clone)]
-pub(crate) enum NodeTemplate {
-  AssertIs(AssertIsNodeData),
-  Const(ConstNodeData),
-  ForRange(ForRangeNodeData),
-  Get(GetNodeData),
-  Log(LogNodeData),
-  MathAdd(MathAddNodeData),
-  MathDivide(MathDivideNodeData),
-  MathMod(MathModNodeData),
-  MathMultiply(MathMultiplyNodeData),
-  MathSubtract(MathSubtractNodeData),
-  Set(SetNodeData),
+pub(crate) struct NodeTemplate {
+  name: &'static str,
+  instance: ShardInstance,
+}
+
+impl Clone for NodeTemplate {
+  fn clone(&self) -> Self {
+    // FIXME for now just create a new instance, but we might have to copy some stuff (like parameters' values)
+    Self::new(self.name)
+  }
+}
+
+impl NodeTemplate {
+  pub fn new(name: &'static str) -> Self {
+    Self {
+      name,
+      instance: createShard(name),
+    }
+  }
+
+  pub fn name(&self) -> &'static str {
+    self.name
+  }
 }
 
 // note: trait redirection because enum items are not considered types yet
 // FIXME maybe there is a better way, but all this code will eventually disappear once we "generate" it for each shard.
 
 impl NodeTemplateTrait for NodeTemplate {
-  fn node_factory_description(&self) -> &str {
-    match self {
-      NodeTemplate::AssertIs(x) => x.node_factory_description(),
-      NodeTemplate::Const(x) => x.node_factory_description(),
-      NodeTemplate::ForRange(x) => x.node_factory_description(),
-      NodeTemplate::Get(x) => x.node_factory_description(),
-      NodeTemplate::Log(x) => x.node_factory_description(),
-      NodeTemplate::MathAdd(x) => x.node_factory_description(),
-      NodeTemplate::MathDivide(x) => x.node_factory_description(),
-      NodeTemplate::MathMod(x) => x.node_factory_description(),
-      NodeTemplate::MathMultiply(x) => x.node_factory_description(),
-      NodeTemplate::MathSubtract(x) => x.node_factory_description(),
-      NodeTemplate::Set(x) => x.node_factory_description(),
-    }
+  fn node_factory_label(&self) -> &str {
+    self.name()
   }
 
-  fn node_factory_label(&self) -> &str {
-    match self {
-      NodeTemplate::AssertIs(x) => x.node_factory_label(),
-      NodeTemplate::Const(x) => x.node_factory_label(),
-      NodeTemplate::ForRange(x) => x.node_factory_label(),
-      NodeTemplate::Get(x) => x.node_factory_label(),
-      NodeTemplate::Log(x) => x.node_factory_label(),
-      NodeTemplate::MathAdd(x) => x.node_factory_label(),
-      NodeTemplate::MathDivide(x) => x.node_factory_label(),
-      NodeTemplate::MathMod(x) => x.node_factory_label(),
-      NodeTemplate::MathMultiply(x) => x.node_factory_label(),
-      NodeTemplate::MathSubtract(x) => x.node_factory_label(),
-      NodeTemplate::Set(x) => x.node_factory_label(),
+  fn node_factory_description(&self) -> &str {
+    let str = self.instance.help();
+    unsafe {
+      if str.string == std::ptr::null_mut() {
+        self.node_factory_label()
+      } else {
+        let slice = CStr::from_ptr(str.string);
+        slice.to_str().unwrap_or(self.node_factory_label())
+      }
     }
   }
 }
 
 impl UIRenderer for NodeTemplate {
   fn ui(&mut self, ui: &mut Ui) -> Response {
-    match self {
-      NodeTemplate::AssertIs(x) => x.ui(ui),
-      NodeTemplate::Const(x) => x.ui(ui),
-      NodeTemplate::ForRange(x) => x.ui(ui),
-      NodeTemplate::Get(x) => x.ui(ui),
-      NodeTemplate::Log(x) => x.ui(ui),
-      NodeTemplate::MathAdd(MathAddNodeData(x)) => x.ui(ui),
-      NodeTemplate::MathDivide(MathDivideNodeData(x)) => x.ui(ui),
-      NodeTemplate::MathMod(MathModNodeData(x)) => x.ui(ui),
-      NodeTemplate::MathMultiply(MathMultiplyNodeData(x)) => x.ui(ui),
-      NodeTemplate::MathSubtract(MathSubtractNodeData(x)) => x.ui(ui),
-      NodeTemplate::Set(x) => x.ui(ui),
-    }
+    ui.vertical(|ui| {
+      let params = self.instance.parameters();
+      if params.len > 0 {
+        unsafe {
+          let params = core::slice::from_raw_parts(params.elements, params.len as usize);
+          for p in params {
+            ui.label(CStr::from_ptr(p.name).to_str().unwrap());
+          }
+        }
+      }
+    })
+    .response
   }
 }
 
@@ -101,6 +96,40 @@ impl VarValue {
     cloneVar(&mut ret.value, initial_value);
     ret
   }
+}
+
+fn any_type() -> Vec<SHType> {
+  vec![
+    // SHType_None, // FIXME need special handling
+    // SHType_Any,
+    // SHType_Enum, // FIXME add support
+    SHType_Bool,
+    SHType_Int,
+    SHType_Int2,
+    SHType_Int3,
+    SHType_Int4,
+    // SHType_Int8, // FIXME add support
+    // SHType_Int16, // FIXME add support
+    SHType_Float,
+    SHType_Float2,
+    SHType_Float3,
+    SHType_Float4,
+    // SHType_Color, // FIXME add support
+    // SHType_ShardRef, // FIXME add support
+    // SHType_EndOfBlittableTypes,
+    // SHType_Bytes, // FIXME add support
+    // SHType_String, // FIXME need special handling
+    // SHType_Path, // FIXME add support
+    // SHType_ContextVar, // FIXME add support
+    // SHType_Image, // FIXME add support
+    // SHType_Seq, // FIXME add support
+    // SHType_Table, // FIXME add support
+    // SHType_Wire, // FIXME add support
+    // SHType_Object, // FIXME add support
+    // SHType_Array, // FIXME add support
+    // SHType_Set, // FIXME add support
+    // SHType_Audio, // FIXME add support
+  ]
 }
 
 impl UIRenderer for VarValue {
@@ -224,189 +253,5 @@ impl UIRenderer for VarValue {
       }
     })
     .response
-  }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct AssertIsNodeData {
-  // FIXME for now only support 64-bit integer
-  pub value: i64,
-  pub abort: bool,
-}
-
-impl NodeTemplateTrait for AssertIsNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Assert.Is"
-  }
-
-  fn node_factory_description(&self) -> &str {
-    "This assertion is used to check whether the input is equal to a given value."
-  }
-}
-
-impl UIRenderer for AssertIsNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    ui.vertical(|ui| {
-      ui.add(egui::DragValue::new(&mut self.value));
-      ui.checkbox(&mut self.abort, "Abort?");
-    })
-    .response
-  }
-}
-
-#[derive(Clone)]
-pub(crate) struct ConstNodeData {
-  pub value: VarValue,
-  pub override_label: Option<&'static str>,
-}
-
-impl NodeTemplateTrait for ConstNodeData {
-  fn node_factory_label(&self) -> &str {
-    self.override_label.unwrap_or("Const")
-  }
-
-  fn node_factory_description(&self) -> &str {
-    "Declares an un-named constant value."
-  }
-}
-
-// FIXME refactor. This should be part of some util that can be used wherever there is a value.
-impl UIRenderer for ConstNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    self.value.ui(ui)
-  }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct ForRangeNodeData {
-  // FIXME for now only support 64-bit integer
-  pub from: i64,
-  pub to: i64,
-}
-
-impl NodeTemplateTrait for ForRangeNodeData {
-  fn node_factory_label(&self) -> &str {
-    "ForRange"
-  }
-}
-
-impl UIRenderer for ForRangeNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    ui.vertical(|ui| {
-      ui.add(egui::DragValue::new(&mut self.from));
-      if self.from > self.to {
-        self.from = self.to;
-      }
-      ui.add(egui::DragValue::new(&mut self.to));
-      if self.to < self.from {
-        self.to = self.from;
-      }
-      // FIXME inner contents
-      // contents(ui);
-    })
-    .response
-  }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct GetNodeData {
-  pub name: String,
-}
-
-impl NodeTemplateTrait for GetNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Get"
-  }
-}
-
-impl UIRenderer for GetNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    ui.text_edit_singleline(&mut self.name)
-  }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct LogNodeData {
-  pub label: String,
-}
-
-impl NodeTemplateTrait for LogNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Log"
-  }
-}
-
-impl UIRenderer for LogNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    ui.text_edit_singleline(&mut self.label)
-  }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct MathUnaryNodeData {
-  pub value: VarValue,
-}
-
-#[derive(Clone)]
-pub(crate) struct MathAddNodeData(pub MathUnaryNodeData);
-#[derive(Clone, Default)]
-pub(crate) struct MathDivideNodeData(pub MathUnaryNodeData);
-#[derive(Clone, Default)]
-pub(crate) struct MathModNodeData(pub MathUnaryNodeData);
-#[derive(Clone, Default)]
-pub(crate) struct MathMultiplyNodeData(pub MathUnaryNodeData);
-#[derive(Clone, Default)]
-pub(crate) struct MathSubtractNodeData(pub MathUnaryNodeData);
-
-impl NodeTemplateTrait for MathAddNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Math.Add"
-  }
-}
-
-impl NodeTemplateTrait for MathDivideNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Math.Divide"
-  }
-}
-
-impl NodeTemplateTrait for MathModNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Math.Mod"
-  }
-}
-
-impl NodeTemplateTrait for MathMultiplyNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Math.Multiply"
-  }
-}
-
-impl NodeTemplateTrait for MathSubtractNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Math.Subtract"
-  }
-}
-
-impl UIRenderer for MathUnaryNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    self.value.ui(ui)
-  }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct SetNodeData {
-  pub name: String,
-}
-
-impl NodeTemplateTrait for SetNodeData {
-  fn node_factory_label(&self) -> &str {
-    "Set"
-  }
-}
-
-impl UIRenderer for SetNodeData {
-  fn ui(&mut self, ui: &mut Ui) -> Response {
-    ui.text_edit_singleline(&mut self.name)
   }
 }

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use super::graph_ui::UIRenderer;
+use egui::Ui;
+
+pub(crate) enum NodeTemplate {}
+
+impl UIRenderer for NodeTemplate {
+  fn ui(&mut self, ui: &mut Ui) {
+    match self {
+      _ => {}
+    }
+  }
+}

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -179,9 +179,6 @@ impl UIRenderer for ShardData {
 #[derive(Default)]
 pub(crate) struct VarValue {
   value: Var,
-  // FIXME String special case (for now)
-  value_s: String,
-  // ---
   allowed_types: Vec<SHType>,
   prev_type: SHType,
   // FIXME use this to "restore" previous value
@@ -216,7 +213,6 @@ impl VarValue {
       allowed_types,
       ..Default::default()
     };
-    // FIXME deal with the String case
     cloneVar(&mut ret.value, initial_value);
     ret.prev_type = ret.value.valueType;
     ret
@@ -253,7 +249,7 @@ fn any_type() -> Vec<SHType> {
     // SHType_ShardRef, // FIXME add support
     // SHType_EndOfBlittableTypes,
     // SHType_Bytes, // FIXME add support
-    // SHType_String, // FIXME need special handling
+    SHType_String,
     // SHType_Path, // FIXME add support
     // SHType_ContextVar, // FIXME add support
     // SHType_Image, // FIXME add support
@@ -408,8 +404,8 @@ impl UIRenderer for VarValue {
             response
           }
           SHType_String => {
-            // FIXME need special care for string here
-            ui.text_edit_singleline(&mut self.value_s)
+            let mut mutable = &mut self.value;
+            ui.text_edit_singleline(&mut mutable)
           }
           _ => ui.colored_label(egui::Color32::RED, "Type of value not supported."),
         }

--- a/rust/src/shards/editor/util.rs
+++ b/rust/src/shards/editor/util.rs
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use egui::Color32;
+
+pub(crate) trait ColorUtils: Sized {
+  type Error;
+
+  /// Multiplies the color rgb values by `factor`, keeping alpha untouched.
+  fn lighten(&self, factor: f32) -> Self;
+  /// Converts a hex string with a leading '#' into a egui::Color32.
+  /// - The first three channels are interpreted as R, G, B.
+  /// - The fourth channel, if present, is used as the alpha value.
+  /// - Both upper and lowercase characters can be used for the hex values.
+  ///
+  /// *Adapted from: https://docs.rs/raster/0.1.0/src/raster/lib.rs.html#425-725.
+  /// Credit goes to original authors.*
+  fn from_hex(hex: &str) -> Result<Self, Self::Error>;
+  /// Converts a color into its canonical hexadecimal representation.
+  /// - The color string will be preceded by '#'.
+  /// - If the alpha channel is completely opaque, it will be ommitted.
+  /// - Characters from 'a' to 'f' will be written in lowercase.
+  fn to_hex(&self) -> String;
+}
+
+impl ColorUtils for Color32 {
+  type Error = &'static str;
+
+  fn lighten(&self, factor: f32) -> Self {
+    Color32::from_rgba_premultiplied(
+      (self.r() as f32 * factor) as u8,
+      (self.g() as f32 * factor) as u8,
+      (self.b() as f32 * factor) as u8,
+      self.a(),
+    )
+  }
+
+  fn from_hex(hex: &str) -> Result<Self, Self::Error> {
+    // Convert a hex string to decimal. Eg. "00" -> 0. "FF" -> 255.
+    fn _hex_dec(hex_string: &str) -> Result<u8, &'static str> {
+      match u8::from_str_radix(hex_string, 16) {
+        Ok(o) => Ok(o),
+        Err(_) => Err("Error parsing hex"),
+      }
+    }
+
+    if hex.len() == 9 && hex.starts_with('#') {
+      // #FFFFFFFF (Red Green Blue Alpha)
+      return Ok(Color32::from_rgba_premultiplied(
+        _hex_dec(&hex[1..3])?,
+        _hex_dec(&hex[3..5])?,
+        _hex_dec(&hex[5..7])?,
+        _hex_dec(&hex[7..9])?,
+      ));
+    } else if hex.len() == 7 && hex.starts_with('#') {
+      // #FFFFFF (Red Green Blue)
+      return Ok(Color32::from_rgb(
+        _hex_dec(&hex[1..3])?,
+        _hex_dec(&hex[3..5])?,
+        _hex_dec(&hex[5..7])?,
+      ));
+    }
+
+    Err("Error parsing hex. Example of valid formats: #FFFFFF or #ffffffff")
+  }
+
+  fn to_hex(&self) -> String {
+    if self.a() < 255 {
+      format!(
+        "#{:02x?}{:02x?}{:02x?}{:02x?}",
+        self.r(),
+        self.g(),
+        self.b(),
+        self.a()
+      )
+    } else {
+      format!("#{:02x?}{:02x?}{:02x?}", self.r(), self.g(), self.b())
+    }
+  }
+}

--- a/rust/src/shards/eth.rs
+++ b/rust/src/shards/eth.rs
@@ -120,7 +120,7 @@ fn token_to_var(token: Token) -> Result<ClonedVar, &'static str> {
       let mut s = Seq::new();
       for token in tokens {
         let v = token_to_var(token)?;
-        s.push(v.0);
+        s.push(&v.0);
       }
       Ok(s.as_ref().into())
     }
@@ -414,7 +414,7 @@ impl Shard for DecodeCall {
 
       for token in decoded {
         let value: ClonedVar = token.try_into()?;
-        self.output.push(value.0);
+        self.output.push(&value.0);
       }
 
       Ok(self.output.as_ref().into())

--- a/rust/src/shards/gui/containers/docking.rs
+++ b/rust/src/shards/gui/containers/docking.rs
@@ -182,7 +182,7 @@ impl Shard for Tab {
       return Ok(false.into());
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)?;
 
       // Always passthrough the input
@@ -400,7 +400,7 @@ impl Shard for DockArea {
 
     let dock = egui_dock::DockArea::new(&mut self.tabs).style(style);
 
-    let parents_stack_var = *self.parents.get();
+    let parents_stack_var = self.parents.get();
     let mut viewer = MyTabViewer::new(context, input);
     viewer.warmup();
     if let Some(ui) = util::get_current_parent(parents_stack_var)? {

--- a/rust/src/shards/gui/containers/panels.rs
+++ b/rust/src/shards/gui/containers/panels.rs
@@ -247,7 +247,7 @@ macro_rules! impl_panel {
           panel = panel.$max_size($max_size.try_into()?);
         }
 
-        if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+        if let Some(ui) = util::get_current_parent(self.parents.get())? {
           panel
             .show_inside(ui, |ui| {
               util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
@@ -442,7 +442,7 @@ impl Shard for CentralPanel {
 
     let gui_ctx = util::get_current_context(&self.instance)?;
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       egui::CentralPanel::default()
         .show_inside(ui, |ui| {
           util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)

--- a/rust/src/shards/gui/containers/scope.rs
+++ b/rust/src/shards/gui/containers/scope.rs
@@ -158,7 +158,7 @@ impl Shard for Scope {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.scope(|ui| {
         util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
       })

--- a/rust/src/shards/gui/containers/window.rs
+++ b/rust/src/shards/gui/containers/window.rs
@@ -14,6 +14,7 @@ use crate::shards::gui::EGUI_CTX_TYPE;
 use crate::shards::gui::FLOAT2_VAR_SLICE;
 use crate::shards::gui::HELP_OUTPUT_EQUAL_INPUT;
 use crate::shards::gui::PARENTS_UI_NAME;
+use crate::types::common_type;
 use crate::types::Context;
 use crate::types::ExposedInfo;
 use crate::types::ExposedTypes;
@@ -33,7 +34,8 @@ use crate::types::SHARDS_OR_NONE_TYPES;
 use crate::types::STRING_TYPES;
 
 lazy_static! {
-  static ref WINDOW_FLAGS_OR_SEQ_TYPES: Vec<Type> = vec![*WINDOW_FLAGS_TYPE, *SEQ_OF_WINDOW_FLAGS];
+  static ref WINDOW_FLAGS_OR_SEQ_TYPES: Vec<Type> =
+    vec![common_type::none, *WINDOW_FLAGS_TYPE, *SEQ_OF_WINDOW_FLAGS];
   static ref WINDOW_PARAMETERS: Parameters = vec![
     (
       cstr!("Title"),

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -8,10 +8,8 @@ use crate::types::ParamVar;
 use egui::{Pos2, Vec2};
 use slotmap::{SecondaryMap, SlotMap};
 
-struct ShardViewer {
-  parents: ParamVar,
-  requiring: ExposedTypes,
-  graph: Graph<NodeTemplate>,
+struct GraphEditorState<NodeData, NodeTemplate> {
+  graph: Graph<NodeData>,
   /// Nodes are drawn in this order. Draw order is important because nodes
   /// that are drawn last are on top.
   node_order: Vec<NodeId>,
@@ -24,8 +22,14 @@ struct ShardViewer {
   ongoing_box_selection: Option<egui::Pos2>,
   /// The node factory.
   node_factory: Option<NodeFactory<NodeTemplate>>,
-  // FIXME find a better way to list all templates
+  // The node templates.
   all_templates: Vec<NodeTemplate>,
+}
+
+struct ShardViewer {
+  parents: ParamVar,
+  requiring: ExposedTypes,
+  state: GraphEditorState<ShardData, ShardTemplate>,
 }
 
 mod shard_viewer;

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -20,6 +20,8 @@ struct ShardViewer {
   /// The currently selected node. Some interface actions depend on the
   /// currently selected node.
   selected_nodes: Vec<NodeId>,
+  /// The mouse drag start position for an ongoing box selection.
+  ongoing_box_selection: Option<egui::Pos2>,
   /// The node factory.
   node_factory: Option<NodeFactory<NodeTemplate>>,
   // FIXME find a better way to list all templates

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -26,10 +26,10 @@ struct GraphEditorState<NodeData, NodeTemplate> {
   all_templates: Vec<NodeTemplate>,
 }
 
-struct ShardViewer {
+struct ShardViewer<'a> {
   parents: ParamVar,
   requiring: ExposedTypes,
-  state: GraphEditorState<ShardData, ShardTemplate>,
+  state: GraphEditorState<ShardData<'a>, ShardTemplate<'a>>,
 }
 
 mod shard_viewer;

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -22,7 +22,7 @@ struct ShardViewer {
   selected_nodes: Vec<NodeId>,
   /// The node factory.
   node_factory: Option<NodeFactory<NodeTemplate>>,
-  // FIXME: find a better way to list all templates
+  // FIXME find a better way to list all templates
   all_templates: Vec<NodeTemplate>,
 }
 

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use crate::core::registerShard;
+use crate::shards::editor::*;
+use crate::types::ExposedTypes;
+use crate::types::ParamVar;
+use egui::{Pos2, Vec2};
+use slotmap::{SecondaryMap, SlotMap};
+
+struct ShardViewer {
+  parents: ParamVar,
+  requiring: ExposedTypes,
+  graph: Graph<NodeTemplate>,
+  /// Nodes are drawn in this order. Draw order is important because nodes
+  /// that are drawn last are on top.
+  node_order: Vec<NodeId>,
+  /// The position of each node.
+  node_positions: SecondaryMap<NodeId, Pos2>,
+  /// The currently selected node. Some interface actions depend on the
+  /// currently selected node.
+  selected_nodes: Vec<NodeId>,
+}
+
+mod shard_viewer;
+
+pub fn registerShards() {
+  registerShard::<ShardViewer>();
+}

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -20,6 +20,10 @@ struct ShardViewer {
   /// The currently selected node. Some interface actions depend on the
   /// currently selected node.
   selected_nodes: Vec<NodeId>,
+  /// The node factory.
+  node_factory: Option<NodeFactory<NodeTemplate>>,
+  // FIXME: find a better way to list all templates
+  all_templates: Vec<NodeTemplate>,
 }
 
 mod shard_viewer;

--- a/rust/src/shards/gui/editor/shard_viewer.rs
+++ b/rust/src/shards/gui/editor/shard_viewer.rs
@@ -34,7 +34,7 @@ impl<NodeData, NodeTemplate> Default for GraphEditorState<NodeData, NodeTemplate
   }
 }
 
-impl Default for ShardViewer {
+impl<'a> Default for ShardViewer<'a> {
   fn default() -> Self {
     let mut parents = ParamVar::default();
     parents.set_name(PARENTS_UI_NAME);
@@ -46,7 +46,7 @@ impl Default for ShardViewer {
   }
 }
 
-impl Shard for ShardViewer {
+impl<'a> Shard for ShardViewer<'a> {
   fn registerName() -> &'static str
   where
     Self: Sized,
@@ -152,7 +152,7 @@ impl Shard for ShardViewer {
 // (schedule root main-wire)
 // (run root)
 
-impl ShardViewer {
+impl<'a> ShardViewer<'a> {
   fn init(&mut self) {
     let mut shards: Vec<&str> = getShards()
       .into_iter()

--- a/rust/src/shards/gui/editor/shard_viewer.rs
+++ b/rust/src/shards/gui/editor/shard_viewer.rs
@@ -1,0 +1,178 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use super::ShardViewer;
+use crate::shard::Shard;
+use crate::shards::editor::*;
+use crate::shards::gui::util;
+use crate::shards::gui::HELP_OUTPUT_EQUAL_INPUT;
+use crate::shards::gui::HELP_VALUE_IGNORED;
+use crate::shards::gui::PARENTS_UI_NAME;
+use crate::types::Context;
+use crate::types::ExposedTypes;
+use crate::types::OptionalString;
+use crate::types::ParamVar;
+use crate::types::Types;
+use crate::types::Var;
+use crate::types::ANY_TYPES;
+
+impl Default for ShardViewer {
+  fn default() -> Self {
+    let mut parents = ParamVar::default();
+    parents.set_name(PARENTS_UI_NAME);
+    Self {
+      parents,
+      requiring: Vec::new(),
+      graph: Default::default(),
+      node_order: Vec::new(),
+      node_positions: Default::default(),
+      selected_nodes: Vec::new(),
+    }
+  }
+}
+
+impl Shard for ShardViewer {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("UI.ShardViewer")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("UI.ShardViewer-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "UI.ShardViewer"
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn inputHelp(&mut self) -> OptionalString {
+    *HELP_VALUE_IGNORED
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn outputHelp(&mut self) -> OptionalString {
+    *HELP_OUTPUT_EQUAL_INPUT
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.Parents to the list of required variables
+    util::require_parents(&mut self.requiring, &self.parents);
+
+    Some(&self.requiring)
+  }
+
+  fn warmup(&mut self, context: &Context) -> Result<(), &str> {
+    self.parents.warmup(context);
+
+    self.init();
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.parents.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
+      self.show(ui);
+
+      // Always passthrough the input
+      Ok(*input)
+    } else {
+      Err("No UI parent")
+    }
+  }
+}
+
+impl ShardViewer {
+  fn init(&mut self) {}
+
+  fn show(&mut self, ui: &mut egui::Ui) {
+    // This causes the graph editor to use as much free space as it can.
+    // (so for windows it will use up to the resizeably set limit
+    // and for a Panel it will fill it completely)
+    let editor_rect = ui.max_rect();
+    ui.allocate_rect(editor_rect, egui::Sense::hover());
+
+    // let cursor_pos = ui.ctx().input().pointer.hover_pos().unwrap_or(Pos2::ZERO);
+    // let mut cursor_in_editor = editor_rect.contains(cursor_pos);
+    // let mut cursor_in_finder = false;
+
+    // The responses returned from node drawing have side effects that are best
+    // executed at the end of this function.
+    let mut delayed_responses = Vec::new();
+
+    // // Used to detect when the background was clicked
+    // let mut click_on_background = false;
+
+    // // Used to detect drag events in the background
+    // let mut drag_started_on_background = false;
+    // let mut drag_released_on_background = false;
+
+    /* Draw nodes */
+    for node_id in self.node_order.iter().copied() {
+      let responses = GraphNodeWidget {
+        position: self.node_positions.get_mut(node_id).unwrap(),
+        graph: &mut self.graph,
+        node_id,
+        pan: editor_rect.min.to_vec2(),
+        selected: self
+          .selected_nodes
+          .iter()
+          .any(|selected| *selected == node_id),
+      }
+      .show(ui);
+
+      delayed_responses.extend(responses);
+    }
+
+    // let r = ui.allocate_rect(
+    //   ui.min_rect(),
+    //   egui::Sense::click().union(egui::Sense::drag()),
+    // );
+    // if r.clicked() {
+    //   click_on_background = true;
+    // } else if r.drag_started() {
+    //   drag_started_on_background = true;
+    // } else if r.drag_released() {
+    //   drag_released_on_background = true;
+    // }
+
+    /* Handle responses from drawing nodes */
+    for response in delayed_responses.iter() {
+      match response {
+        NodeResponse::MoveNode { node, drag_delta } => {
+          self.node_positions[*node] += *drag_delta;
+        }
+        NodeResponse::RaiseNode(node_id) => {
+          let old_pos = self
+            .node_order
+            .iter()
+            .position(|id| *id == *node_id)
+            .expect("Node to be raised should be in `node_order`");
+          self.node_order.remove(old_pos);
+          self.node_order.push(*node_id);
+        }
+        NodeResponse::SelectNode(node_id) => {
+          self.selected_nodes = Vec::from([*node_id]);
+        }
+      }
+    }
+  }
+}

--- a/rust/src/shards/gui/editor/shard_viewer.rs
+++ b/rust/src/shards/gui/editor/shard_viewer.rs
@@ -284,8 +284,16 @@ impl ShardViewer {
     /* Handle responses from drawing nodes */
     for response in delayed_responses.iter() {
       match response {
-        NodeResponse::MoveNode { node, drag_delta } => {
-          self.node_positions[*node] += *drag_delta;
+        NodeResponse::DeleteNodeUi(node_id) => {
+          self.graph.remove_node(*node_id);
+          self.node_positions.remove(*node_id);
+          self.node_order.retain(|id| *id != *node_id);
+        }
+        NodeResponse::MoveNode {
+          node: node_id,
+          drag_delta,
+        } => {
+          self.node_positions[*node_id] += *drag_delta;
         }
         NodeResponse::RaiseNode(node_id) => {
           let old_pos = self

--- a/rust/src/shards/gui/editor/shard_viewer.rs
+++ b/rust/src/shards/gui/editor/shard_viewer.rs
@@ -8,6 +8,7 @@ use crate::shards::gui::util;
 use crate::shards::gui::HELP_OUTPUT_EQUAL_INPUT;
 use crate::shards::gui::HELP_VALUE_IGNORED;
 use crate::shards::gui::PARENTS_UI_NAME;
+use crate::shardsc::*;
 use crate::types::Context;
 use crate::types::ExposedTypes;
 use crate::types::OptionalString;
@@ -142,17 +143,50 @@ impl Shard for ShardViewer {
 impl ShardViewer {
   fn init(&mut self) {
     let templates = vec![
-      NodeTemplate::AssertIs(Default::default()),
-      NodeTemplate::Const(Default::default()),
-      NodeTemplate::ForRange(Default::default()),
+      NodeTemplate::Const(ConstNodeData {
+        override_label: "Const(Int)".into(),
+        value: VarValue::new(
+          &Var::from(0),
+          vec![
+            SHType_Int,
+            SHType_Int2,
+            SHType_Int3,
+            SHType_Int4,
+            SHType_Int8,
+          ],
+        ),
+      }),
+      NodeTemplate::Const(ConstNodeData {
+        override_label: Some("Const(Float)"),
+        value: VarValue::new(
+          &Var::from(0.0),
+          vec![SHType_Float, SHType_Float2, SHType_Float3, SHType_Float4],
+        ),
+      }),
+      // NodeTemplate::AssertIs(Default::default()),
+      // NodeTemplate::ForRange(Default::default()),
       NodeTemplate::Get(Default::default()),
+      NodeTemplate::Set(Default::default()),
       NodeTemplate::Log(Default::default()),
-      NodeTemplate::MathAdd(Default::default()),
+      NodeTemplate::MathAdd(MathAddNodeData(MathUnaryNodeData {
+        value: VarValue::new(
+          &Var::from(0),
+          vec![
+            SHType_Int,
+            SHType_Int2,
+            SHType_Int3,
+            SHType_Int4,
+            SHType_Float,
+            SHType_Float2,
+            SHType_Float3,
+            SHType_Float4,
+          ],
+        ),
+      })),
       NodeTemplate::MathDivide(Default::default()),
       NodeTemplate::MathMultiply(Default::default()),
       NodeTemplate::MathMod(Default::default()),
       NodeTemplate::MathSubtract(Default::default()),
-      NodeTemplate::Set(Default::default()),
     ];
     self.all_templates.extend(templates);
   }
@@ -227,9 +261,10 @@ impl ShardViewer {
           let new_node = self
             .graph
             .add_node(template.node_factory_label().into(), template.clone());
-          self
-            .node_positions
-            .insert(new_node, cursor_pos - editor_rect.min.to_vec2());
+          self.node_positions.insert(
+            new_node,
+            node_factory.position.unwrap_or(cursor_pos) - editor_rect.min.to_vec2(),
+          );
           self.node_order.push(new_node);
           should_close_node_factory = true;
         }

--- a/rust/src/shards/gui/editor/shard_viewer.rs
+++ b/rust/src/shards/gui/editor/shard_viewer.rs
@@ -27,6 +27,8 @@ impl Default for ShardViewer {
       node_order: Vec::new(),
       node_positions: Default::default(),
       selected_nodes: Vec::new(),
+      node_factory: None,
+      all_templates: Vec::new(),
     }
   }
 }
@@ -100,8 +102,60 @@ impl Shard for ShardViewer {
   }
 }
 
+// Euler problem 1
+// ---------------
+// required "blocks":
+// - wire definition
+// - variable definition
+// - integer constant
+// - boolean constant
+// - Assert.Is
+// - Get
+// - ForRange
+// - Is
+// - Log
+// - Or
+// - Math.Add
+// - Math.Mod
+// - Set
+// - When
+//
+// notes: for now, mesh, scheduling and running will be implicit/hidden
+//
+// shard code:
+// (defwire main-wire
+//   0 >= .sum
+//
+//   (ForRange
+//    1 999
+//    (When
+//     (-> (Math.Mod 3) (Is 0) (Or) (Math.Mod 5) (Is 0))
+//     (-> (Math.Add .sum) > .sum)))
+//
+//   .sum (Assert.Is 233168 true)
+//   (Log "Answer"))
+//
+// (defmesh root)
+// (schedule root main-wire)
+// (run root)
+
 impl ShardViewer {
-  fn init(&mut self) {}
+  fn init(&mut self) {
+    let templates = vec![
+      NodeTemplate::AssertIs(Default::default()),
+      NodeTemplate::Const(Default::default()),
+      NodeTemplate::ForRange(Default::default()),
+      NodeTemplate::Get(Default::default()),
+      NodeTemplate::Log(Default::default()),
+      NodeTemplate::MathAdd(Default::default()),
+      NodeTemplate::MathDivide(Default::default()),
+      NodeTemplate::MathMultiply(Default::default()),
+      NodeTemplate::MathMod(Default::default()),
+      NodeTemplate::MathSubtract(Default::default()),
+      NodeTemplate::Set(Default::default()),
+    ];
+    self.all_templates.extend(templates);
+  }
 
   fn show(&mut self, ui: &mut egui::Ui) {
     // This causes the graph editor to use as much free space as it can.
@@ -110,16 +164,21 @@ impl ShardViewer {
     let editor_rect = ui.max_rect();
     ui.allocate_rect(editor_rect, egui::Sense::hover());
 
-    // let cursor_pos = ui.ctx().input().pointer.hover_pos().unwrap_or(Pos2::ZERO);
-    // let mut cursor_in_editor = editor_rect.contains(cursor_pos);
-    // let mut cursor_in_finder = false;
+    let cursor_pos = ui
+      .ctx()
+      .input()
+      .pointer
+      .hover_pos()
+      .unwrap_or(egui::Pos2::ZERO);
+    let mut cursor_in_editor = editor_rect.contains(cursor_pos);
+    let mut cursor_in_factory = false;
 
     // The responses returned from node drawing have side effects that are best
     // executed at the end of this function.
     let mut delayed_responses = Vec::new();
 
     // // Used to detect when the background was clicked
-    // let mut click_on_background = false;
+    let mut click_on_background = false;
 
     // // Used to detect drag events in the background
     // let mut drag_started_on_background = false;
@@ -142,17 +201,50 @@ impl ShardViewer {
       delayed_responses.extend(responses);
     }
 
-    // let r = ui.allocate_rect(
-    //   ui.min_rect(),
-    //   egui::Sense::click().union(egui::Sense::drag()),
-    // );
-    // if r.clicked() {
-    //   click_on_background = true;
-    // } else if r.drag_started() {
-    //   drag_started_on_background = true;
-    // } else if r.drag_released() {
-    //   drag_released_on_background = true;
-    // }
+    let r = ui.allocate_rect(
+      ui.min_rect(),
+      egui::Sense::click().union(egui::Sense::drag()),
+    );
+    if r.clicked() {
+      click_on_background = true;
+      // } else if r.drag_started() {
+      //   drag_started_on_background = true;
+      // } else if r.drag_released() {
+      //   drag_released_on_background = true;
+    }
+
+    /* Draw the node factory, if open */
+    let mut should_close_node_factory = false;
+    if let Some(ref mut node_factory) = self.node_factory {
+      let mut node_factory_area = egui::Area::new("node_factory")
+        .order(egui::Order::Foreground)
+        .movable(false);
+      if let Some(pos) = node_factory.position {
+        node_factory_area = node_factory_area.current_pos(pos);
+      }
+      node_factory_area.show(ui.ctx(), |ui| {
+        if let Some(template) = node_factory.show(ui, &self.all_templates) {
+          let new_node = self
+            .graph
+            .add_node(template.node_factory_label().into(), template.clone());
+          self
+            .node_positions
+            .insert(new_node, cursor_pos - editor_rect.min.to_vec2());
+          self.node_order.push(new_node);
+          should_close_node_factory = true;
+        }
+        let factory_rect = ui.min_rect();
+        // If the cursor is not in the main editor, check if the cursor is in the factory
+        // if the cursor is in the factory, then we can consider that also in the editor.
+        if factory_rect.contains(cursor_pos) {
+          cursor_in_editor = true;
+          cursor_in_factory = true;
+        }
+      });
+    }
+    if should_close_node_factory {
+      self.node_factory = None;
+    }
 
     /* Handle responses from drawing nodes */
     for response in delayed_responses.iter() {
@@ -173,6 +265,21 @@ impl ShardViewer {
           self.selected_nodes = Vec::from([*node_id]);
         }
       }
+    }
+
+    /* Mouse input handling */
+    let mouse = &ui.ctx().input().pointer;
+    if mouse.secondary_released() && cursor_in_editor && !cursor_in_factory {
+      self.node_factory = Some(NodeFactory::new_at(cursor_pos));
+    }
+    if ui.ctx().input().key_pressed(egui::Key::Escape) {
+      self.node_factory = None;
+    }
+    // Deselect and deactivate factory if the editor backround is clicked,
+    // *or* if the the mouse clicks off the ui
+    if click_on_background || (mouse.any_click() && !cursor_in_editor) {
+      self.selected_nodes = Vec::new();
+      self.node_factory = None;
     }
   }
 }

--- a/rust/src/shards/gui/editor/shard_viewer.rs
+++ b/rust/src/shards/gui/editor/shard_viewer.rs
@@ -2,6 +2,7 @@
 /* Copyright © 2023 Fragcolor Pte. Ltd. */
 
 use super::ShardViewer;
+use crate::core::getShards;
 use crate::shard::Shard;
 use crate::shards::editor::*;
 use crate::shards::gui::util;
@@ -144,52 +145,12 @@ impl Shard for ShardViewer {
 
 impl ShardViewer {
   fn init(&mut self) {
-    let templates = vec![
-      NodeTemplate::Const(ConstNodeData {
-        override_label: "Const(Int)".into(),
-        value: VarValue::new(
-          &Var::from(0),
-          vec![
-            SHType_Int,
-            SHType_Int2,
-            SHType_Int3,
-            SHType_Int4,
-            SHType_Int8,
-          ],
-        ),
-      }),
-      NodeTemplate::Const(ConstNodeData {
-        override_label: Some("Const(Float)"),
-        value: VarValue::new(
-          &Var::from(0.0),
-          vec![SHType_Float, SHType_Float2, SHType_Float3, SHType_Float4],
-        ),
-      }),
-      // NodeTemplate::AssertIs(Default::default()),
-      // NodeTemplate::ForRange(Default::default()),
-      NodeTemplate::Get(Default::default()),
-      NodeTemplate::Set(Default::default()),
-      NodeTemplate::Log(Default::default()),
-      NodeTemplate::MathAdd(MathAddNodeData(MathUnaryNodeData {
-        value: VarValue::new(
-          &Var::from(0),
-          vec![
-            SHType_Int,
-            SHType_Int2,
-            SHType_Int3,
-            SHType_Int4,
-            SHType_Float,
-            SHType_Float2,
-            SHType_Float3,
-            SHType_Float4,
-          ],
-        ),
-      })),
-      NodeTemplate::MathDivide(Default::default()),
-      NodeTemplate::MathMultiply(Default::default()),
-      NodeTemplate::MathMod(Default::default()),
-      NodeTemplate::MathSubtract(Default::default()),
-    ];
+    let mut shards: Vec<&str> = getShards()
+      .into_iter()
+      .map(|s| s.to_str().unwrap())
+      .collect();
+    shards.sort();
+    let templates = shards.iter().map(|s| NodeTemplate::new(s));
     self.all_templates.extend(templates);
   }
 

--- a/rust/src/shards/gui/egui_host.rs
+++ b/rust/src/shards/gui/egui_host.rs
@@ -143,7 +143,7 @@ impl EguiHost {
           error = (|| -> Result<(), &str> {
             // Push empty parent UI in case this context is nested inside another UI
             util::update_seq(&mut self.parents, |seq| {
-              seq.push(Var::default());
+              seq.push(&Var::default());
             })?;
 
             let mut _output = Var::default();

--- a/rust/src/shards/gui/layouts/collapsing_header.rs
+++ b/rust/src/shards/gui/layouts/collapsing_header.rs
@@ -197,7 +197,7 @@ impl Shard for CollapsingHeader {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let default_open: bool = self.defaultOpen.get().try_into()?;
 
       if let Some(ret) = if self.header.is_empty() {

--- a/rust/src/shards/gui/layouts/columns.rs
+++ b/rust/src/shards/gui/layouts/columns.rs
@@ -173,7 +173,7 @@ impl Shard for Columns {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.columns(len, |columns| {
         for (i, item) in columns.iter_mut().enumerate() {
           util::activate_ui_contents(context, input, item, &mut self.parents, &mut self.shards[i])?;

--- a/rust/src/shards/gui/layouts/disable.rs
+++ b/rust/src/shards/gui/layouts/disable.rs
@@ -171,7 +171,7 @@ impl Shard for Disable {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.scope(|ui| {
         let disabled: bool = self.disable.get().try_into()?;
         ui.set_enabled(!disabled);

--- a/rust/src/shards/gui/layouts/frame.rs
+++ b/rust/src/shards/gui/layouts/frame.rs
@@ -232,7 +232,7 @@ impl Shard for Frame {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let inner_margin = self.innerMargin.get();
       let inner_margin = if inner_margin.is_none() {
         egui::style::Margin::default()

--- a/rust/src/shards/gui/layouts/grid.rs
+++ b/rust/src/shards/gui/layouts/grid.rs
@@ -209,7 +209,7 @@ impl Shard for Grid {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let mut grid = egui::Grid::new(EguiId::new(self, 0));
 
       let striped = self.striped.get();
@@ -320,7 +320,7 @@ impl Shard for NextRow {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.end_row();
 
       // Always passthrough the input

--- a/rust/src/shards/gui/layouts/group.rs
+++ b/rust/src/shards/gui/layouts/group.rs
@@ -155,7 +155,7 @@ impl Shard for Group {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.group(|ui| {
         util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
       })

--- a/rust/src/shards/gui/layouts/horizontal.rs
+++ b/rust/src/shards/gui/layouts/horizontal.rs
@@ -169,7 +169,7 @@ impl Shard for Horizontal {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let wrap: bool = self.wrap.get().try_into()?;
       if wrap {
         ui.horizontal_wrapped(|ui| {

--- a/rust/src/shards/gui/layouts/indent.rs
+++ b/rust/src/shards/gui/layouts/indent.rs
@@ -158,7 +158,7 @@ impl Shard for Indent {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.indent(EguiId::new(self, 0), |ui| {
         util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
       })

--- a/rust/src/shards/gui/layouts/scroll_area.rs
+++ b/rust/src/shards/gui/layouts/scroll_area.rs
@@ -193,7 +193,7 @@ impl Shard for ScrollArea {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       egui::ScrollArea::new([
         self.horizontal.get().try_into()?,
         self.vertical.get().try_into()?,

--- a/rust/src/shards/gui/layouts/separator.rs
+++ b/rust/src/shards/gui/layouts/separator.rs
@@ -89,7 +89,7 @@ impl Shard for Separator {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.separator();
 
       Ok(*input)

--- a/rust/src/shards/gui/layouts/space.rs
+++ b/rust/src/shards/gui/layouts/space.rs
@@ -121,7 +121,7 @@ impl Shard for Space {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.add_space(self.amount.get().try_into()?);
 
       Ok(*input)

--- a/rust/src/shards/gui/layouts/table.rs
+++ b/rust/src/shards/gui/layouts/table.rs
@@ -330,7 +330,7 @@ impl Shard for Table {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.push_id(EguiId::new(self, 0), |ui| {
         use egui_extras::{Column, TableBuilder};
 

--- a/rust/src/shards/gui/layouts/vertical.rs
+++ b/rust/src/shards/gui/layouts/vertical.rs
@@ -155,7 +155,7 @@ impl Shard for Vertical {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.vertical(|ui| {
         util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
       })

--- a/rust/src/shards/gui/menus/menu.rs
+++ b/rust/src/shards/gui/menus/menu.rs
@@ -118,7 +118,7 @@ impl Shard for CloseMenu {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.close_menu();
       Ok(*input)
     } else {
@@ -253,7 +253,7 @@ If called from within a menu this will instead create a button for a sub-menu."
       return Ok(false.into());
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let title: &str = self.title.get().try_into()?;
       if let Some(result) = ui
         .menu_button(title, |ui| {
@@ -395,7 +395,7 @@ impl Shard for MenuBar {
       return Ok(false.into());
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       match egui::menu::bar(ui, |ui| {
         util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
       })

--- a/rust/src/shards/gui/misc/reset.rs
+++ b/rust/src/shards/gui/misc/reset.rs
@@ -87,7 +87,7 @@ impl Shard for Reset {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       *ui.ctx().memory() = Default::default();
 
       Ok(*input)

--- a/rust/src/shards/gui/misc/style.rs
+++ b/rust/src/shards/gui/misc/style.rs
@@ -121,7 +121,7 @@ impl Shard for Style {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    let mut style = if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    let mut style = if let Some(ui) = util::get_current_parent(self.parents.get())? {
       (**ui.style()).clone()
     } else {
       let gui_ctx = util::get_current_context(&self.instance)?;
@@ -431,7 +431,7 @@ impl Shard for Style {
       style.explanation_tooltips
     );
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       ui.set_style(style);
     } else {
       let gui_ctx = util::get_current_context(&self.instance)?;

--- a/rust/src/shards/gui/misc/style.rs
+++ b/rust/src/shards/gui/misc/style.rs
@@ -150,8 +150,8 @@ impl Shard for Style {
     if let Some(text_styles) = table.get_static(cstr!("text_styles")) {
       let text_styles: Seq = text_styles.try_into()?;
 
-      for var in text_styles {
-        let text_style: Table = var.as_ref().try_into()?;
+      for var in text_styles.iter() {
+        let text_style: Table = var.try_into()?;
         if let Some(name) = text_style.get_static(cstr!("name")) {
           if let Some(key) = style_util::get_text_style(name.try_into()?) {
             if let Some(fontId) = style_util::get_font_id(text_style) {

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -106,6 +106,7 @@ struct EguiContext {
 
 mod containers;
 mod context;
+mod editor;
 mod layouts;
 mod menus;
 mod misc;
@@ -224,6 +225,7 @@ impl egui::TextBuffer for &mut Var {
 pub fn registerShards() {
   containers::registerShards();
   registerShard::<EguiContext>();
+  editor::registerShards();
   layouts::registerShards();
   menus::registerShards();
   misc::registerShards();

--- a/rust/src/shards/gui/properties.rs
+++ b/rust/src/shards/gui/properties.rs
@@ -196,7 +196,7 @@ impl Shard for GetProperty {
   }
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       match self.get_ui_property()? {
         UIProperty::RemainingSpace => {
           let target_size = ui.available_size();

--- a/rust/src/shards/gui/util.rs
+++ b/rust/src/shards/gui/util.rs
@@ -103,7 +103,7 @@ pub(crate) fn get_current_context<'a>(
 }
 
 pub(crate) fn get_current_parent<'a>(
-  parents_stack_var: Var,
+  parents_stack_var: &Var,
 ) -> Result<Option<&'a mut egui::Ui>, &'a str> {
   let seq: Seq = parents_stack_var.try_into()?;
   if !seq.is_empty() {

--- a/rust/src/shards/gui/util.rs
+++ b/rust/src/shards/gui/util.rs
@@ -39,7 +39,7 @@ where
   unsafe {
     let var = Var::new_object_from_ptr(object as *const _, object_type);
     update_seq(stack_var, |seq| {
-      seq.push(var);
+      seq.push(&var);
     })?;
   }
 
@@ -94,7 +94,7 @@ pub(crate) fn get_current_context<'a>(
   let seq: Seq = context_stack_var.get().try_into()?;
   if !seq.is_empty() {
     Ok(Var::from_object_ptr_mut_ref(
-      seq[seq.len() - 1],
+      &seq[seq.len() - 1],
       &EGUI_CTX_TYPE,
     )?)
   } else {
@@ -113,7 +113,7 @@ pub(crate) fn get_current_parent<'a>(
     }
 
     Ok(Some(Var::from_object_ptr_mut_ref(
-      seq[seq.len() - 1],
+      &seq[seq.len() - 1],
       &EGUI_UI_TYPE,
     )?))
   } else {

--- a/rust/src/shards/gui/widgets/button.rs
+++ b/rust/src/shards/gui/widgets/button.rs
@@ -179,7 +179,7 @@ impl Shard for Button {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let label: &str = self.label.get().try_into()?;
       let mut text = egui::RichText::new(label);
 

--- a/rust/src/shards/gui/widgets/checkbox.rs
+++ b/rust/src/shards/gui/widgets/checkbox.rs
@@ -205,7 +205,7 @@ impl Shard for Checkbox {
   }
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let label: &str = self.label.get().try_into()?;
       let mut text = egui::RichText::new(label);
 

--- a/rust/src/shards/gui/widgets/code_editor/mod.rs
+++ b/rust/src/shards/gui/widgets/code_editor/mod.rs
@@ -211,7 +211,7 @@ impl Shard for CodeEditor {
   }
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let theme = if ui.style().visuals.dark_mode {
         CodeTheme::dark()
       } else {

--- a/rust/src/shards/gui/widgets/code_editor/mod.rs
+++ b/rust/src/shards/gui/widgets/code_editor/mod.rs
@@ -7,8 +7,6 @@ use super::CodeEditor;
 use crate::shard::Shard;
 use crate::shards::gui::util;
 use crate::shards::gui::EguiId;
-use crate::shards::gui::ImmutableVar;
-use crate::shards::gui::MutableVar;
 use crate::shards::gui::EGUI_UI_SEQ_TYPE;
 use crate::shards::gui::HELP_VALUE_IGNORED;
 use crate::shards::gui::PARENTS_UI_NAME;
@@ -232,10 +230,10 @@ impl Shard for CodeEditor {
       let mut mutable;
       let mut immutable;
       let text: &mut dyn egui::TextBuffer = if self.mutable_text {
-        mutable = MutableVar(self.variable.get_mut());
+        mutable = self.variable.get_mut();
         &mut mutable
       } else {
-        immutable = ImmutableVar(self.variable.get());
+        immutable = self.variable.get();
         &mut immutable
       };
       let code_editor = egui::TextEdit::multiline(text)

--- a/rust/src/shards/gui/widgets/color_input.rs
+++ b/rust/src/shards/gui/widgets/color_input.rs
@@ -183,7 +183,7 @@ impl Shard for ColorInput {
   }
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let color: shardsc::SHColor = if self.variable.is_variable() {
         unsafe { self.variable.get().payload.__bindgen_anon_1.colorValue }
       } else {

--- a/rust/src/shards/gui/widgets/color_input.rs
+++ b/rust/src/shards/gui/widgets/color_input.rs
@@ -184,27 +184,19 @@ impl Shard for ColorInput {
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
     if let Some(ui) = util::get_current_parent(self.parents.get())? {
-      let color: shardsc::SHColor = if self.variable.is_variable() {
-        unsafe { self.variable.get().payload.__bindgen_anon_1.colorValue }
+      let color = if self.variable.is_variable() {
+        unsafe { &mut self.variable.get_mut().payload.__bindgen_anon_1.colorValue }
       } else {
-        self.tmp
+        &mut self.tmp
       };
       let mut srgba = [color.r, color.g, color.b, color.a];
       ui.color_edit_button_srgba_unmultiplied(&mut srgba);
+      color.r = srgba[0];
+      color.g = srgba[1];
+      color.b = srgba[2];
+      color.a = srgba[3];
 
-      let color = shardsc::SHColor {
-        r: srgba[0],
-        g: srgba[1],
-        b: srgba[2],
-        a: srgba[3],
-      };
-      if self.variable.is_variable() {
-        self.variable.get_mut().payload.__bindgen_anon_1.colorValue = color;
-      } else {
-        self.tmp = color;
-      }
-
-      Ok(color.into())
+      Ok((*color).into())
     } else {
       Err("No UI parent")
     }

--- a/rust/src/shards/gui/widgets/combo.rs
+++ b/rust/src/shards/gui/widgets/combo.rs
@@ -217,7 +217,7 @@ impl Shard for Combo {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let label: &str = self.label.get().try_into()?;
       let mut text = egui::RichText::new(label);
 

--- a/rust/src/shards/gui/widgets/console.rs
+++ b/rust/src/shards/gui/widgets/console.rs
@@ -145,7 +145,7 @@ impl Shard for Console {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let style = self.style.get();
       let mut theme = LogTheme::default();
       if !style.is_none() {

--- a/rust/src/shards/gui/widgets/hex_viewer.rs
+++ b/rust/src/shards/gui/widgets/hex_viewer.rs
@@ -132,7 +132,7 @@ impl Shard for HexViewer {
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
     use egui_memory_editor::MemoryEditor;
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let mem = unsafe {
         let (data, len) = match input.valueType {
           SHType_Bytes => (

--- a/rust/src/shards/gui/widgets/hyperlink.rs
+++ b/rust/src/shards/gui/widgets/hyperlink.rs
@@ -128,7 +128,7 @@ impl Shard for Hyperlink {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let url: &str = input.try_into()?;
 
       let label = self.label.get();

--- a/rust/src/shards/gui/widgets/image.rs
+++ b/rust/src/shards/gui/widgets/image.rs
@@ -151,7 +151,7 @@ impl Shard for Image {
 
 impl Image {
   fn activateImage(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let texture = self
         .cached_ui_image
         .get_egui_texture_from_image(input, ui)?;
@@ -166,7 +166,7 @@ impl Image {
   }
 
   fn activateTexture(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let (texture_id, texture_size) = image_util::get_egui_texture_from_gfx(input)?;
 
       let scale = image_util::get_scale(&self.scale)?;

--- a/rust/src/shards/gui/widgets/image_button.rs
+++ b/rust/src/shards/gui/widgets/image_button.rs
@@ -242,7 +242,7 @@ impl Shard for ImageButton {
 
 impl ImageButton {
   fn activateImage(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let (texture_id, texture_size) = {
         let texture = self
           .cached_ui_image
@@ -258,7 +258,7 @@ impl ImageButton {
   }
 
   fn activateTexture(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let (texture_id, texture_size) = image_util::get_egui_texture_from_gfx(input)?;
       let scale = image_util::get_scale(&self.scale)?;
 

--- a/rust/src/shards/gui/widgets/image_util.rs
+++ b/rust/src/shards/gui/widgets/image_util.rs
@@ -65,7 +65,7 @@ pub fn get_egui_texture_from_gfx(
   input: &Var,
 ) -> Result<(egui::TextureId, egui::Vec2), &'static str> {
   let texture_ptr: *mut gfx_TexturePtr =
-    Var::from_object_ptr_mut_ref::<gfx_TexturePtr>(*input, &TEXTURE_TYPE)?;
+    Var::from_object_ptr_mut_ref::<gfx_TexturePtr>(input, &TEXTURE_TYPE)?;
   let texture_size = {
     let texture_res = unsafe { gfx_TexturePtr_getResolution_ext(texture_ptr) };
     egui::vec2(texture_res.x as f32, texture_res.y as f32)

--- a/rust/src/shards/gui/widgets/label.rs
+++ b/rust/src/shards/gui/widgets/label.rs
@@ -130,7 +130,7 @@ impl Shard for Label {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let text: &str = input.try_into()?;
       let mut text = egui::RichText::new(text);
 

--- a/rust/src/shards/gui/widgets/link.rs
+++ b/rust/src/shards/gui/widgets/link.rs
@@ -165,7 +165,7 @@ impl Shard for Link {
   }
 
   fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let label: &str = self.label.get().try_into()?;
       let mut text = egui::RichText::new(label);
 

--- a/rust/src/shards/gui/widgets/listbox.rs
+++ b/rust/src/shards/gui/widgets/listbox.rs
@@ -183,7 +183,7 @@ impl Shard for ListBox {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let index = &mut if self.index.is_variable() {
         let index: i64 = self.index.get().try_into()?;
         index as usize

--- a/rust/src/shards/gui/widgets/markdown_viewer.rs
+++ b/rust/src/shards/gui/widgets/markdown_viewer.rs
@@ -88,7 +88,7 @@ impl Shard for MarkdownViewer {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let text: &str = input.try_into()?;
       egui_commonmark::CommonMarkViewer::new(EguiId::new(self, 0)).show(ui, &mut self.cache, text);
 

--- a/rust/src/shards/gui/widgets/numeric_input.rs
+++ b/rust/src/shards/gui/widgets/numeric_input.rs
@@ -214,7 +214,7 @@ macro_rules! impl_ui_input {
       }
 
       fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-        if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+        if let Some(ui) = util::get_current_parent(self.parents.get())? {
           let value: &mut $native_type = if self.variable.is_variable() {
             self.variable.get_mut().try_into()?
           } else {
@@ -433,7 +433,7 @@ macro_rules! impl_ui_n_input {
       }
 
       fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-        if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+        if let Some(ui) = util::get_current_parent(self.parents.get())? {
           ui.horizontal(|ui| {
             let values: &mut [$native_type; $n] = if self.variable.is_variable() {
               self.variable.get_mut().try_into()?

--- a/rust/src/shards/gui/widgets/numeric_slider.rs
+++ b/rust/src/shards/gui/widgets/numeric_slider.rs
@@ -234,7 +234,7 @@ macro_rules! impl_ui_slider {
       }
 
       fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-        if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+        if let Some(ui) = util::get_current_parent(self.parents.get())? {
           let value: &mut $native_type = if self.variable.is_variable() {
             self.variable.get_mut().try_into()?
           } else {
@@ -487,7 +487,7 @@ macro_rules! impl_ui_n_slider {
       }
 
       fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-        if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+        if let Some(ui) = util::get_current_parent(self.parents.get())? {
           let max: &[$native_type; $n] = self.max.get().try_into()?;
           let min: &[$native_type; $n] = self.min.get().try_into()?;
 

--- a/rust/src/shards/gui/widgets/plots/plot.rs
+++ b/rust/src/shards/gui/widgets/plots/plot.rs
@@ -224,7 +224,7 @@ impl Shard for Plot {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let mut plot = egui::plot::Plot::new(EguiId::new(self, 0));
 
       let view_aspect = self.view_aspect.get();

--- a/rust/src/shards/gui/widgets/plots/plot_bar.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_bar.rs
@@ -163,7 +163,7 @@ impl Shard for PlotBar {
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
     let plot_ui: &mut egui::plot::PlotUi =
-      Var::from_object_ptr_mut_ref(*self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
+      Var::from_object_ptr_mut_ref(self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
 
     let seq: Seq = input.try_into()?;
     let points = seq.iter().map(|x| {

--- a/rust/src/shards/gui/widgets/plots/plot_line.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_line.rs
@@ -142,7 +142,7 @@ impl Shard for PlotLine {
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
     let plot_ui: &mut egui::plot::PlotUi =
-      Var::from_object_ptr_mut_ref(*self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
+      Var::from_object_ptr_mut_ref(self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
 
     let seq: Seq = input.try_into()?;
     let points = seq.iter().map(|x| {

--- a/rust/src/shards/gui/widgets/plots/plot_points.rs
+++ b/rust/src/shards/gui/widgets/plots/plot_points.rs
@@ -169,7 +169,7 @@ impl Shard for PlotPoints {
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
     let plot_ui: &mut egui::plot::PlotUi =
-      Var::from_object_ptr_mut_ref(*self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
+      Var::from_object_ptr_mut_ref(self.plot_ui.get(), &EGUI_PLOT_UI_TYPE)?;
 
     let seq: Seq = input.try_into()?;
     let points = seq.iter().map(|x| {

--- a/rust/src/shards/gui/widgets/progress_bar.rs
+++ b/rust/src/shards/gui/widgets/progress_bar.rs
@@ -136,7 +136,7 @@ impl Shard for ProgressBar {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let progress = input.try_into()?;
       let mut progressBar = egui::ProgressBar::new(progress);
 

--- a/rust/src/shards/gui/widgets/radio_button.rs
+++ b/rust/src/shards/gui/widgets/radio_button.rs
@@ -217,7 +217,7 @@ impl Shard for RadioButton {
   }
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let label: &str = self.label.get().try_into()?;
       let mut text = egui::RichText::new(label);
 

--- a/rust/src/shards/gui/widgets/render_target.rs
+++ b/rust/src/shards/gui/widgets/render_target.rs
@@ -149,7 +149,7 @@ impl Shard for RenderTarget {
 
 impl RenderTarget {
   fn activateTexture(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let (texture_id, texture_size) = image_util::get_egui_texture_from_gfx(input)?;
       let scale = image_util::get_scale(&self.scale)? / ui.ctx().pixels_per_point();
 

--- a/rust/src/shards/gui/widgets/spinner.rs
+++ b/rust/src/shards/gui/widgets/spinner.rs
@@ -123,7 +123,7 @@ impl Shard for Spinner {
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let mut spinner = egui::Spinner::new();
 
       let size = self.size.get();

--- a/rust/src/shards/gui/widgets/text_input.rs
+++ b/rust/src/shards/gui/widgets/text_input.rs
@@ -199,7 +199,7 @@ impl Shard for TextInput {
   }
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let mut mutable;
       let mut immutable;
       let text: &mut dyn egui::TextBuffer = if self.mutable_text {

--- a/rust/src/shards/gui/widgets/text_input.rs
+++ b/rust/src/shards/gui/widgets/text_input.rs
@@ -4,8 +4,6 @@
 use super::TextInput;
 use crate::shard::Shard;
 use crate::shards::gui::util;
-use crate::shards::gui::ImmutableVar;
-use crate::shards::gui::MutableVar;
 use crate::shards::gui::HELP_VALUE_IGNORED;
 use crate::shards::gui::PARENTS_UI_NAME;
 use crate::shards::gui::STRING_VAR_SLICE;
@@ -203,10 +201,10 @@ impl Shard for TextInput {
       let mut mutable;
       let mut immutable;
       let text: &mut dyn egui::TextBuffer = if self.mutable_text {
-        mutable = MutableVar(self.variable.get_mut());
+        mutable = self.variable.get_mut();
         &mut mutable
       } else {
-        immutable = ImmutableVar(self.variable.get());
+        immutable = self.variable.get();
         &mut immutable
       };
       let text_edit = if self.multiline.get().try_into()? {

--- a/rust/src/shards/gui/widgets/tooltip.rs
+++ b/rust/src/shards/gui/widgets/tooltip.rs
@@ -186,7 +186,7 @@ impl Shard for Tooltip {
       return Ok(*input);
     }
 
-    if let Some(ui) = util::get_current_parent(*self.parents.get())? {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
       let response = {
         let inner_response = ui.scope(|ui| {
           util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)

--- a/rust/src/shards/gui/widgets/tooltip.rs
+++ b/rust/src/shards/gui/widgets/tooltip.rs
@@ -73,7 +73,9 @@ impl Shard for Tooltip {
   }
 
   fn help(&mut self) -> OptionalString {
-    OptionalString(shccstr!("Display a tooltip when the Contents is hovered over."))
+    OptionalString(shccstr!(
+      "Display a tooltip when the Contents is hovered over."
+    ))
   }
 
   fn inputTypes(&mut self) -> &Types {

--- a/rust/src/shards/http.rs
+++ b/rust/src/shards/http.rs
@@ -117,7 +117,7 @@ impl Default for RequestBase {
     };
     let table = Table::new();
     s.output_table
-      .insert_fast_static(cstr!("headers"), table.as_ref().into());
+      .insert_fast_static(cstr!("headers"), &table.as_ref().into());
     s
   }
 }
@@ -183,7 +183,7 @@ impl RequestBase {
     if self.full_response {
       self
         .output_table
-        .insert_fast_static(cstr!("status"), response.status().as_u16().try_into()?);
+        .insert_fast_static(cstr!("status"), &response.status().as_u16().try_into()?);
 
       let headers = self.output_table.get_mut_fast_static(cstr!("headers"));
       let mut headers: Table = headers.as_ref().try_into()?;
@@ -196,7 +196,7 @@ impl RequestBase {
           shlog!("Failure details: {}", e);
           "Failed to convert header value"
         })?;
-        headers.insert_fast(&key, value.as_ref().into());
+        headers.insert_fast(&key, &value.as_ref().into());
       }
     }
 
@@ -207,7 +207,7 @@ impl RequestBase {
       })?;
       self
         .output_table
-        .insert_fast_static(cstr!("body"), bytes.as_ref().into());
+        .insert_fast_static(cstr!("body"), &bytes.as_ref().into());
     } else {
       let str = response.text().map_err(|e| {
         shlog!("Failure details: {}", e);
@@ -215,7 +215,7 @@ impl RequestBase {
       })?;
       self
         .output_table
-        .insert_fast_static(cstr!("body"), Var::ephemeral_string(str.as_str()));
+        .insert_fast_static(cstr!("body"), &Var::ephemeral_string(str.as_str()));
       // will clone
     }
 

--- a/rust/src/shards/mod.rs
+++ b/rust/src/shards/mod.rs
@@ -28,6 +28,8 @@ pub mod curve25519;
 
 pub mod chachapoly;
 
+pub mod editor;
+
 pub mod gui;
 
 pub mod date;

--- a/rust/src/shards/onnx.rs
+++ b/rust/src/shards/onnx.rs
@@ -228,7 +228,7 @@ impl Shard for Activate {
     let current_model = self.model_var.get();
     let model = match self.previous_model {
       None => {
-        self.model = Some(Var::from_object_as_clone(*current_model, &MODEL_VAR_TYPE)?);
+        self.model = Some(Var::from_object_as_clone(current_model, &MODEL_VAR_TYPE)?);
         unsafe {
           let model_ptr = Rc::as_ptr(self.model.as_ref().unwrap()) as *mut ModelWrapper;
           &*model_ptr
@@ -236,7 +236,7 @@ impl Shard for Activate {
       }
       Some(ref previous_model) => {
         if previous_model != current_model {
-          self.model = Some(Var::from_object_as_clone(*current_model, &MODEL_VAR_TYPE)?);
+          self.model = Some(Var::from_object_as_clone(current_model, &MODEL_VAR_TYPE)?);
           unsafe {
             let model_ptr = Rc::as_ptr(self.model.as_ref().unwrap()) as *mut ModelWrapper;
             &*model_ptr

--- a/rust/src/shards/physics/forces.rs
+++ b/rust/src/shards/physics/forces.rs
@@ -132,11 +132,11 @@ impl Shard for Impulse {
   }
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
     let simulation = self.simulation.get();
-    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(*simulation, &SIMULATION_TYPE)
+    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(simulation, &SIMULATION_TYPE)
       .map_err(|_| "Physics simulation not found")?;
 
     let rb = self.rb.get();
-    let rb = Var::from_object_mut_ref::<RigidBody>(*rb, &RIGIDBODY_TYPE)
+    let rb = Var::from_object_mut_ref::<RigidBody>(rb, &RIGIDBODY_TYPE)
       .map_err(|_| "RigidBody not found")?;
 
     for rb in &rb.rigid_bodies {

--- a/rust/src/shards/physics/queries.rs
+++ b/rust/src/shards/physics/queries.rs
@@ -85,7 +85,7 @@ impl Shard for CastRay {
     self.output.clear();
 
     let simulation = self.simulation_var.get();
-    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(*simulation, &SIMULATION_TYPE)
+    let simulation = Var::from_object_ptr_mut_ref::<Simulation>(simulation, &SIMULATION_TYPE)
       .map_err(|_| "Physics simulation not found.")?;
 
     let inputs: Seq = input.try_into().unwrap();
@@ -112,7 +112,7 @@ impl Shard for CastRay {
       let closest = simulation.colliders.get(closest.0).unwrap().user_data;
       unsafe {
         let closest = Var::new_object_from_raw_ptr(closest as SHPointer, &RIGIDBODY_TYPE);
-        self.output.push(closest);
+        self.output.push(&closest);
       }
     }
 

--- a/rust/src/shards/substrate.rs
+++ b/rust/src/shards/substrate.rs
@@ -537,7 +537,7 @@ impl Shard for SHEncode {
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
     let values: Seq = input.try_into()?;
-    let hints: Seq = self.hints.0.try_into()?;
+    let hints: Seq = self.hints.0.as_ref().try_into()?;
 
     if values.len() != hints.len() {
       return Err("Invalid input length");
@@ -628,8 +628,8 @@ impl Shard for SHDecode {
 
   fn activate(&mut self, _: &Context, input: &Var) -> Result<Var, &str> {
     let bytes: &[u8] = input.try_into()?;
-    let types: Seq = self.types.0.try_into()?;
-    let hints: Seq = self.hints.0.try_into()?;
+    let types: Seq = self.types.0.as_ref().try_into()?;
+    let hints: Seq = self.hints.0.as_ref().try_into()?;
     let mut offset = 0;
     self.output.clear();
     for (t, h) in types.iter().zip(hints.iter()) {

--- a/rust/src/shards/ws.rs
+++ b/rust/src/shards/ws.rs
@@ -130,10 +130,10 @@ impl ClientUser {
   fn activate(&mut self) -> Result<&mut WsClient, &str> {
     if self.ws.is_none() {
       let ws = self.instance.get();
-      self.ws = Var::from_object_as_clone(*ws, &WS_CLIENT_TYPE)?;
+      self.ws = Var::from_object_as_clone(ws, &WS_CLIENT_TYPE)?;
     }
 
-    let ws = Var::from_object_mut_ref(*self.instance.get(), &WS_CLIENT_TYPE)?;
+    let ws = Var::from_object_mut_ref(self.instance.get(), &WS_CLIENT_TYPE)?;
 
     if let Some(ws) = ws {
       Ok(ws)

--- a/rust/src/shards/ws.rs
+++ b/rust/src/shards/ws.rs
@@ -1,5 +1,5 @@
 use crate::{
-  core::{run_blocking, registerShard, BlockingShard},
+  core::{registerShard, run_blocking, BlockingShard},
   types::{
     ClonedVar, Context, ExposedInfo, ExposedTypes, ParamVar, Parameters, Type, Types, Var,
     ANYS_TYPES, FRAG_CC, NONE_TYPES, STRING_TYPES,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1027,8 +1027,8 @@ impl Serialize for Var {
       SHType_Seq => {
         let seq: Seq = self.try_into().unwrap();
         let mut s = se.serialize_seq(Some(seq.len()))?;
-        for value in seq {
-          s.serialize_element(&value)?;
+        for value in seq.iter() {
+          s.serialize_element(value)?;
         }
         s.end()
       }
@@ -1973,7 +1973,7 @@ impl Var {
     }
   }
 
-  pub fn from_object_as_clone<T>(var: Var, info: &Type) -> Result<Rc<T>, &str> {
+  pub fn from_object_as_clone<'a, T>(var: &Var, info: &'a Type) -> Result<Rc<T>, &'a str> {
     // use this to store the smart pointer in order to keep it alive
     // this will not allow mutable references btw
     unsafe {
@@ -1999,7 +1999,7 @@ impl Var {
     Ok(c)
   }
 
-  pub fn from_object_mut_ref<T>(var: Var, info: &Type) -> Result<&mut T, &str> {
+  pub fn from_object_mut_ref<'a, T>(var: &Var, info: &'a Type) -> Result<&'a mut T, &'a str> {
     // used to use the object once, when it comes from a simple pointer
     unsafe {
       if var.valueType != SHType_Object
@@ -2017,7 +2017,7 @@ impl Var {
     }
   }
 
-  pub fn from_object_ptr_mut_ref<T>(var: Var, info: &Type) -> Result<&mut T, &str> {
+  pub fn from_object_ptr_mut_ref<'a, T>(var: &Var, info: &'a Type) -> Result<&'a mut T, &'a str> {
     // used to use the object once, when it comes from a Rc
     unsafe {
       if var.valueType != SHType_Object
@@ -2033,7 +2033,7 @@ impl Var {
     }
   }
 
-  pub fn from_object_ptr_ref<T>(var: Var, info: &Type) -> Result<&T, &str> {
+  pub fn from_object_ptr_ref<'a, T>(var: &Var, info: &'a Type) -> Result<&'a T, &'a str> {
     // used to use the object once, when it comes from a Rc
     unsafe {
       if var.valueType != SHType_Object
@@ -3065,29 +3065,11 @@ impl TryFrom<&Var> for &[Var] {
   }
 }
 
-impl TryFrom<Var> for &[Var] {
+impl TryFrom<&Var> for WireRef {
   type Error = &'static str;
 
   #[inline(always)]
-  fn try_from(var: Var) -> Result<Self, Self::Error> {
-    if var.valueType != SHType_Seq {
-      Err("Expected Seq variable, but casting failed.")
-    } else {
-      unsafe {
-        let elems = var.payload.__bindgen_anon_1.seqValue.elements;
-        let len = var.payload.__bindgen_anon_1.seqValue.len;
-        let res = std::slice::from_raw_parts(elems, len as usize);
-        Ok(res)
-      }
-    }
-  }
-}
-
-impl TryFrom<Var> for WireRef {
-  type Error = &'static str;
-
-  #[inline(always)]
-  fn try_from(var: Var) -> Result<Self, Self::Error> {
+  fn try_from(var: &Var) -> Result<Self, Self::Error> {
     if var.valueType != SHType_Wire {
       Err("Expected Wire variable, but casting failed.")
     } else {
@@ -3105,19 +3087,6 @@ impl From<WireRef> for Var {
         __bindgen_anon_1: SHVarPayload__bindgen_ty_1 { wireValue: wire.0 },
       },
       ..Default::default()
-    }
-  }
-}
-
-impl TryFrom<Var> for ShardRef {
-  type Error = &'static str;
-
-  #[inline(always)]
-  fn try_from(var: Var) -> Result<Self, Self::Error> {
-    if var.valueType != SHType_ShardRef {
-      Err("Expected Shard variable, but casting failed.")
-    } else {
-      unsafe { Ok(ShardRef(var.payload.__bindgen_anon_1.shardValue)) }
     }
   }
 }
@@ -3352,9 +3321,9 @@ impl ShardsVar {
 
     if let Ok(s) = Seq::try_from(self.param.0.as_ref()) {
       for shard in s.iter() {
-        self.shards.push(shard.try_into()?);
+        self.shards.push(shard.as_ref().try_into()?);
       }
-    } else if let Ok(s) = ShardRef::try_from(self.param.0) {
+    } else if let Ok(s) = ShardRef::try_from(&self.param.0) {
       self.shards.push(s);
     } else if value.is_none() {
       // we allow none
@@ -3782,30 +3751,30 @@ impl Drop for Seq {
   }
 }
 
-pub struct SeqIterator {
-  s: Seq,
+pub struct SeqIterator<'a> {
+  s: &'a Seq,
   i: u32,
 }
 
-impl Iterator for SeqIterator {
+impl<'a> Iterator for SeqIterator<'a> {
   fn next(&mut self) -> Option<Self::Item> {
     let res = if self.i < self.s.s.len {
-      unsafe { Some(*self.s.s.elements.offset(self.i.try_into().unwrap())) }
+      unsafe { Some(&*self.s.s.elements.offset(self.i.try_into().unwrap())) }
     } else {
       None
     };
     self.i += 1;
     res
   }
-  type Item = Var;
+  type Item = &'a Var;
 }
 
-impl DoubleEndedIterator for SeqIterator {
+impl<'a> DoubleEndedIterator for SeqIterator<'a> {
   fn next_back(&mut self) -> Option<Self::Item> {
     let res = if self.i < self.s.s.len {
       unsafe {
         Some(
-          *self
+          &*self
             .s
             .s
             .elements
@@ -3818,14 +3787,6 @@ impl DoubleEndedIterator for SeqIterator {
     self.i += 1;
     res
   }
-}
-
-impl IntoIterator for Seq {
-  fn into_iter(self) -> Self::IntoIter {
-    SeqIterator { s: self, i: 0 }
-  }
-  type Item = Var;
-  type IntoIter = SeqIterator;
 }
 
 impl Index<usize> for SHSeq {
@@ -3889,7 +3850,7 @@ impl Seq {
     }
   }
 
-  pub fn push(&mut self, value: Var) {
+  pub fn push<'a>(&'a mut self, value: &Var) {
     // we need to clone to own the memory shards side
     let mut tmp = SHVar::default();
     cloneVar(&mut tmp, &value);
@@ -3898,7 +3859,7 @@ impl Seq {
     }
   }
 
-  pub fn insert(&mut self, index: usize, value: Var) {
+  pub fn insert<'a>(&'a mut self, index: usize, value: &Var) {
     // we need to clone to own the memory shards side
     let mut tmp = SHVar::default();
     cloneVar(&mut tmp, &value);
@@ -3937,10 +3898,7 @@ impl Seq {
   }
 
   pub fn iter(&self) -> SeqIterator {
-    SeqIterator {
-      s: self.clone(),
-      i: 0,
-    }
+    SeqIterator { s: self, i: 0 }
   }
 }
 
@@ -4063,7 +4021,7 @@ impl Table {
     }
   }
 
-  pub fn insert(&mut self, k: &CString, v: Var) -> Option<Var> {
+  pub fn insert<'a>(&'a mut self, k: &'a CString, v: &Var) -> Option<Var> {
     unsafe {
       let cstr = k.as_bytes_with_nul().as_ptr() as *const std::os::raw::c_char;
       if (*self.t.api).tableContains.unwrap()(self.t, cstr) {
@@ -4073,13 +4031,13 @@ impl Table {
         Some(old)
       } else {
         let p = (*self.t.api).tableAt.unwrap()(self.t, cstr);
-        *p = v;
+        *p = *v;
         None
       }
     }
   }
 
-  pub fn insert_fast(&mut self, k: &CString, v: Var) {
+  pub fn insert_fast<'a>(&'a mut self, k: &'a CString, v: &Var) {
     unsafe {
       let cstr = k.as_bytes_with_nul().as_ptr() as *const std::os::raw::c_char;
       let p = (*self.t.api).tableAt.unwrap()(self.t, cstr);
@@ -4087,7 +4045,7 @@ impl Table {
     }
   }
 
-  pub fn insert_fast_static(&mut self, k: &'static str, v: Var) {
+  pub fn insert_fast_static<'a>(&'a mut self, k: &'static str, v: &Var) {
     unsafe {
       let cstr = k.as_ptr() as *const std::os::raw::c_char;
       let p = (*self.t.api).tableAt.unwrap()(self.t, cstr);

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -542,7 +542,9 @@ impl From<SHParametersInfo> for &[SHParameterInfo] {
 Static common type infos utility
 */
 pub mod common_type {
+  use crate::shardsc::util_type2Name;
   use crate::shardsc::SHStrings;
+  use crate::shardsc::SHType;
   use crate::shardsc::SHTypeInfo;
   use crate::shardsc::SHTypeInfo_Details;
   use crate::shardsc::SHTypeInfo_Details_Table;
@@ -572,6 +574,7 @@ pub mod common_type {
   use crate::shardsc::SHType_Table;
   use crate::shardsc::SHType_Wire;
   use crate::shardsc::SHTypesInfo;
+  use std::ffi::CStr;
 
   const fn base_info() -> SHTypeInfo {
     SHTypeInfo {
@@ -590,6 +593,14 @@ pub mod common_type {
   }
 
   pub static none: SHTypeInfo = base_info();
+
+  pub fn type2name(value_type: SHType) -> &'static str {
+    unsafe {
+      let ptr = util_type2Name(value_type);
+      let s = CStr::from_ptr(ptr);
+      s.to_str().unwrap()
+    }
+  }
 
   macro_rules! shtype {
     ($fname:ident, $type:expr, $name:ident, $names:ident, $name_var:ident, $names_var:ident, $name_table:ident, $name_table_var:ident) => {

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3296,7 +3296,9 @@ impl ShardsVar {
       let mut tmp = SHVar {
         valueType: SHType_ShardRef,
         payload: SHVarPayload {
-          __bindgen_anon_1: SHVarPayload__bindgen_ty_1 { shardValue: shard.0 },
+          __bindgen_anon_1: SHVarPayload__bindgen_ty_1 {
+            shardValue: shard.0,
+          },
         },
         ..Default::default()
       };

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3339,7 +3339,7 @@ impl ShardsVar {
 
     self.param = value.into(); // clone it
 
-    if let Ok(s) = Seq::try_from(self.param.0) {
+    if let Ok(s) = Seq::try_from(self.param.0.as_ref()) {
       for shard in s.iter() {
         self.shards.push(shard.try_into()?);
       }
@@ -3987,24 +3987,6 @@ impl TryFrom<&Var> for Seq {
 
   #[inline(always)]
   fn try_from(v: &Var) -> Result<Self, Self::Error> {
-    if v.valueType != SHType_Seq {
-      Err("Expected Seq variable, but casting failed.")
-    } else {
-      unsafe {
-        Ok(Seq {
-          s: v.payload.__bindgen_anon_1.seqValue,
-          owned: false,
-        })
-      }
-    }
-  }
-}
-
-impl TryFrom<Var> for Seq {
-  type Error = &'static str;
-
-  #[inline(always)]
-  fn try_from(v: Var) -> Result<Self, Self::Error> {
     if v.valueType != SHType_Seq {
       Err("Expected Seq variable, but casting failed.")
     } else {

--- a/src/core/shards/flow.hpp
+++ b/src/core/shards/flow.hpp
@@ -618,7 +618,8 @@ template <bool COND> struct When {
 
     if (!nextIsNone && !ares.flowStopper && !_passth) {
       if (ares.outputType != data.inputType) {
-        SHLOG_ERROR("When Passthrough is false but action output type ({}) does not match input type ({}).", ares.outputType, data.inputType);
+        SHLOG_ERROR("When Passthrough is false but action output type ({}) does not match input type ({}).", ares.outputType,
+                    data.inputType);
         throw ComposeError("When Passthrough is false but action output type "
                            "does not match input type.");
       }

--- a/src/core/shards/wires.hpp
+++ b/src/core/shards/wires.hpp
@@ -39,7 +39,7 @@ struct WireBase {
 
   bool passthrough{false};
 
-   // if false, means the Shard is not going to activate the wire, but just wait for it to complete usually or similar
+  // if false, means the Shard is not going to activate the wire, but just wait for it to complete usually or similar
   bool activating{true};
 
   bool capturing{false};

--- a/src/extra/egui/context.hpp
+++ b/src/extra/egui/context.hpp
@@ -14,7 +14,7 @@ void egui_hostGetExposedTypeInfo(EguiHost, SHExposedTypesInfo &outTypes);
 void egui_hostWarmup(EguiHost, SHContext *shContext);
 void egui_hostCleanup(EguiHost);
 const char *egui_hostActivate(EguiHost, const egui::Input &eguiInput, const Shards &shards, SHContext *shContext,
-                          const SHVar &input, SHVar &output);
+                              const SHVar &input, SHVar &output);
 const egui::FullOutput *egui_hostGetOutput(const EguiHost);
 }
 

--- a/src/extra/gfx.hpp
+++ b/src/extra/gfx.hpp
@@ -20,8 +20,7 @@ struct GraphicsContext {
   static inline SHTypeInfo Type{SHType::Object, {.object = {.vendorId = VendorId, .typeId = TypeId}}};
   static inline const char VariableName[] = "GFX.Context";
   static inline const SHOptionalString VariableDescription = SHCCSTR("The graphics context.");
-  static inline SHExposedTypeInfo VariableInfo =
-      shards::ExposedInfo::ProtectedVariable(VariableName, VariableDescription, Type);
+  static inline SHExposedTypeInfo VariableInfo = shards::ExposedInfo::ProtectedVariable(VariableName, VariableDescription, Type);
 
   std::shared_ptr<Context> context;
   std::shared_ptr<Window> window;
@@ -39,7 +38,8 @@ struct GraphicsContext {
   SDL_Window *getSdlWindow();
 };
 
-typedef shards::RequiredContextVariable<GraphicsContext, GraphicsContext::Type, GraphicsContext::VariableName> RequiredGraphicsContext;
+typedef shards::RequiredContextVariable<GraphicsContext, GraphicsContext::Type, GraphicsContext::VariableName>
+    RequiredGraphicsContext;
 
 struct ContextUserData {
   SHContext *shardsContext{};

--- a/src/extra/gfx/drawable.cpp
+++ b/src/extra/gfx/drawable.cpp
@@ -144,9 +144,7 @@ struct DrawShard {
   ParamVar _queueVar{};
   RequiredGraphicsContext _graphicsContext{};
 
-  bool isQueueSet() const {
-    return _queueVar->valueType != SHType::None;
-  }
+  bool isQueueSet() const { return _queueVar->valueType != SHType::None; }
 
   void setParam(int index, const SHVar &value) {
     switch (index) {

--- a/src/extra/gfx/main_window.cpp
+++ b/src/extra/gfx/main_window.cpp
@@ -156,14 +156,16 @@ struct MainWindow final {
 
     if (_graphicsContextVar) {
       if (_graphicsContextVar->refcount > 1) {
-        SHLOG_ERROR("MainWindow: Found {} dangling reference(s) to {}", _graphicsContextVar->refcount - 1, GraphicsContext::VariableName);
+        SHLOG_ERROR("MainWindow: Found {} dangling reference(s) to {}", _graphicsContextVar->refcount - 1,
+                    GraphicsContext::VariableName);
       }
       releaseVariable(_graphicsContextVar);
     }
 
     if (_inputContextVar) {
       if (_inputContextVar->refcount > 1) {
-        SHLOG_ERROR("MainWindow: Found {} dangling reference(s) to {}", _inputContextVar->refcount - 1, InputContext::VariableName);
+        SHLOG_ERROR("MainWindow: Found {} dangling reference(s) to {}", _inputContextVar->refcount - 1,
+                    InputContext::VariableName);
       }
       releaseVariable(_inputContextVar);
     }

--- a/src/extra/gfx/view.cpp
+++ b/src/extra/gfx/view.cpp
@@ -104,7 +104,8 @@ struct RegionShard {
   }
 
   SHExposedTypesInfo requiredVariables() {
-    static auto e = exposedTypesOf(RequiredGraphicsContext::getExposedTypeInfo(), Inputs::RequiredInputContext::getExposedTypeInfo());
+    static auto e =
+        exposedTypesOf(RequiredGraphicsContext::getExposedTypeInfo(), Inputs::RequiredInputContext::getExposedTypeInfo());
     return e;
   }
 

--- a/src/extra/inputs.hpp
+++ b/src/extra/inputs.hpp
@@ -13,8 +13,7 @@ struct InputContext {
   static inline SHTypeInfo Type{SHType::Object, {.object = {.vendorId = CoreCC, .typeId = TypeId}}};
   static inline const char VariableName[] = "Input.Context";
   static inline const SHOptionalString VariableDescription = SHCCSTR("The input context.");
-  static inline SHExposedTypeInfo VariableInfo =
-      shards::ExposedInfo::ProtectedVariable(VariableName, VariableDescription, Type);
+  static inline SHExposedTypeInfo VariableInfo = shards::ExposedInfo::ProtectedVariable(VariableName, VariableDescription, Type);
 
   std::shared_ptr<gfx::Window> window;
   std::vector<SDL_Event> events;

--- a/src/extra/rust_interop.cpp
+++ b/src/extra/rust_interop.cpp
@@ -10,6 +10,8 @@ using namespace gfx;
 using namespace shards;
 using GFXTypes = gfx::Types;
 
+SHString const util_type2Name(SHType type) { return type2Name_raw(type); }
+
 SHTypeInfo *gfx_getGraphicsContextType() {
   static SHTypeInfo type = gfx::GraphicsContext::Type;
   return &type;

--- a/src/extra/rust_interop.cpp
+++ b/src/extra/rust_interop.cpp
@@ -10,6 +10,10 @@ using namespace gfx;
 using namespace shards;
 using GFXTypes = gfx::Types;
 
+const SHEnumInfo *util_findEnumInfo(int32_t vendorId, int32_t typeId) { return shards::findEnumInfo(vendorId, typeId); }
+
+const SHObjectInfo *util_findObjectInfo(int32_t vendorId, int32_t typeId) { return shards::findObjectInfo(vendorId, typeId); }
+
 SHString const util_type2Name(SHType type) { return type2Name_raw(type); }
 
 SHTypeInfo *gfx_getGraphicsContextType() {

--- a/src/extra/rust_interop.hpp
+++ b/src/extra/rust_interop.hpp
@@ -16,6 +16,8 @@ extern "C" {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
+const SHEnumInfo *util_findEnumInfo(int32_t vendorId, int32_t typeId);
+const SHObjectInfo *util_findObjectInfo(int32_t vendorId, int32_t typeId);
 SHString const util_type2Name(SHType type);
 
 // gfx::GraphicsContext::Type

--- a/src/extra/rust_interop.hpp
+++ b/src/extra/rust_interop.hpp
@@ -31,8 +31,8 @@ gfx::DrawQueuePtr *gfx_getDrawQueueFromVar(const SHVar &var);
 
 gfx::int4 gfx_getEguiMappedRegion(const SHVar &inputContext);
 gfx::int4 gfx_getViewport(const SHVar &graphicsContext);
-const egui::Input *gfx_getEguiWindowInputs(gfx::EguiInputTranslator *translator, const SHVar &graphicsContext, const SHVar &inputContext,
-                                           float scalingFactor);
+const egui::Input *gfx_getEguiWindowInputs(gfx::EguiInputTranslator *translator, const SHVar &graphicsContext,
+                                           const SHVar &inputContext, float scalingFactor);
 }
 
 #endif /* E325D8E3_F64E_413D_965B_DF275CF18AC4 */

--- a/src/extra/rust_interop.hpp
+++ b/src/extra/rust_interop.hpp
@@ -16,6 +16,8 @@ extern "C" {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
+SHString const util_type2Name(SHType type);
+
 // gfx::GraphicsContext::Type
 SHTypeInfo *gfx_getGraphicsContextType();
 const char *gfx_getGraphicsContextVarName();

--- a/src/extra/spatial/spatial.cpp
+++ b/src/extra/spatial/spatial.cpp
@@ -34,8 +34,8 @@ struct SpatialUIContextShard {
   PARAM(ShardsVar, _contents, "Contents", "The list of UI panels to render.", {CoreInfo::ShardsOrNone});
   PARAM_VAR(_scale, "Scale", "The scale of how many UI units per world unit.", {CoreInfo::FloatType});
   PARAM_VAR(_debug, "Debug", "Visualize panel outlines and pointer input being sent to panels.", {CoreInfo::BoolType});
-  PARAM_IMPL(SpatialUIContextShard, PARAM_IMPL_FOR(_queue), PARAM_IMPL_FOR(_view), PARAM_IMPL_FOR(_contents), PARAM_IMPL_FOR(_scale),
-             PARAM_IMPL_FOR(_debug));
+  PARAM_IMPL(SpatialUIContextShard, PARAM_IMPL_FOR(_queue), PARAM_IMPL_FOR(_view), PARAM_IMPL_FOR(_contents),
+             PARAM_IMPL_FOR(_scale), PARAM_IMPL_FOR(_debug));
 
   SpatialUIContextShard() {
     _scale = Var(1000.0f);
@@ -66,7 +66,8 @@ struct SpatialUIContextShard {
 
     if (_spatialContextVar) {
       if (_spatialContextVar->refcount > 1) {
-        SHLOG_ERROR("Spatial.UI: Found {} dangling reference(s) to {}", _spatialContextVar->refcount - 1, SpatialContext::VariableName);
+        SHLOG_ERROR("Spatial.UI: Found {} dangling reference(s) to {}", _spatialContextVar->refcount - 1,
+                    SpatialContext::VariableName);
       }
       releaseVariable(_spatialContextVar);
     }
@@ -200,7 +201,8 @@ struct SpatialPanelShard {
   // This evaluates the egui contents for this panel
   virtual const egui::FullOutput &render(const egui::Input &inputs) {
     SHVar output{};
-    const char *error = egui_hostActivate(_eguiHost, inputs, _contents.shards(), _context->activationContext, _context->activationInput, output);
+    const char *error =
+        egui_hostActivate(_eguiHost, inputs, _contents.shards(), _context->activationContext, _context->activationInput, output);
     if (error)
       throw ActivationError(fmt::format("egui activation error: {}", error));
 

--- a/src/extra/spatial/spatial.hpp
+++ b/src/extra/spatial/spatial.hpp
@@ -31,7 +31,8 @@ struct SpatialContext {
   std::vector<Panel> panels;
 };
 
-typedef shards::RequiredContextVariable<SpatialContext, SpatialContext::Type, SpatialContext::VariableName> RequiredSpatialContext;
+typedef shards::RequiredContextVariable<SpatialContext, SpatialContext::Type, SpatialContext::VariableName>
+    RequiredSpatialContext;
 
 } // namespace shards::Spatial
 

--- a/src/gfx/drawable_processors/mesh_drawable_processor.hpp
+++ b/src/gfx/drawable_processors/mesh_drawable_processor.hpp
@@ -283,7 +283,7 @@ struct MeshDrawableProcessor final : public IDrawableProcessor {
   void waitForBufferMap(Context &context, PrepareData *prepareData) {
     do {
       bool everythingMapped = true;
-      auto check = [&](auto& buffers) {
+      auto check = [&](auto &buffers) {
         for (auto &drawBuffer : buffers) {
           if (drawBuffer.mappingStatus == WGPUBufferMapAsyncStatus_Unknown)
             everythingMapped = false;

--- a/src/gfx/egui/input.cpp
+++ b/src/gfx/egui/input.cpp
@@ -74,8 +74,7 @@ void EguiInputTranslator::setupWindowInput(Window &window, int4 mappedWindowRegi
   windowToEguiScale = inputScale / eguiDrawScale;
 
   // Convert from pixel to window coordinates
-  this->mappedWindowRegion =
-      int4(float4(mappedWindowRegion) / float4(inputScale.x, inputScale.y, inputScale.x, inputScale.y));
+  this->mappedWindowRegion = int4(float4(mappedWindowRegion) / float4(inputScale.x, inputScale.y, inputScale.x, inputScale.y));
 
   // Take viewport size and scale it by the draw scale
   float2 viewportSizeFloat = float2(float(viewportSize.x), float(viewportSize.y));

--- a/src/gfx/egui/renderer.hpp
+++ b/src/gfx/egui/renderer.hpp
@@ -17,7 +17,8 @@ struct EguiRenderer {
   EguiRenderer();
 
   // clipGeometry controls settings of screen space clip rectangles based on egui
-  void render(const egui::FullOutput &output, const float4x4 &rootTransform, const gfx::DrawQueuePtr &drawQueue, bool clipGeometry = true);
+  void render(const egui::FullOutput &output, const float4x4 &rootTransform, const gfx::DrawQueuePtr &drawQueue,
+              bool clipGeometry = true);
   void renderNoTransform(const egui::FullOutput &output, const gfx::DrawQueuePtr &drawQueue);
 
   static EguiRenderer *create();

--- a/src/mal/SHCore.cpp
+++ b/src/mal/SHCore.cpp
@@ -460,16 +460,14 @@ private:
 
 class malSHVar : public malValue, public malRoot {
 public:
-  malSHVar(const SHVar &var, bool owned) : m_owned(owned) {
-    m_var = var;
-  }
+  malSHVar(const SHVar &var, bool owned) : m_owned(owned) { m_var = var; }
 
   malSHVar(const malSHVar &that, const malValuePtr &meta) : malValue(meta), m_owned(true) {
     m_var = SHVar();
     shards::cloneVar(m_var, that.m_var);
   }
 
-  static malSHVar* newCloned(const SHVar& var) {
+  static malSHVar *newCloned(const SHVar &var) {
     SHVar clonedVar{};
     cloneVar(clonedVar, var);
     return new malSHVar(clonedVar, true);
@@ -1082,7 +1080,7 @@ malSHVarPtr varify(const malValuePtr &arg, bool consumeShard) {
     providerVar->line = arg->line;
     return malSHVarPtr(providerVar);
   } else if (malShard *v = DYNAMIC_CAST(malShard, arg)) {
-    auto shard = v->value(); 
+    auto shard = v->value();
     SHVar var{};
     var.valueType = SHType::ShardRef;
     var.payload.shardValue = shard;


### PR DESCRIPTION
Have a 2D representation of individual shards where their parameters can be edited.

Note that `(ShardViewer)` shard is a temporary shard that can be used as a sandbox to test those editors. In subsequent work (and PR) we will have a proper wire editor and remove that shard.