### PR TITLE
Simple wire viewer/editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
+ "slotmap",
  "sp-core",
  "syntect",
  "tiny-keccak",
@@ -3327,6 +3328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ egui_dock = { version = "0.3.0", optional = true }
 egui_extras = { version = "0.20.0", optional = true }
 egui-gfx = { path = "../src/gfx/egui", optional = true }
 egui_memory_editor = { version = "0.2.2", optional = true }
+slotmap = { version = "1.0", optional = true }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"], optional = true }
 half = { version = "2.0.0" }
 tract-onnx = { version = "0.19.2", optional = true }
@@ -91,6 +92,7 @@ shards = ["reqwest",
           "egui_dock",
           "egui_extras",
           "egui-gfx",
+          "slotmap",
           "code_editor",
           "hex_viewer",
           "tract-onnx",

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -416,6 +416,10 @@ impl WireRef {
       Ok(None)
     }
   }
+
+  pub fn get_wire_info(&self) -> SHWireInfo {
+    unsafe { (*Core).getWireInfo.unwrap()(self.0) }
+  }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -606,6 +606,7 @@ impl core::fmt::Debug for SHVarPayloadDebugView<'_> {
   }
 }
 
+#[derive(Debug)]
 pub struct ShardInstance {
   ptr: ShardPtr,
 }
@@ -617,6 +618,12 @@ impl Drop for ShardInstance {
         (*self.ptr).destroy.unwrap()(self.ptr);
       }
     }
+  }
+}
+
+impl From<ShardPtr> for ShardInstance {
+  fn from(ptr: ShardPtr) -> Self {
+    Self { ptr }
   }
 }
 

