### PR TITLE
Any type as input if Expect is the first shard

### DIFF
--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -358,8 +358,8 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
 
   // we need to clone this, as might disappear, since outside wire
   mutable shards::TypeInfo inputType{};
-  // flag if we changed inputType to None on purpose (first block is none)
-  mutable bool inputTypeForceNone{false};
+  // flag if we changed inputType to None or Any on purpose
+  mutable bool ignoreInputTypeCheck{false};
   // this one is a shard inside the wire, so won't disappear
   mutable SHTypeInfo outputType{};
 

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -1283,14 +1283,18 @@ SHComposeResult composeWire(const SHWire *wire, SHValidationCallback callback, v
     auto inTypes = wire->shards[0]->inputTypes(wire->shards[0]);
     if (inTypes.len == 1 && inTypes.elements[0].basicType == SHType::None) {
       wire->inputType = SHTypeInfo{};
-      wire->inputTypeForceNone = true;
+      wire->ignoreInputTypeCheck = true;
     } else {
       wire->inputType = data.inputType;
-      wire->inputTypeForceNone = false;
+      wire->ignoreInputTypeCheck = false;
     }
+  } else if (wire->shards.size() > 0 && strncmp(wire->shards[0]->name(wire->shards[0]), "Expect", 6) == 0) {
+    // If first shard is an Expect, this wire can accept ANY input type as the type is checked at runtime
+    wire->inputType = SHTypeInfo{SHType::Any};
+    wire->ignoreInputTypeCheck = true;
   } else {
     wire->inputType = data.inputType;
-    wire->inputTypeForceNone = false;
+    wire->ignoreInputTypeCheck = false;
   }
 
   auto res = composeWire(wire->shards, callback, userData, data);

--- a/src/core/shards/casting.cpp
+++ b/src/core/shards/casting.cpp
@@ -409,7 +409,7 @@ struct ExpectLike {
         SHVar example = _example;
         _expectedType = deriveTypeInfo(example, data);
         _dispose = true;
-        _outputTypeHash = deriveTypeHash(_expectedType);
+        _outputTypeHash = deriveTypeHash(example);
         return _expectedType;
       }
     }

--- a/src/core/shards/wires.cpp
+++ b/src/core/shards/wires.cpp
@@ -39,7 +39,7 @@ std::unordered_set<const SHWire *> &WireBase::gatheringWires() {
 
 void WireBase::verifyAlreadyComposed(const SHInstanceData &data, IterableExposedInfo &shared) {
   // verify input type
-  if (!passthrough && data.inputType != wire->inputType && !wire->inputTypeForceNone) {
+  if (!passthrough && data.inputType != wire->inputType && !wire->ignoreInputTypeCheck) {
     SHLOG_ERROR("Previous wire composed type {} requested call type {}", *wire->inputType, data.inputType);
     throw ComposeError("Attempted to call an already composed wire with a "
                        "different input type! wire: " +


### PR DESCRIPTION
Allow wires (especially valid for pure ones) to have Any type as input if Expect is the first shard