### PR TITLE
Initialize empty string when exposing a new variable

### DIFF
--- a/docs/samples/shards/UI/TextInput/3.edn
+++ b/docs/samples/shards/UI/TextInput/3.edn
@@ -1,0 +1,16 @@
+(GFX.MainWindow
+ :Contents
+ (->
+  (Setup
+   (GFX.DrawQueue) >= .ui-draw-queue
+   (GFX.UIPass .ui-draw-queue) >> .render-steps)
+  .ui-draw-queue (GFX.ClearQueue)
+
+  (UI
+   .ui-draw-queue
+   (UI.CentralPanel
+    (->
+     ;; exposing a new variable
+     (UI.TextInput .text))))
+
+  (GFX.Render :Steps .render-steps)))

--- a/rust/src/shards/gui/widgets/text_input.rs
+++ b/rust/src/shards/gui/widgets/text_input.rs
@@ -2,6 +2,7 @@
 /* Copyright © 2022 Fragcolor Pte. Ltd. */
 
 use super::TextInput;
+use crate::core::cloneVar;
 use crate::shard::Shard;
 use crate::shards::gui::util;
 use crate::shards::gui::ImmutableVar;
@@ -184,7 +185,9 @@ impl Shard for TextInput {
     self.multiline.warmup(ctx);
 
     if self.should_expose {
-      self.variable.get_mut().valueType = common_type::string.basicType;
+      // new string
+      let tmp = Var::ephemeral_string("");
+      cloneVar(self.variable.get_mut(), &tmp);
     }
 
     Ok(())


### PR DESCRIPTION
Fix a crash when exposing a new string variable in a `UI.TextInput`.

Add a documentation sample to cover this case.