### PR TITLE
Add egui clipboard/cursor handling

### DIFF
--- a/rust/src/shards/gui/context.rs
+++ b/rust/src/shards/gui/context.rs
@@ -227,6 +227,9 @@ impl Shard for EguiContext {
 
     let queue_var = self.queue.get();
     unsafe {
+      // Apply outputs to input related functionality (clipboard, cursor, etc.)
+      egui_gfx::gfx_EguiInputTranslator_applyOutput(self.input_translator.as_mut_ptr(), egui_output);
+
       let queue = shardsc::gfx_getDrawQueueFromVar(queue_var);
       self
         .renderer

--- a/src/gfx/egui/egui_types.hpp
+++ b/src/gfx/egui/egui_types.hpp
@@ -253,6 +253,11 @@ struct FullOutput {
   TextureUpdates textureUpdates;
   const ClippedPrimitive *primitives;
   size_t numPrimitives;
+  egui::CursorIcon cursorIcon;
+  const char* openUrl;
+  const char* copiedText;
+  bool mutableTextUnderCursor;
+  const egui::Pos2* textCursorPosition;
 };
 } // namespace egui
 

--- a/src/gfx/egui/input.cpp
+++ b/src/gfx/egui/input.cpp
@@ -1,11 +1,22 @@
 #include "input.hpp"
 #include "../linalg.hpp"
+#include "../platform.hpp"
 #include <SDL.h>
+#include <SDL_keycode.h>
 #include <gfx/window.hpp>
 #include "renderer.hpp"
 #include <map>
 
 namespace gfx {
+
+// Defines the primary command key
+//   on apple this is the cmd key
+//   otherwise the ctrl key
+#if GFX_APPLE
+#define KMOD_PRIMARY KMOD_GUI
+#else
+#define KMOD_PRIMARY KMOD_CTRL
+#endif
 
 struct SDLCursor {
   SDL_Cursor *cursor{};
@@ -192,13 +203,13 @@ bool EguiInputTranslator::translateEvent(const SDL_Event &sdlEvent) {
 
     // Translate cut/copy/paste using the standard keys combos
     if (ievent.type == SDL_KEYDOWN) {
-      if ((ievent.keysym.mod & KMOD_CTRL) && ievent.keysym.sym == SDLK_c) {
+      if ((ievent.keysym.mod & KMOD_PRIMARY) && ievent.keysym.sym == SDLK_c) {
         newEvent(InputEventType::Copy);
-      } else if ((ievent.keysym.mod & KMOD_CTRL) && ievent.keysym.sym == SDLK_v) {
+      } else if ((ievent.keysym.mod & KMOD_PRIMARY) && ievent.keysym.sym == SDLK_v) {
         auto &evt = newEvent(InputEventType::Paste);
 
         evt.paste.str = strings.emplace_back(SDL_GetClipboardText()).c_str();
-      } else if ((ievent.keysym.mod & KMOD_CTRL) && ievent.keysym.sym == SDLK_x) {
+      } else if ((ievent.keysym.mod & KMOD_PRIMARY) && ievent.keysym.sym == SDLK_x) {
         newEvent(InputEventType::Cut);
       }
     }

--- a/src/gfx/egui/input.cpp
+++ b/src/gfx/egui/input.cpp
@@ -66,6 +66,8 @@ static egui::ModifierKeys translateModifierKeys(SDL_Keymod flags) {
 }
 
 void EguiInputTranslator::setupWindowInput(Window &window, int4 mappedWindowRegion, int2 viewportSize, float scalingFactor) {
+  this->window = &window;
+
   // UI Points per pixel
   float eguiDrawScale = EguiRenderer::getDrawScale(window) * scalingFactor;
 
@@ -163,30 +165,20 @@ bool EguiInputTranslator::translateEvent(const SDL_Event &sdlEvent) {
       newEvent(InputEventType::CompositionStart);
     }
 
-    newEvent(InputEventType::CompositionUpdate);
-    strings.emplace_back(ievent.text);
-    deferQueue.emplace_back([this, eventIdx = events.size() - 1, stringIdx = strings.size() - 1]() {
-      events[eventIdx].compositionUpdate.text = strings[stringIdx].c_str();
-    });
+    auto &evt = newEvent(InputEventType::CompositionUpdate);
+    evt.compositionUpdate.text = strings.emplace_back(ievent.text).c_str();
     break;
   }
   case SDL_TEXTINPUT: {
     auto &ievent = sdlEvent.text;
 
     if (imeComposing) {
-      newEvent(InputEventType::CompositionEnd);
-      strings.emplace_back(ievent.text);
-      deferQueue.emplace_back([this, eventIdx = events.size() - 1, stringIdx = strings.size() - 1]() {
-        events[eventIdx].compositionEnd.text = strings[stringIdx].c_str();
-      });
+      auto &evt = newEvent(InputEventType::CompositionEnd);
+      evt.compositionEnd.text = strings.emplace_back(ievent.text).c_str();
       imeComposing = false;
     } else {
-      newEvent(InputEventType::Text);
-      strings.emplace_back(ievent.text);
-
-      deferQueue.emplace_back([this, eventIdx = events.size() - 1, stringIdx = strings.size() - 1]() {
-        events[eventIdx].text.text = strings[stringIdx].c_str();
-      });
+      auto &evt = newEvent(InputEventType::Text);
+      evt.text.text = strings.emplace_back(ievent.text).c_str();
     }
     break;
   }
@@ -203,12 +195,9 @@ bool EguiInputTranslator::translateEvent(const SDL_Event &sdlEvent) {
       if ((ievent.keysym.mod & KMOD_CTRL) && ievent.keysym.sym == SDLK_c) {
         newEvent(InputEventType::Copy);
       } else if ((ievent.keysym.mod & KMOD_CTRL) && ievent.keysym.sym == SDLK_v) {
-        newEvent(InputEventType::Paste);
+        auto &evt = newEvent(InputEventType::Paste);
 
-        strings.emplace_back(SDL_GetClipboardText());
-        deferQueue.emplace_back([this, eventIdx = events.size() - 1, stringIdx = strings.size() - 1]() {
-          events[eventIdx].paste.str = strings[stringIdx].c_str();
-        });
+        evt.paste.str = strings.emplace_back(SDL_GetClipboardText()).c_str();
       } else if ((ievent.keysym.mod & KMOD_CTRL) && ievent.keysym.sym == SDLK_x) {
         newEvent(InputEventType::Cut);
       }
@@ -220,10 +209,6 @@ bool EguiInputTranslator::translateEvent(const SDL_Event &sdlEvent) {
 }
 
 void EguiInputTranslator::end() {
-  for (auto &deferred : deferQueue) {
-    deferred();
-  }
-
   input.inputEvents = events.data();
   input.numInputEvents = events.size();
 
@@ -232,8 +217,8 @@ void EguiInputTranslator::end() {
 }
 
 const egui::Input *EguiInputTranslator::translateFromInputEvents(const EguiInputTranslatorArgs &args) {
-  setupWindowInput(args.window, args.mappedWindowRegion, args.viewportSize, args.scalingFactor);
   begin(args.time, args.deltaTime);
+  setupWindowInput(args.window, args.mappedWindowRegion, args.viewportSize, args.scalingFactor);
   for (const auto &event : args.events)
     translateEvent(event);
   end();
@@ -247,6 +232,17 @@ egui::Pos2 EguiInputTranslator::translatePointerPos(const egui::Pos2 &pos) {
       (pos.x - mappedWindowRegion.x) * windowToEguiScale.x,
       (pos.y - mappedWindowRegion.y) * windowToEguiScale.y,
   };
+}
+
+void EguiInputTranslator::applyOutput(const egui::FullOutput &output) {
+  if (window)
+    updateTextCursorPosition(*window, output.textCursorPosition);
+
+  if (output.copiedText)
+    copyText(output.copiedText);
+
+  if (input.numInputEvents > 0)
+    updateCursorIcon(output.cursorIcon);
 }
 
 void EguiInputTranslator::updateTextCursorPosition(Window &window, const egui::Pos2 *pos) {
@@ -287,7 +283,7 @@ void EguiInputTranslator::updateCursorIcon(egui::CursorIcon icon) {
 void EguiInputTranslator::reset() {
   strings.clear();
   events.clear();
-  deferQueue.clear();
+  this->window = nullptr;
 }
 
 EguiInputTranslator *EguiInputTranslator::create() { return new EguiInputTranslator(); }

--- a/src/gfx/egui/input.hpp
+++ b/src/gfx/egui/input.hpp
@@ -3,6 +3,7 @@
 
 #include "egui_types.hpp"
 #include "../linalg.hpp"
+#include <deque>
 #include <vector>
 
 namespace gfx {
@@ -26,14 +27,14 @@ struct EguiInputTranslatorArgs {
 struct EguiInputTranslator {
 private:
   egui::Input input;
-  std::vector<std::string> strings;
+  std::deque<std::string> strings;
   std::vector<egui::InputEvent> events;
   egui::Pos2 lastCursorPosition;
   bool imeComposing{};
   bool textInputActive{};
   float2 windowToEguiScale;
   int4 mappedWindowRegion;
-  std::vector<std::function<void()>> deferQueue;
+  Window* window{};
 
 public:
   EguiInputTranslator() = default;
@@ -63,6 +64,9 @@ public:
 
   // Translate from window coordinates to local egui coordinates
   egui::Pos2 translatePointerPos(const egui::Pos2 &pos);
+
+  // Applies egui output to update cursor pos, clipboard, etc.
+  void applyOutput(const egui::FullOutput &output);
 
   // Set or clear the position for the text cursor
   void updateTextCursorPosition(Window &window, const egui::Pos2 *pos);


### PR DESCRIPTION
Adds handling of egui outputs such as:
- clipboard
- cursor icon
- IME position

to the default `UI.Context` by passing egui outputs back to the input translator