--- a/rust/src/shards/editor/graph.rs
+++ b/rust/src/shards/editor/graph.rs
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use super::id_types::*;
+use slotmap::SlotMap;
+
+pub(crate) struct Graph<NodeData> {
+  pub nodes: SlotMap<NodeId, Node<NodeData>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct Node<NodeData> {
+  pub id: NodeId,
+  pub label: String,
+  pub data: NodeData,
+}
+
+impl<NodeData> Default for Graph<NodeData> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<NodeData> Graph<NodeData> {
+  pub fn new() -> Self {
+    Self {
+      nodes: SlotMap::default(),
+    }
+  }
+
+  pub fn add_node(&mut self, label: String, data: NodeData) -> NodeId {
+    self.nodes.insert_with_key(|id| Node::new(id, label, data))
+  }
+
+  pub fn remove_node(&mut self, node_id: NodeId) -> Node<NodeData> {
+    self.nodes.remove(node_id).expect("Node should exist")
+  }
+
+  pub fn clear(&mut self) {
+    self.nodes.clear();
+  }
+}
+
+impl<NodeData> Node<NodeData> {
+  pub fn new(id: NodeId, label: String, data: NodeData) -> Self {
+    Self { id, label, data }
+  }
+}

--- a/rust/src/shards/editor/graph_ui.rs
+++ b/rust/src/shards/editor/graph_ui.rs
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use egui::*;
+
+pub(crate) trait UIRenderer {
+  fn ui(&mut self, ui: &mut Ui) -> Response;
+}

--- a/rust/src/shards/editor/id_types.rs
+++ b/rust/src/shards/editor/id_types.rs
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+slotmap::new_key_type! { pub(crate) struct NodeId; }

--- a/rust/src/shards/editor/index_impls.rs
+++ b/rust/src/shards/editor/index_impls.rs
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use super::graph::*;
+use super::id_types::*;
+
+macro_rules! impl_index_traits {
+  ($id_type:ty, $output_type:ty, $arena:ident) => {
+    impl<A> std::ops::Index<$id_type> for Graph<A> {
+      type Output = $output_type;
+
+      fn index(&self, index: $id_type) -> &Self::Output {
+        self.$arena.get(index).unwrap_or_else(|| {
+          panic!(
+            "{} index error for {:?}. Has the value been deleted?",
+            stringify!($id_type),
+            index
+          )
+        })
+      }
+    }
+
+    impl<A> std::ops::IndexMut<$id_type> for Graph<A> {
+      fn index_mut(&mut self, index: $id_type) -> &mut Self::Output {
+        self.$arena.get_mut(index).unwrap_or_else(|| {
+          panic!(
+            "{} index error for {:?}. Has the value been deleted?",
+            stringify!($id_type),
+            index
+          )
+        })
+      }
+    }
+  };
+}
+
+impl_index_traits!(NodeId, Node<A>, nodes);

--- a/rust/src/shards/editor/mod.rs
+++ b/rust/src/shards/editor/mod.rs
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+/// Implements the graph
+pub(crate) mod graph;
+pub(crate) use graph::*;
+/// Type declarations for the different id types (node, input, output)
+pub(crate) mod id_types;
+pub(crate) use id_types::*;
+/// Implements the index trait for the Graph type, allowing indexing by all id types
+mod index_impls;
+/// Implements some utilities
+pub(crate) mod util;

--- a/rust/src/shards/editor/mod.rs
+++ b/rust/src/shards/editor/mod.rs
@@ -4,10 +4,16 @@
 /// Implements the graph
 pub(crate) mod graph;
 pub(crate) use graph::*;
+/// Implements the graph basic ui
+pub(crate) mod graph_ui;
+pub(crate) use graph_ui::*;
 /// Type declarations for the different id types (node, input, output)
 pub(crate) mod id_types;
 pub(crate) use id_types::*;
 /// Implements the index trait for the Graph type, allowing indexing by all id types
 mod index_impls;
+/// Implements the different nodes
+pub(crate) mod node_templates;
+pub(crate) use node_templates::*;
 /// Implements some utilities
 pub(crate) mod util;

--- a/rust/src/shards/editor/node_templates.rs
+++ b/rust/src/shards/editor/node_templates.rs
@@ -1,0 +1,434 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use super::graph_ui::UIRenderer;
+use crate::core::cloneVar;
+use crate::core::createShard;
+use crate::core::ShardInstance;
+use crate::shardsc::*;
+use crate::types::common_type::type2name;
+use crate::types::Var;
+use egui::Response;
+use egui::Ui;
+use std::collections::BTreeMap;
+use std::ffi::CStr;
+use std::ptr::slice_from_raw_parts;
+
+#[derive(Clone)]
+pub(crate) struct ShardTemplate<'a> {
+  name: &'a str,
+  help: &'a str,
+}
+
+impl<'a> ShardTemplate<'a> {
+  pub fn new(name: &'a str) -> Self {
+    let instance = createShard(name);
+    let help = instance.help();
+    let help = unsafe {
+      if help.string == std::ptr::null_mut() {
+        ""
+      } else {
+        let slice = CStr::from_ptr(help.string);
+        slice.to_str().unwrap_or("")
+      }
+    };
+
+    Self { name, help }
+  }
+}
+
+impl<'a> UIRenderer for ShardTemplate<'a> {
+  fn ui(&mut self, ui: &mut Ui) -> Response {
+    ui.label(self.help)
+  }
+}
+
+#[derive(Debug)]
+pub(crate) struct ShardData<'a> {
+  pub name: &'a str,
+  pub instance: ShardInstance,
+  pub params: Vec<(&'a str, VarValue<'a>)>,
+}
+
+impl<'a> ShardData<'a> {
+  fn new(name: &'a str) -> Self {
+    let instance = createShard(name);
+    instance.into()
+  }
+}
+
+impl<'a> From<ShardInstance> for ShardData<'a> {
+  fn from(instance: ShardInstance) -> Self {
+    unsafe {
+      let name = CStr::from_ptr(instance.name()).to_str().unwrap();
+      let params = instance.parameters();
+      let params = if params.len > 0 {
+        let params = core::slice::from_raw_parts(params.elements, params.len as usize);
+        params
+          .iter()
+          .enumerate()
+          .map(|(i, p)| {
+            let mut data = VarValueData::Basic;
+            let types = p.valueTypes;
+            let mut types = if types.len > 0 {
+              let types = core::slice::from_raw_parts(types.elements, types.len as usize);
+              types
+                .iter()
+                .map(|t| {
+                  if t.basicType == SHType_Enum {
+                    let details = t.details.enumeration;
+                    let info = util_findEnumInfo(details.vendorId, details.typeId)
+                      .as_ref()
+                      .unwrap();
+                    let name = CStr::from_ptr(info.name).to_str().unwrap();
+                    let labels =
+                      core::slice::from_raw_parts(info.labels.elements, info.labels.len as usize);
+                    let labels: Vec<&str> = labels
+                      .iter()
+                      .map(|l| CStr::from_ptr(*l).to_str().unwrap())
+                      .collect();
+                    let descriptions = core::slice::from_raw_parts(
+                      info.descriptions.elements,
+                      info.descriptions.len as usize,
+                    );
+                    let descriptions: Vec<&str> = descriptions
+                      .iter()
+                      .map(|l| {
+                        if l.string == std::ptr::null_mut() {
+                          ""
+                        } else {
+                          CStr::from_ptr(l.string).to_str().unwrap()
+                        }
+                      })
+                      .collect();
+                    let values =
+                      core::slice::from_raw_parts(info.values.elements, info.values.len as usize);
+
+                    assert_eq!(values.len(), labels.len());
+                    assert_eq!(labels.len(), descriptions.len());
+
+                    // FIXME have a cache for enums
+                    // FIXME support multiple enum types
+                    data = VarValueData::Enum {
+                      enum_name: name,
+                      enum_values: (0..labels.len())
+                        .map(|i| (values[i], (labels[i], descriptions[i])))
+                        .collect(),
+                    };
+                  }
+                  t.basicType
+                })
+                .collect()
+            } else {
+              vec![]
+            };
+            // TODO deal with ContextVar
+            // deal with Any
+            if types.contains(&SHType_Any) {
+              // FIXME might also need Any's ContextVar
+              // FIXME might also need to restore some Enum values
+              //       note: we expect them to be explicitly allowed in the parameter info as we
+              //       can offer all enum types here (except maybe for radio button)
+              types = any_type();
+            }
+
+            let type_name = CStr::from_ptr(p.name).to_str().unwrap();
+            let initial_value = instance.getParam(i as i32);
+            (type_name, VarValue::new(&initial_value, types, data))
+          })
+          .collect()
+      } else {
+        vec![]
+      };
+
+      Self {
+        name,
+        instance,
+        params,
+      }
+    }
+  }
+}
+
+impl<'a> UIRenderer for ShardData<'a> {
+  fn ui(&mut self, ui: &mut Ui) -> Response {
+    egui::Grid::new(self.name)
+      .show(ui, |ui| {
+        for (i, (name, p)) in self.params.iter_mut().enumerate() {
+          ui.label(*name);
+          ui.push_id(i, |ui| p.ui(ui));
+          ui.end_row();
+        }
+      })
+      .response
+  }
+}
+
+#[derive(Debug)]
+pub(crate) struct VarValue<'a> {
+  value: Var,
+  allowed_types: Vec<SHType>,
+  prev_type: SHType,
+  // FIXME use this to "restore" previous value
+  // prev_value: Option<SHVarPayload>,
+  data: VarValueData<'a>,
+}
+
+#[derive(Debug)]
+pub(crate) enum VarValueData<'a> {
+  Basic,
+  Enum {
+    enum_name: &'a str,
+    enum_values: BTreeMap<i32, (&'a str, &'a str)>,
+  },
+}
+
+impl<'a> Clone for VarValue<'a> {
+  fn clone(&self) -> Self {
+    VarValue::new(&self.value, self.allowed_types.clone(), self.data.clone())
+  }
+}
+
+impl<'a> Clone for VarValueData<'a> {
+  fn clone(&self) -> Self {
+    match self {
+      Self::Basic => Self::Basic,
+      Self::Enum {
+        enum_name,
+        enum_values,
+      } => Self::Enum {
+        enum_name,
+        enum_values: enum_values.clone(),
+      },
+    }
+  }
+}
+
+impl<'a> VarValue<'a> {
+  pub fn new(initial_value: &Var, allowed_types: Vec<SHType>, data: VarValueData<'a>) -> Self {
+    debug_assert!(allowed_types.len() > 0usize);
+    if cfg!(debug_assertions) {
+      if !allowed_types.contains(&initial_value.valueType) {
+        // HACK: put a breakpoint here or uncomment
+        shlog_debug!(
+          "Type {} is not amongst allowed types {:?}",
+          initial_value.valueType,
+          allowed_types
+        );
+      }
+    }
+
+    let mut ret = Self {
+      value: Var::default(),
+      allowed_types,
+      prev_type: initial_value.valueType,
+      data,
+    };
+    cloneVar(&mut ret.value, initial_value);
+    ret
+  }
+}
+
+fn any_type() -> Vec<SHType> {
+  vec![
+    // SHType_None, // FIXME need special handling
+    // SHType_Any,
+    // SHType_Enum, // FIXME add support
+    SHType_Bool,
+    SHType_Int,
+    SHType_Int2,
+    SHType_Int3,
+    SHType_Int4,
+    // SHType_Int8, // FIXME add support
+    // SHType_Int16, // FIXME add support
+    SHType_Float,
+    SHType_Float2,
+    SHType_Float3,
+    SHType_Float4,
+    SHType_Color,
+    // SHType_ShardRef, // FIXME add support
+    // SHType_EndOfBlittableTypes,
+    // SHType_Bytes, // FIXME add support
+    SHType_String,
+    // SHType_Path, // FIXME add support
+    // SHType_ContextVar, // FIXME add support
+    // SHType_Image, // FIXME add support
+    // SHType_Seq, // FIXME add support
+    // SHType_Table, // FIXME add support
+    // SHType_Wire, // FIXME add support
+    // SHType_Object, // FIXME add support
+    // SHType_Array, // FIXME add support
+    // SHType_Set, // FIXME add support
+    // SHType_Audio, // FIXME add support
+  ]
+}
+
+macro_rules! invalid_data {
+  ($ui:ident) => {
+    if cfg!(debug_assertions) {
+      $ui.colored_label(egui::Color32::RED, "Invalid type of VarValueData")
+    } else {
+      $ui.label("")
+    }
+  };
+}
+
+impl<'a> UIRenderer for VarValue<'a> {
+  fn ui(&mut self, ui: &mut Ui) -> Response {
+    ui.horizontal(|ui| {
+      egui::ComboBox::from_id_source(("VarValue", "type"))
+        // FIXME display actualy name instead of int
+        .selected_text(type2name(self.value.valueType))
+        .show_ui(ui, |ui| {
+          for t in &self.allowed_types {
+            // FIXME display actualy name instead of int
+            ui.selectable_value(&mut self.value.valueType, *t, type2name(*t));
+          }
+        });
+
+      if self.prev_type != self.value.valueType {
+        self.prev_type = self.value.valueType;
+        // FIXME conversion or reset the value
+        // for now just clear the value
+        self.value.payload = Default::default();
+      }
+
+      unsafe {
+        match self.value.valueType {
+          SHType_None => ui.label(""),
+          SHType_Enum => {
+            if let VarValueData::Enum {
+              enum_name,
+              enum_values,
+            } = &mut self.data
+            {
+              let value = &mut self
+                .value
+                .payload
+                .__bindgen_anon_1
+                .__bindgen_anon_3
+                .enumValue;
+              egui::ComboBox::from_label(*enum_name)
+                .selected_text(enum_values.get(value).unwrap_or(&("", "")).0)
+                .show_ui(ui, |ui| {
+                  for i in enum_values.keys() {
+                    ui.selectable_value(value, *i, enum_values.get(i).unwrap().0);
+                  }
+                })
+                .response
+            } else {
+              invalid_data!(ui)
+            }
+          }
+          SHType_Bool => ui.checkbox(&mut self.value.payload.__bindgen_anon_1.boolValue, ""),
+          SHType_Int => ui.add(egui::DragValue::new(
+            &mut self.value.payload.__bindgen_anon_1.intValue,
+          )),
+          SHType_Int2 => {
+            ui.horizontal(|ui| {
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int2Value[0],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int2Value[1],
+              ));
+            })
+            .response
+          }
+          SHType_Int3 => {
+            ui.horizontal(|ui| {
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int3Value[0],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int3Value[1],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int3Value[2],
+              ));
+            })
+            .response
+          }
+          SHType_Int4 => {
+            ui.horizontal(|ui| {
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int4Value[0],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int4Value[1],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int4Value[2],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.int4Value[3],
+              ));
+            })
+            .response
+          }
+          SHType_Float => ui.add(egui::DragValue::new(
+            &mut self.value.payload.__bindgen_anon_1.floatValue,
+          )),
+          SHType_Float2 => {
+            ui.horizontal(|ui| {
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float2Value[0],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float2Value[1],
+              ));
+            })
+            .response
+          }
+          SHType_Float3 => {
+            ui.horizontal(|ui| {
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float3Value[0],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float3Value[1],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float3Value[2],
+              ));
+            })
+            .response
+          }
+          SHType_Float4 => {
+            ui.horizontal(|ui| {
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float4Value[0],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float4Value[1],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float4Value[2],
+              ));
+              ui.add(egui::DragValue::new(
+                &mut self.value.payload.__bindgen_anon_1.float4Value[3],
+              ));
+            })
+            .response
+          }
+          SHType_Color => {
+            let color = &mut self.value.payload.__bindgen_anon_1.colorValue;
+            let mut srgba = [color.r, color.g, color.b, color.a];
+            let response = ui.color_edit_button_srgba_unmultiplied(&mut srgba);
+            color.r = srgba[0];
+            color.g = srgba[1];
+            color.b = srgba[2];
+            color.a = srgba[3];
+            response
+          }
+          SHType_String => {
+            let mut mutable = &mut self.value;
+            ui.text_edit_singleline(&mut mutable)
+          }
+          _ => ui.colored_label(egui::Color32::RED, "Type of value not supported."),
+        }
+      }
+    })
+    .response
+  }
+}

