### PR TITLE
Add hack to treat Render outputs as cleared/written

### DIFF
--- a/src/gfx/renderer.hpp
+++ b/src/gfx/renderer.hpp
@@ -13,6 +13,11 @@ namespace gfx {
 
 struct RendererImpl;
 
+struct RendererHacks {
+  // Hints about definitely cleared render targets
+  std::vector<std::string> clearedHints;
+};
+
 /// Instance that caches render pipelines
 /// <div rustbindgen opaque></div>
 struct Renderer {
@@ -30,7 +35,7 @@ public:
   Context &getContext();
 
   /// <div rustbindgen hide></div>
-  void render(std::vector<ViewPtr> views, const PipelineSteps &pipelineSteps);
+  void render(std::vector<ViewPtr> views, const PipelineSteps &pipelineSteps, const RendererHacks& hacks = {});
 
   /// <div rustbindgen hide></div>
   void render(ViewPtr view, const PipelineSteps &pipelineSteps);


### PR DESCRIPTION
This allows having multiple GFX.Render calls overlay on the same color buffer for now without having to merge the render graphs
