### PR TITLE
Allow custom logging pattern

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -42,12 +42,12 @@ jobs:
           for i in $(find shards -name '*.edn' \( ! -path '*UI*' ! -path '*GFX*' \));
           do
             echo "Running sample $i";
-            ./shards.exe run-sample.edn --file "$i" > >(tee "$i.log");
+            LOG_shards_FORMAT="[%l] %v" ./shards.exe run-sample.edn --file "$i" > >(tee "$i.log");
           done
           for i in $(find shards -name '*.edn' \( -path '*UI*' -or -path '*GFX*' \));
           do
             echo "Running sample $i";
-            ./shards.exe run-sample.edn --looped true --file "$i" > >(tee "$i.log");
+            LOG_shards_FORMAT="[%l] %v" ./shards.exe run-sample.edn --looped true --file "$i" > >(tee "$i.log");
           done
       - name: Upload samples logs
         uses: actions/upload-artifact@v3

--- a/src/log/log.cpp
+++ b/src/log/log.cpp
@@ -14,6 +14,7 @@
 namespace shards::logging {
 void init(Logger logger) {
   initLogLevel(logger);
+  initLogFormat(logger);
   initSinks(logger);
 }
 
@@ -24,6 +25,13 @@ void initLogLevel(Logger logger) {
     if (enumVal.has_value()) {
       logger->set_level(enumVal.value());
     }
+  }
+}
+
+void initLogFormat(Logger logger) {
+  std::string varName = fmt::format("LOG_{}_FORMAT", logger->name());
+  if (const char *val = SDL_getenv(varName.c_str())) {
+    logger->set_pattern(val);
   }
 }
 
@@ -78,6 +86,8 @@ static void setupDefaultLogger() {
 
   // Init log level from environment variable
   initLogLevel(logger);
+  // Init log format from environment variable
+  initLogFormat(logger);
 
   // Redirect all existing loggers to the default sink
   redirectAll(logger->sinks());

--- a/src/log/log.hpp
+++ b/src/log/log.hpp
@@ -14,6 +14,8 @@ void init(Logger logger);
 void initSinks(Logger logger);
 // Sets the log level for this logger based on the LOG_<name> environment variable if it is set
 void initLogLevel(Logger logger);
+// Sets the log format for this logger based on the LOG_<name>_FORMAT environment variable if it is set
+void initLogFormat(Logger logger);
 void redirectAll(const std::vector<spdlog::sink_ptr> &sinks);
 
 // Setup the default logger if it's not setup already


### PR DESCRIPTION
Would help simplify the logs, for instance when running the documentation sample.

**before**
```
./build/Release/shards docs/samples/run-sample.edn --file shards/Assert/is/2.edn
```
```
[error] [2023-02-14 20:31:56.037] [T-23040] [assert.cpp::66] Failed assertion Is, input: 7 expected: 8
[error] [2023-02-14 20:31:56.038] [T-23040] [runtime.cpp::715] Shard activation error, failed shard: Assert.Is, error: Assert failed - Is
[warning] [2023-02-14 20:31:56.039] [T-23040] [flow.hpp::451] Maybe shard Ignored an error: Assert failed - Is
```

**after**
```
LOG_shards_FORMAT=%v ./build/Release/shards docs/samples/run-sample.edn --file shards/Assert/is/2.edn
```
```
Failed assertion Is, input: 7 expected: 8
Shard activation error, failed shard: Assert.Is, error: Assert failed - Is
Maybe shard Ignored an error: Assert failed - Is
```

**or**
```
LOG_shards_FORMAT="%^[%l]%$ %v" ./build/Release/shards docs/samples/run-sample.edn --file shards/Assert/is/2.edn
```
```
[error] Failed assertion Is, input: 7 expected: 8
[error] Shard activation error, failed shard: Assert.Is, error: Assert failed - Is
[warning] Maybe shard Ignored an error: Assert failed - Is
```
*note visible, put the log colors are also preserved thanks to `%^%$` pattern.*