--- a/rust/src/shards/editor/util.rs
+++ b/rust/src/shards/editor/util.rs
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+// Some parts taken from egui_node_graph
+// MIT license
+// Copyright (c) 2022 setzer22
+
+use egui::Color32;
+
+pub(crate) trait ColorUtils: Sized {
+  type Error;
+
+  /// Multiplies the color rgb values by `factor`, keeping alpha untouched.
+  fn lighten(&self, factor: f32) -> Self;
+  /// Converts a hex string with a leading '#' into a egui::Color32.
+  /// - The first three channels are interpreted as R, G, B.
+  /// - The fourth channel, if present, is used as the alpha value.
+  /// - Both upper and lowercase characters can be used for the hex values.
+  ///
+  /// *Adapted from: https://docs.rs/raster/0.1.0/src/raster/lib.rs.html#425-725.
+  /// Credit goes to original authors.*
+  fn from_hex(hex: &str) -> Result<Self, Self::Error>;
+  /// Converts a color into its canonical hexadecimal representation.
+  /// - The color string will be preceded by '#'.
+  /// - If the alpha channel is completely opaque, it will be ommitted.
+  /// - Characters from 'a' to 'f' will be written in lowercase.
+  fn to_hex(&self) -> String;
+}
+
+impl ColorUtils for Color32 {
+  type Error = &'static str;
+
+  fn lighten(&self, factor: f32) -> Self {
+    Color32::from_rgba_premultiplied(
+      (self.r() as f32 * factor) as u8,
+      (self.g() as f32 * factor) as u8,
+      (self.b() as f32 * factor) as u8,
+      self.a(),
+    )
+  }
+
+  fn from_hex(hex: &str) -> Result<Self, Self::Error> {
+    // Convert a hex string to decimal. Eg. "00" -> 0. "FF" -> 255.
+    fn _hex_dec(hex_string: &str) -> Result<u8, &'static str> {
+      match u8::from_str_radix(hex_string, 16) {
+        Ok(o) => Ok(o),
+        Err(_) => Err("Error parsing hex"),
+      }
+    }
+
+    if hex.len() == 9 && hex.starts_with('#') {
+      // #FFFFFFFF (Red Green Blue Alpha)
+      return Ok(Color32::from_rgba_premultiplied(
+        _hex_dec(&hex[1..3])?,
+        _hex_dec(&hex[3..5])?,
+        _hex_dec(&hex[5..7])?,
+        _hex_dec(&hex[7..9])?,
+      ));
+    } else if hex.len() == 7 && hex.starts_with('#') {
+      // #FFFFFF (Red Green Blue)
+      return Ok(Color32::from_rgb(
+        _hex_dec(&hex[1..3])?,
+        _hex_dec(&hex[3..5])?,
+        _hex_dec(&hex[5..7])?,
+      ));
+    }
+
+    Err("Error parsing hex. Example of valid formats: #FFFFFF or #ffffffff")
+  }
+
+  fn to_hex(&self) -> String {
+    if self.a() < 255 {
+      format!(
+        "#{:02x?}{:02x?}{:02x?}{:02x?}",
+        self.r(),
+        self.g(),
+        self.b(),
+        self.a()
+      )
+    } else {
+      format!("#{:02x?}{:02x?}{:02x?}", self.r(), self.g(), self.b())
+    }
+  }
+}

--- a/rust/src/shards/gui/containers/window.rs
+++ b/rust/src/shards/gui/containers/window.rs
@@ -14,6 +14,7 @@ use crate::shards::gui::EGUI_CTX_TYPE;
 use crate::shards::gui::FLOAT2_VAR_SLICE;
 use crate::shards::gui::HELP_OUTPUT_EQUAL_INPUT;
 use crate::shards::gui::PARENTS_UI_NAME;
+use crate::types::common_type;
 use crate::types::Context;
 use crate::types::ExposedInfo;
 use crate::types::ExposedTypes;
@@ -33,7 +34,8 @@ use crate::types::SHARDS_OR_NONE_TYPES;
 use crate::types::STRING_TYPES;
 
 lazy_static! {
-  static ref WINDOW_FLAGS_OR_SEQ_TYPES: Vec<Type> = vec![*WINDOW_FLAGS_TYPE, *SEQ_OF_WINDOW_FLAGS];
+  static ref WINDOW_FLAGS_OR_SEQ_TYPES: Vec<Type> =
+    vec![common_type::none, *WINDOW_FLAGS_TYPE, *SEQ_OF_WINDOW_FLAGS];
   static ref WINDOW_PARAMETERS: Parameters = vec![
     (
       cstr!("Title"),

--- a/rust/src/shards/gui/editor/mod.rs
+++ b/rust/src/shards/gui/editor/mod.rs
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use crate::core::registerShard;
+use crate::shards::editor::Graph;
+use crate::shards::editor::NodeId;
+use crate::shards::editor::ShardData;
+use crate::types::ExposedTypes;
+use crate::types::ParamVar;
+
+struct WireViewer<'a> {
+  wire: ParamVar,
+  parents: ParamVar,
+  requiring: ExposedTypes,
+  graph: Graph<ShardData<'a>>,
+  node_order: Vec<NodeId>,
+}
+
+mod wire_viewer;
+
+pub fn registerShards() {
+  registerShard::<WireViewer>();
+}

--- a/rust/src/shards/gui/editor/wire_viewer.rs
+++ b/rust/src/shards/gui/editor/wire_viewer.rs
@@ -1,0 +1,249 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2023 Fragcolor Pte. Ltd. */
+
+use super::WireViewer;
+use crate::core::ShardInstance;
+use crate::shard::Shard;
+use crate::shards::editor::util::ColorUtils;
+use crate::shards::editor::ShardData;
+use crate::shards::editor::UIRenderer;
+use crate::shards::gui::util;
+use crate::shards::gui::HELP_OUTPUT_EQUAL_INPUT;
+use crate::shards::gui::HELP_VALUE_IGNORED;
+use crate::shards::gui::PARENTS_UI_NAME;
+use crate::types::common_type;
+use crate::types::Context;
+use crate::types::ExposedTypes;
+use crate::types::OptionalString;
+use crate::types::ParamVar;
+use crate::types::Parameters;
+use crate::types::Type;
+use crate::types::Types;
+use crate::types::Var;
+use crate::types::WireRef;
+use crate::types::ANY_TYPES;
+
+lazy_static! {
+  static ref WIRE_OR_VAR_TYPES: Vec<Type> = vec![common_type::wire, common_type::wire_var];
+  static ref VIEWER_PARAMETERS: Parameters =
+    vec![(cstr!("Wire"), shccstr!("TODO"), &WIRE_OR_VAR_TYPES[..]).into(),];
+}
+
+impl<'a> Default for WireViewer<'a> {
+  fn default() -> Self {
+    let mut parents = ParamVar::default();
+    parents.set_name(PARENTS_UI_NAME);
+    Self {
+      wire: ParamVar::default(),
+      parents,
+      requiring: Vec::new(),
+      graph: Default::default(),
+      node_order: Vec::new(),
+    }
+  }
+}
+
+impl<'a> Shard for WireViewer<'a> {
+  fn registerName() -> &'static str
+  where
+    Self: Sized,
+  {
+    cstr!("WireViewer")
+  }
+
+  fn hash() -> u32
+  where
+    Self: Sized,
+  {
+    compile_time_crc32::crc32!("WireViewer-rust-0x20200101")
+  }
+
+  fn name(&mut self) -> &str {
+    "WireViewer"
+  }
+
+  fn inputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn inputHelp(&mut self) -> OptionalString {
+    *HELP_VALUE_IGNORED
+  }
+
+  fn outputTypes(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+
+  fn outputHelp(&mut self) -> OptionalString {
+    *HELP_OUTPUT_EQUAL_INPUT
+  }
+
+  fn parameters(&mut self) -> Option<&Parameters> {
+    Some(&VIEWER_PARAMETERS)
+  }
+
+  fn setParam(&mut self, index: i32, value: &Var) -> Result<(), &str> {
+    match index {
+      0 => Ok(self.wire.set_param(value)),
+      _ => Err("Invalid parameter index"),
+    }
+  }
+
+  fn getParam(&mut self, index: i32) -> Var {
+    match index {
+      0 => self.wire.get_param(),
+      _ => Var::default(),
+    }
+  }
+
+  fn requiredVariables(&mut self) -> Option<&ExposedTypes> {
+    self.requiring.clear();
+
+    // Add UI.Parents to the list of required variables
+    util::require_parents(&mut self.requiring, &self.parents);
+
+    Some(&self.requiring)
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.wire.warmup(ctx);
+    self.parents.warmup(ctx);
+
+    // FIXME we should recompute the data if the wire changed (or not)
+    self.compute_data(ctx)?;
+
+    Ok(())
+  }
+
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.graph.clear();
+
+    self.wire.cleanup();
+    self.parents.cleanup();
+
+    Ok(())
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Var, &str> {
+    if let Some(ui) = util::get_current_parent(self.parents.get())? {
+      for node_id in self.node_order.iter().copied() {
+        ui.push_id(node_id, |ui| {
+          use egui::epaint::*;
+          use egui::style::*;
+          use egui::*;
+
+          let margin = Margin::symmetric(15.0, 5.0);
+          let (background_color, text_color) = if ui.visuals().dark_mode {
+            (
+              Color32::from_hex("#3f3f3f").unwrap(),
+              Color32::from_hex("#fefefe").unwrap(),
+            )
+          } else {
+            (
+              Color32::from_hex("#ffffff").unwrap(),
+              Color32::from_hex("#505050").unwrap(),
+            )
+          };
+          ui.visuals_mut().widgets.noninteractive.fg_stroke = Stroke::new(2.0, text_color);
+
+          // Preallocate shapes to paint below contents
+          let background_shape = ui.painter().add(Shape::Noop);
+
+          let mut title_height = 0.0;
+
+          let node = &mut self.graph[node_id];
+          Frame::none().inner_margin(margin).show(ui, |ui| {
+            ui.vertical(|ui| {
+              ui.horizontal(|ui| {
+                ui.add(Label::new(
+                  RichText::new(&node.label)
+                    .text_style(TextStyle::Button)
+                    .color(text_color),
+                ));
+                ui.add_space(8.0); // The size of the little cross icon
+              });
+              title_height = ui.min_size().y;
+              ui.add_space(margin.top);
+
+              // First pass: Draw the inner fields. Compute port heights
+              node.data.ui(ui);
+            })
+          });
+
+          // Second pass, iterate again to draw the ports. This happens outside
+          // the child_ui because we want ports to overflow the node background.
+          let outer_rect = ui.min_rect();
+
+          // Draw the background shape.
+          // NOTE: This code is a bit more involved than it needs to be because egui
+          // does not support drawing rectangles with asymmetrical round corners.
+          let shape = {
+            let rounding_radius = 4.0;
+
+            let titlebar_height = title_height + margin.top * 2.0;
+            let titlebar_rect =
+              Rect::from_min_size(outer_rect.min, vec2(outer_rect.width(), titlebar_height));
+            let titlebar = Shape::Rect(RectShape {
+              rect: titlebar_rect,
+              rounding: Rounding {
+                nw: rounding_radius,
+                ne: rounding_radius,
+                sw: 0.0,
+                se: 0.0,
+              },
+              fill: background_color.lighten(0.8),
+              stroke: Stroke::NONE,
+            });
+
+            let body_rect = Rect::from_min_size(
+              outer_rect.min + vec2(0.0, titlebar_height),
+              vec2(outer_rect.width(), outer_rect.height() - titlebar_height),
+            );
+            let body = Shape::Rect(RectShape {
+              rect: body_rect,
+              rounding: Rounding {
+                nw: 0.0,
+                ne: 0.0,
+                sw: rounding_radius,
+                se: rounding_radius,
+              },
+              fill: background_color,
+              stroke: Stroke::NONE,
+            });
+
+            Shape::Vec(vec![titlebar, body])
+          };
+
+          ui.painter().set(background_shape, shape);
+        });
+      }
+
+      // Always passthrough the input
+      Ok(*input)
+    } else {
+      Err("No UI parent")
+    }
+  }
+}
+
+impl<'a> WireViewer<'a> {
+  fn compute_data(&mut self, _ctx: &Context) -> Result<(), &str> {
+    let wire: WireRef = self.wire.get().try_into()?;
+    let info = wire.get_wire_info();
+
+    let shards = info.shards;
+    let shards: Vec<ShardInstance> =
+      unsafe { core::slice::from_raw_parts(shards.elements, shards.len as usize) }
+        .iter()
+        .map(|ptr| (*ptr).into())
+        .collect();
+
+    for s in shards.into_iter() {
+      let data: ShardData = s.into();
+      let node_id = self.graph.add_node(data.name.to_string(), data);
+      self.node_order.push(node_id);
+    }
+
+    Ok(())
+  }
+}

--- a/rust/src/shards/gui/mod.rs
+++ b/rust/src/shards/gui/mod.rs
@@ -106,6 +106,7 @@ struct EguiContext {
 
 mod containers;
 mod context;
+mod editor;
 mod layouts;
 mod menus;
 mod misc;
@@ -224,6 +225,7 @@ impl egui::TextBuffer for &mut Var {
 pub fn registerShards() {
   containers::registerShards();
   registerShard::<EguiContext>();
+  editor::registerShards();
   layouts::registerShards();
   menus::registerShards();
   misc::registerShards();

--- a/rust/src/shards/gui/widgets/color_input.rs
+++ b/rust/src/shards/gui/widgets/color_input.rs
@@ -184,27 +184,19 @@ impl Shard for ColorInput {
 
   fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Var, &str> {
     if let Some(ui) = util::get_current_parent(self.parents.get())? {
-      let color: shardsc::SHColor = if self.variable.is_variable() {
-        unsafe { self.variable.get().payload.__bindgen_anon_1.colorValue }
+      let color = if self.variable.is_variable() {
+        unsafe { &mut self.variable.get_mut().payload.__bindgen_anon_1.colorValue }
       } else {
-        self.tmp
+        &mut self.tmp
       };
       let mut srgba = [color.r, color.g, color.b, color.a];
       ui.color_edit_button_srgba_unmultiplied(&mut srgba);
+      color.r = srgba[0];
+      color.g = srgba[1];
+      color.b = srgba[2];
+      color.a = srgba[3];
 
-      let color = shardsc::SHColor {
-        r: srgba[0],
-        g: srgba[1],
-        b: srgba[2],
-        a: srgba[3],
-      };
-      if self.variable.is_variable() {
-        self.variable.get_mut().payload.__bindgen_anon_1.colorValue = color;
-      } else {
-        self.tmp = color;
-      }
-
-      Ok(color.into())
+      Ok((*color).into())
     } else {
       Err("No UI parent")
     }

--- a/rust/src/shards/mod.rs
+++ b/rust/src/shards/mod.rs
@@ -28,6 +28,8 @@ pub mod curve25519;
 
 pub mod chachapoly;
 
+pub mod editor;
+
 pub mod gui;
 
 pub mod date;

--- a/src/tests/wire_viewer.edn
+++ b/src/tests/wire_viewer.edn
@@ -1,0 +1,75 @@
+(decompress-strings)
+
+(defwire my-wire
+  (color 255 128 0 128)
+  42 (Math.Multiply -1) >= .result
+  (Log :Level LogLevel.Debug)
+  ;
+  )
+
+(def timestep (/ 1.0 120.0))
+(defmesh root)
+(defloop main-wire
+  (Setup
+   (GFX.DrawQueue) >= .queue
+   (GFX.DrawQueue) >= .screen-ui-queue
+
+    ; Create render steps
+   (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
+   (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features
+   {:Features .features :Queue .queue :Sort SortMode.Queue} (GFX.DrawablePass) >> .render-steps
+   (GFX.UIPass .screen-ui-queue) >> .render-steps
+
+   ; Initial panel transforms
+   -15.0 (Math.DegreesToRadians) (Math.AxisAngleY) (Math.Rotation) >= .tmp
+   (Float3 1.0 0.0 0.0) (Math.Translation) (Math.MatMul .tmp) >= .panel-t-1
+
+   ; Initial view
+   {:Position (Float3 1 2 10) :Target (Float3 0 0 0)} (Math.LookAt) >= .view-transform
+   (GFX.View :View .view-transform) >= .view)
+
+  (GFX.MainWindow
+   :Title "Shard Editor (alpha)"
+   :Width 1600 :Height 900
+   :Contents
+   (->
+    ; Update view transform
+    .view-transform (FreeCamera :FlySpeed 10.0) > .view-transform
+
+    .queue (GFX.ClearQueue)
+    (Spatial.UI
+     :Queue .queue :View .view :Scale 100.0
+     :Contents
+     (->
+      (Spatial.Panel
+       :Transform .panel-t-1 :Size (Float2 360 240)
+       :Contents
+       (->
+        (UI.CentralPanel
+         :Contents
+         (->
+          (UI.ScrollArea
+           :Contents
+           (->
+            (WireViewer my-wire)))
+          (UI.Separator)))))
+      ;
+      ))
+
+    .screen-ui-queue (GFX.ClearQueue)
+    (UI
+     .screen-ui-queue
+     (->
+      (UI.LeftPanel
+       :Contents
+       (->
+        (UI.ScrollArea
+         :Contents
+         (->
+          (WireViewer my-wire)
+          (UI.Separator)))))))
+
+    (GFX.Render :Steps .render-steps :View .view))))
+
+(schedule root main-wire)
+(if (run root timestep) nil (throw "Root tick failed"))


### PR DESCRIPTION
Replaces #544.
Removed code around drag&drop, selection, etc.
Simplified UI renderers.

Not all shards are supported. Work is still needed for
- [ ] shards that contain other shards (e.g. `Repeat`)
- [ ] creating/selecting context variables by name

Purpose of this PR is to validate the overall design of the editor as this stage.

Preview:
> src/tests/wire_viewer.edn
```clj
(defwire my-wire
  (color 255 128 0 128)
  42 (Math.Multiply -1) >= .result
  (Log :Level LogLevel.Debug))
```
![image](https://user-images.githubusercontent.com/3006525/218803280-0aadbb63-1b36-4e7f-abc5-7ed90d448389.png)
