### PR TITLE
Remove Drawable input tables

### DIFF
--- a/docs/samples/shards/GFX/Render/1.edn
+++ b/docs/samples/shards/GFX/Render/1.edn
@@ -37,10 +37,11 @@
 
     ; Rotate the cube's transform
     .time (Math.Add timestep) > .time
-    (spin-transform .time (Float3 0.0 0 0)) > .transform
+    (spin-transform .time (Float3 0.0 0 0))
 
     ; Update and retrieve the drawable
-    (GFX.Drawable :Transform .transform :Mesh .mesh :Params {:baseColor (Float4 0 1 0 1)}) >= .drawable
+    ; Note that the transform is the input 
+    (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 0 1 0 1)}) >= .drawable
     
     ; Add drawable to the queue
     .drawable (GFX.Draw .queue)

--- a/docs/samples/shards/GFX/Render/1.edn
+++ b/docs/samples/shards/GFX/Render/1.edn
@@ -14,11 +14,11 @@
      ; Keep track of the time variable
      0.0 >= .time 
      
-     ; Use the built-in cube mesh and setup a drawable using the mesh
+     ; Load the built-in cube mesh
      (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
+
+     ; Declare transform variable
      (Float3 0 0 0) (Math.Translation) >= .transform
-     ; NOTE: The transform is passed as a parameter so it will be dynamic
-     {:Mesh .mesh :Params {:baseColor (Float4 0 1 0 1)}} (GFX.Drawable :Transform .transform) >= .drawable
 
      ; The queue that will contain the draw commands (just the cube)
      (GFX.DrawQueue) >= .queue
@@ -35,11 +35,14 @@
     ; Clear the queue before rendering
     .queue (GFX.ClearQueue)
 
-    ; Rotate the cube
+    ; Rotate the cube's transform
     .time (Math.Add timestep) > .time
     (spin-transform .time (Float3 0.0 0 0)) > .transform
 
-    ; Add draw command to the queue
+    ; Update and retrieve the drawable
+    (GFX.Drawable :Transform .transform :Mesh .mesh :Params {:baseColor (Float4 0 1 0 1)}) >= .drawable
+    
+    ; Add drawable to the queue
     .drawable (GFX.Draw .queue)
     
     ; Render everyghing

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -1727,7 +1727,8 @@ bool validateSetParam(Shard *shard, int index, const SHVar &value, SHValidationC
     }
   }
 
-  std::string err(fmt::format("Parameter {} not accepting this kind of variable: {}", param.name, varType));
+  std::string err(fmt::format("Parameter {} not accepting this kind of variable: {} (valid types: {})", param.name, varType,
+                              param.valueTypes));
   callback(shard, err.c_str(), false, userData);
 
   return false;

--- a/src/core/shards/linalg.cpp
+++ b/src/core/shards/linalg.cpp
@@ -372,6 +372,7 @@ void registerShards() {
   REGISTER_SHARD("Math.AxisAngleZ", AxisAngleZ);
   REGISTER_SHARD("Math.DegreesToRadians", Deg2Rad);
   REGISTER_SHARD("Math.RadiansToDegrees", Rad2Deg);
+  REGISTER_SHARD("Math.MatIdentity", MatIdentity);
 }
 
 }; // namespace LinAlg

--- a/src/core/shards/linalg.hpp
+++ b/src/core/shards/linalg.hpp
@@ -1,10 +1,17 @@
 #pragma once
 
+#include "common_types.hpp"
+#include "foundation.hpp"
+#include "linalg.h"
+#include "shards.h"
 #include "shared.hpp"
 #include "math.hpp"
+#include "core.hpp"
+#include "params.hpp"
 #include <linalg_shim.hpp>
 #include <math.h>
 #include <cmath>
+#include <stdexcept>
 
 namespace shards {
 namespace Math {
@@ -434,6 +441,39 @@ struct Rad2Deg {
   static SHTypesInfo outputTypes() { return CoreInfo::FloatType; }
 
   SHVar activate(SHContext *context, const SHVar &input) { return Var(input.payload.floatValue * (180.0 / PI)); }
+};
+
+struct MatIdentity {
+  PARAM_VAR(_type, "Type", "The matrix row type of the corresponding matrix", {CoreInfo2::TypeEnumInfo::Type});
+  PARAM_IMPL(MatIdentity, PARAM_IMPL_FOR(_type));
+
+  static SHOptionalString help() { return SHCCSTR("Gives identity values for square matrix types"); }
+  static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHTypesInfo outputTypes() {
+    static Types types{CoreInfo::Float4x4Type};
+    return types;
+  }
+
+  static inline Mat4 Float4x4Identity = linalg::identity;
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    switch (BasicTypes(_type.payload.enumValue)) {
+    case shards::BasicTypes::Float4:
+      return CoreInfo::Float4x4Type;
+    default:
+      throw std::runtime_error("Unsuported matrix row type");
+    }
+    return SHTypeInfo{};
+  }
+
+  SHVar activate(SHContext *context, const SHVar &input) {
+    switch (BasicTypes(_type.payload.enumValue)) {
+    case shards::BasicTypes::Float4:
+      return Float4x4Identity;
+    default:
+      return SHVar{};
+    }
+  }
 };
 
 } // namespace LinAlg

--- a/src/core/shards/linalg.hpp
+++ b/src/core/shards/linalg.hpp
@@ -456,6 +456,8 @@ struct MatIdentity {
 
   static inline Mat4 Float4x4Identity = linalg::identity;
 
+  MatIdentity() { _type = Var::Enum(BasicTypes::Float4, CoreInfo2::TypeEnumInfo::Type); }
+
   SHTypeInfo compose(const SHInstanceData &data) {
     switch (BasicTypes(_type.payload.enumValue)) {
     case shards::BasicTypes::Float4:

--- a/src/extra/gfx/drawable.cpp
+++ b/src/extra/gfx/drawable.cpp
@@ -6,6 +6,7 @@
 #include "gfx/drawables/mesh_drawable.hpp"
 #include "gfx/fwd.hpp"
 #include "runtime.hpp"
+#include "shards.h"
 #include "shards.hpp"
 #include "shards_utils.hpp"
 #include <gfx/drawable.hpp>
@@ -24,17 +25,17 @@ struct DrawableShard {
   static inline Type MeshVarType = Type::VariableOf(Types::Mesh);
   static inline Type TransformVarType = Type::VariableOf(CoreInfo::Float4x4Type);
 
-  PARAM_EXT(ParamVar, _transform, Types::TransformParameterInfo);
   PARAM_PARAMVAR(_mesh, "Mesh", "The mesh to use for this drawable.", {MeshVarType});
   PARAM_EXT(ParamVar, _material, Types::MaterialParameterInfo);
   PARAM_EXT(ParamVar, _params, Types::ParamsParameterInfo);
   PARAM_EXT(ParamVar, _features, Types::FeaturesParameterInfo);
 
-  PARAM_IMPL(DrawableShard, PARAM_IMPL_FOR(_transform), PARAM_IMPL_FOR(_mesh), PARAM_IMPL_FOR(_material), PARAM_IMPL_FOR(_params),
-             PARAM_IMPL_FOR(_features));
+  PARAM_IMPL(DrawableShard, PARAM_IMPL_FOR(_mesh), PARAM_IMPL_FOR(_material), PARAM_IMPL_FOR(_params), PARAM_IMPL_FOR(_features));
 
   static SHOptionalString help() { return SHCCSTR(R"(Drawable help text)"); }
-  static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return SHCCSTR("The drawable's transform"); }
+
+  static SHTypesInfo inputTypes() { return CoreInfo::Float4x4Type; }
   static SHTypesInfo outputTypes() { return Types::Drawable; }
 
   SHDrawable *_drawable{};
@@ -72,11 +73,8 @@ struct DrawableShard {
   SHVar activate(SHContext *shContext, const SHVar &input) {
     auto &meshDrawable = getMeshDrawable();
 
+    meshDrawable->transform = toFloat4x4(input);
     meshDrawable->mesh = *varAsObjectChecked<MeshPtr>(_mesh.get(), Types::Mesh);
-
-    if (!_transform.isNone()) {
-      meshDrawable->transform = toFloat4x4(_transform.get());
-    }
 
     if (!_material.isNone()) {
       meshDrawable->material = varAsObjectChecked<SHMaterial>(_material.get(), Types::Material)->material;

--- a/src/extra/gfx/gltf.cpp
+++ b/src/extra/gfx/gltf.cpp
@@ -26,10 +26,9 @@ struct GLTFShard {
   static inline Type ByteInputType = CoreInfo::BytesType;
   static inline Type TransformVarType = Type::VariableOf(CoreInfo::Float4x4Type);
 
-  static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHTypesInfo inputTypes() { return CoreInfo::Float4x4Type; }
   static SHTypesInfo outputTypes() { return Types::Drawable; }
 
-  PARAM_PARAMVAR(_transform, "Transform", "The transform variable to use", {CoreInfo::NoneType, TransformVarType});
   PARAM_PARAMVAR(_path, "Path", "The path to load the model from",
                  {CoreInfo::NoneType, CoreInfo::StringType, CoreInfo::StringVarType});
   PARAM_PARAMVAR(_bytes, "Bytes", "The bytes to load the model from",
@@ -38,8 +37,8 @@ struct GLTFShard {
                  {CoreInfo::NoneType, Type::VariableOf(Types::Drawable)});
   PARAM_EXT(ParamVar, _params, Types::ParamsParameterInfo);
   PARAM_EXT(ParamVar, _features, Types::FeaturesParameterInfo);
-  PARAM_IMPL(GLTFShard, PARAM_IMPL_FOR(_transform), PARAM_IMPL_FOR(_path), PARAM_IMPL_FOR(_bytes), PARAM_IMPL_FOR(_copy),
-             PARAM_IMPL_FOR(_params), PARAM_IMPL_FOR(_features));
+  PARAM_IMPL(GLTFShard, PARAM_IMPL_FOR(_path), PARAM_IMPL_FOR(_bytes), PARAM_IMPL_FOR(_copy), PARAM_IMPL_FOR(_params),
+             PARAM_IMPL_FOR(_features));
 
   enum LoadMode {
     Invalid,
@@ -152,9 +151,7 @@ struct GLTFShard {
       }
     }
 
-    if (!_transform.isNone()) {
-      drawable->transform = toFloat4x4(_transform.get());
-    }
+    drawable->transform = toFloat4x4(input);
 
     // Only apply recursive parameters once
     if (!_dynamicsApplied) {

--- a/src/extra/gfx/shards_utils.hpp
+++ b/src/extra/gfx/shards_utils.hpp
@@ -2,6 +2,7 @@
 #define AD2CA4AE_4D00_49A0_8DD6_323B82813690
 
 #include <foundation.hpp>
+#include <utility.hpp>
 #include <gfx/error_utils.hpp>
 #include <gfx/linalg.hpp>
 #include <gfx/fwd.hpp>
@@ -51,33 +52,6 @@ inline void applyFeatures(SHContext *context, std::vector<FeaturePtr> &outFeatur
     auto &elem = input.payload.seqValue.elements[i];
     FeaturePtr *ptr = varAsObjectChecked<FeaturePtr>(elem, Types::Feature);
     outFeatures.push_back(*ptr);
-  }
-}
-
-// Collects all ContextVar references
-inline void requireReferences(const SHExposedTypesInfo &exposed, const SHVar &var, shards::ExposedInfo &out) {
-  using namespace std::literals;
-  switch (var.valueType) {
-  case SHType::ContextVar: {
-    auto sv = std::string_view(var.payload.stringValue);
-    for (const auto &entry : exposed) {
-      if (sv == entry.name) {
-        out.push_back(SHExposedTypeInfo{
-            .name = var.payload.stringValue,
-            .exposedType = entry.exposedType,
-        });
-        break;
-      }
-    }
-  } break;
-  case SHType::Seq:
-    shards::ForEach(var.payload.seqValue, [&](const SHVar &v) { requireReferences(exposed, v, out); });
-    break;
-  case SHType::Table:
-    shards::ForEach(var.payload.tableValue, [&](const char *key, const SHVar &v) { requireReferences(exposed, v, out); });
-    break;
-  default:
-    break;
   }
 }
 } // namespace gfx

--- a/src/extra/gfx/view.cpp
+++ b/src/extra/gfx/view.cpp
@@ -115,7 +115,6 @@ struct RenderIntoShard {
   RequiredGraphicsRendererContext _graphicsRendererContext;
   Inputs::OptionalInputContext _inputContext;
   RenderTargetPtr _renderTarget;
-  ExposedInfo _requiredVariables;
 
   void warmup(SHContext *context) {
     _graphicsRendererContext.warmup(context);
@@ -131,13 +130,11 @@ struct RenderIntoShard {
     _renderTarget.reset();
   }
 
-  SHExposedTypesInfo requiredVariables() { return (SHExposedTypesInfo)_requiredVariables; }
-
+  PARAM_REQUIRED_VARIABLES();
   SHTypeInfo compose(SHInstanceData &data) {
-    _requiredVariables.clear();
+    PARAM_COMPOSE_REQUIRED_VARIABLES(data);
+    
     _requiredVariables.push_back(decltype(_graphicsRendererContext)::getExposedTypeInfo());
-
-    requireReferences(data.shared, _textures, _requiredVariables);
 
     return _contents.compose(data).outputType;
   }

--- a/src/extra/gizmos/highlight.cpp
+++ b/src/extra/gizmos/highlight.cpp
@@ -7,9 +7,9 @@ using namespace gfx;
 
 struct HighlightShard : public Base {
   // TODO: Merge with DrawShard type
-  static inline shards::Types SingleDrawableTypes = shards::Types{gfx::Types::Drawable, gfx::Types::TreeDrawable};
+  static inline shards::Types SingleDrawableTypes = shards::Types{gfx::Types::Drawable};
   static inline Type DrawableSeqType = Type::SeqOf(SingleDrawableTypes);
-  static inline shards::Types DrawableTypes{gfx::Types::Drawable, gfx::Types::TreeDrawable, DrawableSeqType};
+  static inline shards::Types DrawableTypes{gfx::Types::Drawable, DrawableSeqType};
 
   static SHTypesInfo inputTypes() { return DrawableTypes; }
   static SHTypesInfo outputTypes() { return CoreInfo::NoneType; }
@@ -25,14 +25,10 @@ struct HighlightShard : public Base {
   }
 
   SHVar activateSingle(SHContext *shContext, const SHVar &input) {
-    SHTypeInfo inputType = shards::Type::Object(input.payload.objectVendorId, input.payload.objectTypeId);
-    if (gfx::Types::Drawable == inputType) {
-      SHDrawable *dPtr = static_cast<SHDrawable *>(input.payload.objectValue);
-      _gizmoContext->wireframeRenderer.overlayWireframe(*_gizmoContext->queue.get(), dPtr->drawable);
-    } else if (gfx::Types::TreeDrawable == inputType) {
-      SHTreeDrawable *dhPtr = static_cast<SHTreeDrawable *>(input.payload.objectValue);
-      _gizmoContext->wireframeRenderer.overlayWireframe(*_gizmoContext->queue.get(), *dhPtr->drawable.get());
-    }
+    SHDrawable *drawable = static_cast<SHDrawable *>(input.payload.objectValue);
+    std::visit(
+        [&](auto &drawable) { _gizmoContext->wireframeRenderer.overlayWireframe(*_gizmoContext->queue.get(), *drawable.get()); },
+        drawable->drawable);
 
     return SHVar{};
   }

--- a/src/gfx/features/base_color.hpp
+++ b/src/gfx/features/base_color.hpp
@@ -41,7 +41,7 @@ struct BaseColor {
 
     FeaturePtr feature = std::make_shared<Feature>();
     feature->shaderParams.emplace_back("baseColor", float4(1, 1, 1, 1));
-    feature->textureParams.emplace_back("baseColor");
+    feature->textureParams.emplace_back("baseColorTexture");
 
     feature->state.set_blend(BlendState{
         .color = BlendComponent::Alpha,
@@ -92,8 +92,8 @@ struct BaseColor {
     // Apply base color texture
     auto &sampleTexture = feature->shaderEntryPoints.emplace_back(
         "textureColor", ProgrammableGraphicsStage::Fragment,
-        WithTexture("baseColor", true,
-                    WriteGlobal("color", colorFieldType, ReadGlobal("color"), "*", SampleTexture("baseColor"))));
+        WithTexture("baseColorTexture", true,
+                    WriteGlobal("color", colorFieldType, ReadGlobal("color"), "*", SampleTexture("baseColorTexture"))));
     sampleTexture.dependencies.emplace_back("readColor");
     sampleTexture.dependencies.emplace_back("writeColor", DependencyType::Before);
 

--- a/src/gfx/gltf/gltf.cpp
+++ b/src/gfx/gltf/gltf.cpp
@@ -402,8 +402,8 @@ struct Loader {
       convertOptionalFloat4Param("baseColor", gltfMaterial.pbrMetallicRoughness.baseColorFactor, float4(1, 1, 1, 1));
       convertOptionalFloatParam("roughness", gltfMaterial.pbrMetallicRoughness.roughnessFactor, 1.0f);
       convertOptionalFloatParam("metallic", gltfMaterial.pbrMetallicRoughness.metallicFactor, 0.0f);
-      convertTextureParam("baseColor", gltfMaterial.pbrMetallicRoughness.baseColorTexture);
-      convertTextureParam("metallicRougness", gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture);
+      convertTextureParam("baseColorTexture", gltfMaterial.pbrMetallicRoughness.baseColorTexture);
+      convertTextureParam("metallicRougnessTexture", gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture);
     }
   }
 

--- a/src/gfx/tests/test_general.cpp
+++ b/src/gfx/tests/test_general.cpp
@@ -402,12 +402,12 @@ TEST_CASE("Textures", "[General]") {
 
   transform = linalg::translation_matrix(float3(-.5f, 0.0f, 0.0f));
   drawable = std::make_shared<MeshDrawable>(planeMesh, transform);
-  drawable->parameters.set("baseColor", textureA);
+  drawable->parameters.set("baseColorTexture", textureA);
   queue->add(drawable);
 
   transform = linalg::translation_matrix(float3(.5f, 0.0f, 0.0f));
   drawable = std::make_shared<MeshDrawable>(planeMesh, transform);
-  drawable->parameters.set("baseColor", textureB);
+  drawable->parameters.set("baseColorTexture", textureB);
   queue->add(drawable);
 
   FeaturePtr blendFeature = std::make_shared<Feature>();

--- a/src/gfx/tests/test_rendergraph.cpp
+++ b/src/gfx/tests/test_rendergraph.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Viewport render target", "[RenderGraph]") {
                   }(),
               },
           .parameters{
-              .textures = {{"baseColor", TextureParameter(rt->getAttachment("color"))}},
+              .textures = {{"baseColorTexture", TextureParameter(rt->getAttachment("color"))}},
           },
           .output = makeRenderStepOutput(steps::getDefaultColorOutput()),
           .overlay = true,

--- a/src/gfx/tests/test_shader.cpp
+++ b/src/gfx/tests/test_shader.cpp
@@ -224,14 +224,14 @@ TEST_CASE("Shader textures", "[Shader]") {
   auto positionFieldType = NumFieldType(ShaderFieldBaseType::Float32, 4);
 
   TextureBindingLayoutBuilder textureLayoutBuilder;
-  textureLayoutBuilder.addOrUpdateSlot("baseColor", TextureDimension::D2, 0);
+  textureLayoutBuilder.addOrUpdateSlot("baseColorTexture", TextureDimension::D2, 0);
 
   generator.textureBindingLayout = textureLayoutBuilder.finalize(0);
   generator.outputFields.emplace_back("color", colorFieldType);
 
   std::vector<EntryPoint> entryPoints;
   entryPoints.emplace_back("color", ProgrammableGraphicsStage::Fragment,
-                           blocks::WriteOutput("color", colorFieldType, blocks::SampleTexture("baseColor")));
+                           blocks::WriteOutput("color", colorFieldType, blocks::SampleTexture("baseColorTexture")));
   entryPoints.emplace_back("interpolate", ProgrammableGraphicsStage::Vertex, blocks::DefaultInterpolation());
 
   GeneratorOutput output = generator.build(entryPoints);

--- a/src/tests/gfx-cube.edn
+++ b/src/tests/gfx-cube.edn
@@ -30,7 +30,6 @@
    0.0 >= .time
    cube (GFX.Mesh :Layout cube-layout :WindingOrder WindingOrder.CW) >= .mesh
    (Float3 0 0 0) (Math.Translation) >= .transform
-   {:Transform .transform :Mesh .mesh} (GFX.Drawable :Transform .transform) >= .drawable
 
     ; Create render steps
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
@@ -49,7 +48,7 @@
     .time (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
     .time (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
     .rotX (Math.MatMul .rotY) (Math.MatMul .rotZ) > .transform
-    .drawable (GFX.Draw)
+    (GFX.Drawable :Transform .transform :Mesh .mesh) (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule Root test-wire)

--- a/src/tests/gfx-cube.edn
+++ b/src/tests/gfx-cube.edn
@@ -48,7 +48,7 @@
     .time (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
     .time (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
     .rotX (Math.MatMul .rotY) (Math.MatMul .rotZ) > .transform
-    (GFX.Drawable :Transform .transform :Mesh .mesh) (GFX.Draw)
+    .transform (GFX.Drawable :Mesh .mesh) (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule Root test-wire)

--- a/src/tests/gfx-effect.edn
+++ b/src/tests/gfx-effect.edn
@@ -57,7 +57,7 @@
   .time (Math.Add timestep) > .time
   (spin-transform .time (Float3 0.0 0 0)) > .transform-0
 
-  (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 1 1 1)}) (GFX.Draw)
+  .transform-0 (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 1 1 1)}) (GFX.Draw)
   (GFX.Render :Steps .render-steps1 :View .view))
 
 (defmesh root)

--- a/src/tests/gfx-effect.edn
+++ b/src/tests/gfx-effect.edn
@@ -13,7 +13,6 @@
 
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
    (Float3 0 0 0) (Math.Translation) >= .transform-0
-   {:Mesh .mesh :Params {:baseColor (Float4 1 1 1 1)}} (GFX.Drawable :Transform .transform-0) >> .drawables
 
    ; The first pass that just renders the spinning cube
    (GFX.BuiltinFeature BuiltinFeatureId.Transform) >> .features
@@ -58,7 +57,7 @@
   .time (Math.Add timestep) > .time
   (spin-transform .time (Float3 0.0 0 0)) > .transform-0
 
-  .drawables (GFX.Draw)
+  (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 1 1 1)}) (GFX.Draw)
   (GFX.Render :Steps .render-steps1 :View .view))
 
 (defmesh root)

--- a/src/tests/gfx-feature.edn
+++ b/src/tests/gfx-feature.edn
@@ -61,11 +61,12 @@
     .time (Math.Add timestep) > .time
     .time (Broadcast "time")
 
-    (spin-transform .time (Float3 -0.6 0 0)) > .transform-0
-    (spin-transform (-> .time (Math.Multiply 0.5)) (Float3 0.6 0 0)) > .transform-1
-    (GFX.Drawable :Mesh .mesh :Transform .transform-0) >> .drawables
-    (GFX.Drawable :Mesh .mesh :Transform .transform-1) >> .drawables
-    .drawables (GFX.Draw)
+    (spin-transform .time (Float3 -0.6 0 0))
+    (GFX.Drawable :Mesh .mesh) (GFX.Draw)
+
+    (spin-transform (-> .time (Math.Multiply 0.5)) (Float3 0.6 0 0))
+    (GFX.Drawable :Mesh .mesh) (GFX.Draw)
+
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule root test-wire)

--- a/src/tests/gfx-feature.edn
+++ b/src/tests/gfx-feature.edn
@@ -17,8 +17,6 @@
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
    (Float3 -1 0 0) (Math.Translation) >= .transform-0
    (Float3 1 0 0) (Math.Translation) >= .transform-1
-   {:Mesh .mesh} (GFX.Drawable :Transform .transform-0) >> .drawables
-   {:Mesh .mesh} (GFX.Drawable :Transform .transform-1) >> .drawables
    (Float3 0 0 -1) (Math.Normalize) >= .light-direction
 
    0.0 >= .time
@@ -65,6 +63,8 @@
 
     (spin-transform .time (Float3 -0.6 0 0)) > .transform-0
     (spin-transform (-> .time (Math.Multiply 0.5)) (Float3 0.6 0 0)) > .transform-1
+    (GFX.Drawable :Mesh .mesh :Transform .transform-0) >> .drawables
+    (GFX.Drawable :Mesh .mesh :Transform .transform-1) >> .drawables
     .drawables (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 

--- a/src/tests/gfx-generated.edn
+++ b/src/tests/gfx-generated.edn
@@ -80,10 +80,10 @@
    .transform (Math.MatMul .tmp-rot) (Math.MatMul .tmp-scale) >= .cube-transform
 
    (GFX.BuiltinMesh :Type BuiltinMeshType.Plane) >= .plane-mesh
-   {:Mesh .plane-mesh :Params {:baseColor (Float4 0.4 0.4 0.94 1.0)}} (GFX.Drawable :Transform .plane-transform) >> .drawables
-
+   .plane-transform (GFX.Drawable :Mesh .plane-mesh :Params {:baseColor (Float4 0.4 0.4 0.94 1.0)}) >> .drawables
+   
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .cube-mesh
-   {:Mesh .cube-mesh :Params {:baseColor (Float4 0.12 0.7 0.2 1.0)}} (GFX.Drawable :Transform .cube-transform) >> .drawables
+   .cube-transform (GFX.Drawable :Mesh .cube-mesh :Params {:baseColor (Float4 0.12 0.7 0.2 1.0)}) >> .drawables
 
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
    (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features

--- a/src/tests/gfx-gizmos.edn
+++ b/src/tests/gfx-gizmos.edn
@@ -16,7 +16,6 @@
    0.0 >= .time
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
    (Float3 0 0 0) (Math.Translation) >= .transform-0
-   {:Mesh .mesh :Params {:baseColor (Float4 1 0 0 1)}} (GFX.Drawable :Transform .transform-0) >> .drawable-0
 
    (GFX.DrawQueue) >= .editor-queue
    (GFX.DrawQueue) >= .editor-queue-no-depth
@@ -42,7 +41,8 @@
    (->
     .time (Math.Add timestep) > .time
 
-    .drawable-0 (GFX.Draw)
+    (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 0 1)}) >= .drawable-0
+    (GFX.Draw)
 
     ; Draw helpers (using scene depth)
     .editor-queue (GFX.ClearQueue)

--- a/src/tests/gfx-gizmos.edn
+++ b/src/tests/gfx-gizmos.edn
@@ -41,7 +41,7 @@
    (->
     .time (Math.Add timestep) > .time
 
-    (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 0 1)}) >= .drawable-0
+    .transform-0 (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0 0 1)}) >= .drawable-0
     (GFX.Draw)
 
     ; Draw helpers (using scene depth)

--- a/src/tests/gfx-gltf.edn
+++ b/src/tests/gfx-gltf.edn
@@ -34,30 +34,30 @@
     .drawables (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 
-(defloop test-static
+(defloop test-path-static
   (Setup
    (default-setup)
-   {} (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables)
+   (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables)
 
   (default-window))
-(schedule root test-static)
+(schedule root test-path-static)
 (if (run root timestep 100) nil (throw "Root tick failed"))
 
-(defloop test-file
+(defloop test-path-var
   (Setup
    (default-setup)
-   {:Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb"} >= .path
-   .path (GFX.glTF) >> .drawables)
+   "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb" >= .path-var
+   (GFX.glTF :Path .path-var) >> .drawables)
 
   (default-window))
-(schedule root test-file)
+(schedule root test-path-var)
 (if (run root timestep 100) nil (throw "Root tick failed"))
 
 (defloop test-binary
   (Setup
    (default-setup)
    "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb" (FS.Read :Bytes true) >= .bytes
-   {:Bytes .bytes} (GFX.glTF) >> .drawables)
+   (GFX.glTF :Bytes .bytes) >> .drawables)
 
   (default-window))
 (schedule root test-binary)
@@ -68,10 +68,7 @@
    (default-setup)
    (Float3 -0.05 0 0) (Math.Translation) >= .t1
    (get-xy-wave-transform 0.0 0.0) >= .t2
-   (Float3 0.05 0 0) (Math.Translation) >= .t3
-   {:Transform .t1} (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
-   {} (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb" :Transform .t2) >> .drawables
-   {:Transform .t3} (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables)
+   (Float3 0.05 0 0) (Math.Translation) >= .t3)
 
   (GFX.MainWindow
    :Title "SDL Window" :Width 1280 :Height 720 :Debug false
@@ -82,6 +79,9 @@
     (get-view-transform .time) > .view-transform
     (get-xy-wave-transform 0.0 .time) > .t2
 
+    (GFX.glTF :Transform .t1 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
+    (GFX.glTF :Transform .t2 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
+    (GFX.glTF :Transform .t3 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
     .drawables (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 (schedule root test-transforms)
@@ -92,9 +92,9 @@
    (default-setup)
    (Float3 -0.05 0 0) (Math.Translation) >= .t1
    (Float3 0.05 0 0) (Math.Translation) >= .t2
-   {:Transform .t1} (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >= .avocado-a
+   (GFX.glTF :Transform .t1 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >= .avocado-a
    .avocado-a >> .drawables
-   {:Transform .t2 :Copy .avocado-a} (GFX.glTF) >> .drawables)
+   (GFX.glTF :Transform .t2 :Copy .avocado-a) >> .drawables)
 
   (default-window))
 (schedule root test-copy)

--- a/src/tests/gfx-gltf.edn
+++ b/src/tests/gfx-gltf.edn
@@ -37,7 +37,7 @@
 (defloop test-path-static
   (Setup
    (default-setup)
-   (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables)
+   (Math.MatIdentity) (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables)
 
   (default-window))
 (schedule root test-path-static)
@@ -47,7 +47,7 @@
   (Setup
    (default-setup)
    "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb" >= .path-var
-   (GFX.glTF :Path .path-var) >> .drawables)
+   (Math.MatIdentity) (GFX.glTF :Path .path-var) >> .drawables)
 
   (default-window))
 (schedule root test-path-var)
@@ -57,7 +57,7 @@
   (Setup
    (default-setup)
    "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb" (FS.Read :Bytes true) >= .bytes
-   (GFX.glTF :Bytes .bytes) >> .drawables)
+   (Math.MatIdentity) (GFX.glTF :Bytes .bytes) >> .drawables)
 
   (default-window))
 (schedule root test-binary)
@@ -79,9 +79,9 @@
     (get-view-transform .time) > .view-transform
     (get-xy-wave-transform 0.0 .time) > .t2
 
-    (GFX.glTF :Transform .t1 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
-    (GFX.glTF :Transform .t2 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
-    (GFX.glTF :Transform .t3 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
+    .t1 (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
+    .t2 (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
+    .t3 (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >> .drawables
     .drawables (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 (schedule root test-transforms)
@@ -92,9 +92,9 @@
    (default-setup)
    (Float3 -0.05 0 0) (Math.Translation) >= .t1
    (Float3 0.05 0 0) (Math.Translation) >= .t2
-   (GFX.glTF :Transform .t1 :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >= .avocado-a
+   .t1 (GFX.glTF :Path "../../external/glTF-Sample-Models/2.0/Avocado/glTF-Binary/Avocado.glb") >= .avocado-a
    .avocado-a >> .drawables
-   (GFX.glTF :Transform .t2 :Copy .avocado-a) >> .drawables)
+   .t2 (GFX.glTF :Copy .avocado-a) >> .drawables)
 
   (default-window))
 (schedule root test-copy)

--- a/src/tests/gfx-highlight.edn
+++ b/src/tests/gfx-highlight.edn
@@ -34,15 +34,14 @@
    :Contents
    (->
     .time (Math.Add timestep) > .time
-    (spin-transform .time (Float3 0.0 0 0)) > .transform-0
-
-   (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}) >= .drawable-0
+    (spin-transform .time (Float3 0.0 0 0))
+    (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}) >= .drawable-0
     .drawable-0 (GFX.Draw)
 
     .editor-queue (GFX.ClearQueue)
     (Gizmos.Context :Queue .editor-queue :View .view
-                     :Content (->
-                               .drawable-0 (Gizmos.Highlight)))
+                    :Content (->
+                              .drawable-0 (Gizmos.Highlight)))
 
     (GFX.Render :Steps .render-steps :View .view))))
 

--- a/src/tests/gfx-highlight.edn
+++ b/src/tests/gfx-highlight.edn
@@ -16,7 +16,6 @@
    0.0 >= .time
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
    (Float3 0 0 0) (Math.Translation) >= .transform-0
-   {:Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}} (GFX.Drawable :Transform .transform-0) >> .drawable-0
 
    (GFX.DrawQueue) >= .editor-queue
 
@@ -37,6 +36,7 @@
     .time (Math.Add timestep) > .time
     (spin-transform .time (Float3 0.0 0 0)) > .transform-0
 
+   (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}) >= .drawable-0
     .drawable-0 (GFX.Draw)
 
     .editor-queue (GFX.ClearQueue)
@@ -47,4 +47,4 @@
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule root test-wire)
-(if (run root timestep 200) nil (throw "Root tick failed"))
+(if (run root timestep 100) nil (throw "Root tick failed"))

--- a/src/tests/gfx-materials.edn
+++ b/src/tests/gfx-materials.edn
@@ -23,54 +23,61 @@
     2 3 6
     6 3 7]})
 
+(defloop spawned-0
+  (GFX.Drawable :Transform .transform :Mesh .mesh :Params {:baseColor .color}) (GFX.Draw))
+(defwire spawn-dynamic-0
+  [{:Location (Float3 -3 0 -2) :Color (Float4 1 0 0 1)}
+   {:Location (Float3 0 0 -2) :Color (Float4 0 1 0 1)}]
+  (Map (->
+        (| (Take "Location") (Math.Translation) >= .transform)
+        (| (Take "Color") >= .color)
+        (Spawn spawned-0))))
+
+(defloop spawned-1
+  (GFX.Drawable :Transform .transform :Mesh .mesh :Material .magenta-material) (GFX.Draw))
+(defwire spawn-dynamic-1
+  [{:Location (Float3 -3 0 2)}
+   {:Location (Float3 0 0 2)}
+   {:Location (Float3 3 0 2)}]
+  (Map (->
+        (| (Take "Location") (Math.Translation) >= .transform)
+        (Spawn spawned-1))))
+
 (def timestep (/ 1.0 120.0))
 (defmesh Root)
 (defloop test-wire
-   (Setup
-    0.0 >= .time
-    cube (GFX.Mesh :Layout cube-layout :WindingOrder WindingOrder.CW) >= .mesh
+  (Setup
+   0.0 >= .time
+   cube (GFX.Mesh :Layout cube-layout :WindingOrder WindingOrder.CW) >= .mesh
 
-    [{:Location (Float3 -3 0 -2) :Color (Float4 1 0 0 1)}
-     {:Location (Float3 0 0 -2) :Color (Float4 0 1 0 1)}]
-    (Map (->
-          (| (Take "Location") (Math.Translation) >= .transform)
-          (| (Take "Color") >= .color)
-          {:Transform .transform :Mesh .mesh :Params {:baseColor .color}} (GFX.Drawable))) >= .drawables-0
+   ; Create render steps
+   (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
+   (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features
+   {:Features .features} (GFX.DrawablePass) >> .render-steps
+
+   ; Static material
+   (GFX.Material :Params {:baseColor (Float4 1 0 1 1)}) >= .magenta-material
+
+   ; Create view
+   {:Position (Float3 0 15 10) :Target (Float3 0 0 0)} (Math.LookAt) >= .view-transform
+   (GFX.View :View .view-transform) >= .view)
+  (GFX.MainWindow
+   :Title "SDL Window" :Width 1280 :Height 720 :Debug false
+   :Contents
+   (->
+    .time (Math.Add timestep) > .time
+    .time (Math.Multiply 0.9) (Math.Add 0.0) (Math.FMod 1.0) >> .c
+    .time (Math.Multiply 1.2) (Math.Add 0.3) (Math.FMod 1.0) >> .c
+    .time (Math.Multiply 1.4) (Math.Add 0.6) (Math.FMod 1.0) >> .c
+    1.0 >> .c
+    .c (ToFloat4) >= .color-var
 
     (Float3 3 0 -2) (Math.Translation) >= .transform
-    (Float4 0.2 0.4 1 1) >= .color-var
-    {:Transform .transform :Mesh .mesh} (GFX.Drawable :Params {:baseColor .color-var}) >> .drawables-0
+    (GFX.Drawable :Transform .transform :Mesh .mesh :Params {:baseColor .color-var}) (GFX.Draw)
 
-    {:Params {:baseColor (Float4 1 0 1 1)}} (GFX.Material) >= .magenta-material
-
-    [{:Location (Float3 -3 0 2)}
-     {:Location (Float3 0 0 2)}
-     {:Location (Float3 3 0 2)}]
-    (Map (->
-          (| (Take "Location") (Math.Translation) >= .transform)
-          {:Transform .transform :Mesh .mesh :Material .magenta-material} (GFX.Drawable))) >= .drawables-1
-
-    ; Create render steps
-    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
-    (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features
-    {:Features .features} (GFX.DrawablePass) >> .render-steps
-
-    ; Create view
-    {:Position (Float3 0 15 10) :Target (Float3 0 0 0)} (Math.LookAt) >= .view-transform
-    (GFX.View :View .view-transform) >= .view)
-   (GFX.MainWindow
-    :Title "SDL Window" :Width 1280 :Height 720 :Debug false
-    :Contents
-    (->
-     .time (Math.Add timestep) > .time
-     .time (Math.Multiply 0.9) (Math.Add 0.0) (Math.FMod 1.0) >> .c
-     .time (Math.Multiply 1.2) (Math.Add 0.3) (Math.FMod 1.0) >> .c
-     .time (Math.Multiply 1.4) (Math.Add 0.6) (Math.FMod 1.0) >> .c
-     1.0 >> .c
-     .c (ToFloat4) > .color-var
-     .drawables-0 (GFX.Draw)
-     .drawables-1 (GFX.Draw)
-     (GFX.Render :Steps .render-steps :View .view))))
+    (Branch [spawn-dynamic-0])
+    (Branch [spawn-dynamic-1])
+    (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule Root test-wire)
 (if (run Root timestep 100) nil (throw "Root tick failed"))

--- a/src/tests/gfx-materials.edn
+++ b/src/tests/gfx-materials.edn
@@ -24,7 +24,7 @@
     6 3 7]})
 
 (defloop spawned-0
-  (GFX.Drawable :Transform .transform :Mesh .mesh :Params {:baseColor .color}) (GFX.Draw))
+  .transform (GFX.Drawable :Mesh .mesh :Params {:baseColor .color}) (GFX.Draw))
 (defwire spawn-dynamic-0
   [{:Location (Float3 -3 0 -2) :Color (Float4 1 0 0 1)}
    {:Location (Float3 0 0 -2) :Color (Float4 0 1 0 1)}]
@@ -34,7 +34,7 @@
         (Spawn spawned-0))))
 
 (defloop spawned-1
-  (GFX.Drawable :Transform .transform :Mesh .mesh :Material .magenta-material) (GFX.Draw))
+  .transform (GFX.Drawable :Mesh .mesh :Material .magenta-material) (GFX.Draw))
 (defwire spawn-dynamic-1
   [{:Location (Float3 -3 0 2)}
    {:Location (Float3 0 0 2)}
@@ -72,8 +72,8 @@
     1.0 >> .c
     .c (ToFloat4) >= .color-var
 
-    (Float3 3 0 -2) (Math.Translation) >= .transform
-    (GFX.Drawable :Transform .transform :Mesh .mesh :Params {:baseColor .color-var}) (GFX.Draw)
+    (Float3 3 0 -2) (Math.Translation)
+    (GFX.Drawable :Mesh .mesh :Params {:baseColor .color-var}) (GFX.Draw)
 
     (Branch [spawn-dynamic-0])
     (Branch [spawn-dynamic-1])

--- a/src/tests/gfx-queue.edn
+++ b/src/tests/gfx-queue.edn
@@ -15,12 +15,7 @@
   (Setup
    0.0 >= .time
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
-   (Float3 0 0 0) (Math.Translation) >= .transform-0
-   (Float3 0 0 0) (Math.Translation) >= .transform-1
-   (Float3 0 0 0) (Math.Translation) >= .transform-2
-   {:Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}} (GFX.Drawable :Transform .transform-0) >> .drawable-0
-   {:Mesh .mesh :Params {:baseColor (Float4 0 1 1 0.5)}} (GFX.Drawable :Transform .transform-1) >> .drawable-1
-   {:Mesh .mesh :Params {:baseColor (Float4 1 0.2 1 0.5)}} (GFX.Drawable :Transform .transform-2) >> .drawable-2
+   (Float3 0 0 0) (Math.Translation) >= .transform-0 >= .transform-1 >= .transform-2
 
    (GFX.DrawQueue) >= .queue-0
    (GFX.DrawQueue) >= .queue-1
@@ -51,8 +46,10 @@
 
     .queue-0 (GFX.ClearQueue)
     .queue-1 (GFX.ClearQueue)
-    .drawable-0 (GFX.Draw :Queue .queue-0)
-    .drawable-1 (GFX.Draw :Queue .queue-1)
+
+    (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}) (GFX.Draw :Queue .queue-0)
+    (GFX.Drawable :Transform .transform-1 :Mesh .mesh :Params {:baseColor (Float4 0 1 1 0.5)}) (GFX.Draw :Queue .queue-1)
+    (GFX.Drawable :Transform .transform-2 :Mesh .mesh :Params {:baseColor (Float4 1 0.2 1 0.5)}) (GFX.Draw :Queue .queue-1)
 
     (GFX.Render :Steps .render-steps :View .view))))
 

--- a/src/tests/gfx-queue.edn
+++ b/src/tests/gfx-queue.edn
@@ -15,7 +15,6 @@
   (Setup
    0.0 >= .time
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
-   (Float3 0 0 0) (Math.Translation) >= .transform-0 >= .transform-1 >= .transform-2
 
    (GFX.DrawQueue) >= .queue-0
    (GFX.DrawQueue) >= .queue-1
@@ -40,16 +39,18 @@
    :Contents
    (->
     .time (Math.Add timestep) > .time
-    (spin-transform .time (Float3 -0.4 0 0)) > .transform-0
-    (spin-transform (-> .time (Math.Multiply 0.5)) (Float3 0.4 0 0)) > .transform-1
-    (spin-transform (-> .time (Math.Multiply 0.7)) (Float3 0.8 0 0)) > .transform-2
 
     .queue-0 (GFX.ClearQueue)
     .queue-1 (GFX.ClearQueue)
 
-    (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}) (GFX.Draw :Queue .queue-0)
-    (GFX.Drawable :Transform .transform-1 :Mesh .mesh :Params {:baseColor (Float4 0 1 1 0.5)}) (GFX.Draw :Queue .queue-1)
-    (GFX.Drawable :Transform .transform-2 :Mesh .mesh :Params {:baseColor (Float4 1 0.2 1 0.5)}) (GFX.Draw :Queue .queue-1)
+    (spin-transform .time (Float3 -0.4 0 0))
+    (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0 0 0.5)}) (GFX.Draw :Queue .queue-0)
+
+    (spin-transform (-> .time (Math.Multiply 0.5)) (Float3 0.4 0 0))
+    (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 0 1 1 0.5)}) (GFX.Draw :Queue .queue-1)
+
+    (spin-transform (-> .time (Math.Multiply 0.7)) (Float3 0.8 0 0))
+    (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0.2 1 0.5)}) (GFX.Draw :Queue .queue-1)
 
     (GFX.Render :Steps .render-steps :View .view))))
 

--- a/src/tests/gfx-shader-translator-2.edn
+++ b/src/tests/gfx-shader-translator-2.edn
@@ -52,7 +52,7 @@
   (Float3 0.25) (Math.Scaling) >= .transform
   .time (Math.Cos) (Math.Multiply 10.0) (Math.DegreesToRadians) (Math.AxisAngleZ) (Math.Rotation) >= .rmat-0
   .time (Math.Multiply 0.8) (Math.Cos) (Math.Multiply 3.0) (Math.DegreesToRadians) (Math.AxisAngleY) (Math.Rotation) >= .rmat-1
-  .rmat-1 (Math.MatMul .rmat-0) (Math.MatMul .transform) > .transform)
+  .rmat-1 (Math.MatMul .rmat-0) (Math.MatMul .transform))
 
 (defloop gfx
   (Setup
@@ -64,7 +64,6 @@
 
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .cube
 
-   (Float3 0.0) (Math.Translation) >= .transform
    (Do update-cube-transform)
 
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
@@ -82,8 +81,7 @@
   .time (Math.Add timestep) > .time
   .time (Broadcast "time")
   (Do update-cube-transform)
-
-  (GFX.Drawable :Transform .transform :Mesh .cube) (GFX.Draw)
+  (GFX.Drawable :Mesh .cube) (GFX.Draw)
   (GFX.Render :Steps .render-steps :View .view))
 
 (defmesh root)

--- a/src/tests/gfx-shader-translator-2.edn
+++ b/src/tests/gfx-shader-translator-2.edn
@@ -66,7 +66,6 @@
 
    (Float3 0.0) (Math.Translation) >= .transform
    (Do update-cube-transform)
-   {:Mesh .cube} (GFX.Drawable :Transform .transform) >= .drawable
 
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
    (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features
@@ -84,7 +83,7 @@
   .time (Broadcast "time")
   (Do update-cube-transform)
 
-  .drawable (GFX.Draw)
+  (GFX.Drawable :Transform .transform :Mesh .cube) (GFX.Draw)
   (GFX.Render :Steps .render-steps :View .view))
 
 (defmesh root)

--- a/src/tests/gfx-texture.edn
+++ b/src/tests/gfx-texture.edn
@@ -31,7 +31,7 @@
     .time (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
     .time (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
     .rotX (Math.MatMul .rotY) (Math.MatMul .rotZ) > .transform
-    (GFX.Drawable :Transform .transform :Transform .transform :Mesh .mesh :Params {:baseColor .texture}) (GFX.Draw)
+    (GFX.Drawable :Transform .transform :Transform .transform :Mesh .mesh :Params {:baseColorTexture .texture}) (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule Root test-wire)

--- a/src/tests/gfx-texture.edn
+++ b/src/tests/gfx-texture.edn
@@ -13,8 +13,7 @@
    (Log "Texture")
 
    (Float3 0 0 0) (Math.Translation) >= .transform
-   {:Transform .transform :Mesh .mesh :Textures {:baseColor .texture}} (GFX.Drawable :Transform .transform) >= .drawable
-
+   
     ; Create render steps
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
    (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features
@@ -32,7 +31,7 @@
     .time (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
     .time (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
     .rotX (Math.MatMul .rotY) (Math.MatMul .rotZ) > .transform
-    .drawable (GFX.Draw)
+    (GFX.Drawable :Transform .transform :Transform .transform :Mesh .mesh :Params {:baseColor .texture}) (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule Root test-wire)

--- a/src/tests/gfx-texture.edn
+++ b/src/tests/gfx-texture.edn
@@ -5,15 +5,13 @@
   (Setup
    0.0 >= .time
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
-   
+
    ; Load texture
    (LoadImage "../../assets/ShardsLogo.png") >= .image
    (Log "Image")
    (GFX.Texture) >= .texture
    (Log "Texture")
 
-   (Float3 0 0 0) (Math.Translation) >= .transform
-   
     ; Create render steps
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features
    (GFX.BuiltinFeature :Id BuiltinFeatureId.BaseColor) >> .features
@@ -30,8 +28,7 @@
     .time (Math.Multiply 0.2) (Math.AxisAngleX) (Math.Rotation) >= .rotX
     .time (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
     .time (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
-    .rotX (Math.MatMul .rotY) (Math.MatMul .rotZ) > .transform
-    (GFX.Drawable :Transform .transform :Transform .transform :Mesh .mesh :Params {:baseColorTexture .texture}) (GFX.Draw)
+    .rotX (Math.MatMul .rotY) (Math.MatMul .rotZ) (GFX.Drawable :Mesh .mesh :Params {:baseColorTexture .texture}) (GFX.Draw)
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule Root test-wire)

--- a/src/tests/gfx-ui-rt.edn
+++ b/src/tests/gfx-ui-rt.edn
@@ -16,8 +16,7 @@
 
          (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
          (Float3 0 0 0) (Math.Translation) >= .transform-0
-         {:Mesh .mesh :Params {:baseColor base-color}} (GFX.Drawable :Transform .transform-0) >> .drawables
-
+         
          (GFX.DrawQueue) >= .queue
          (GFX.DrawQueue) >= .ui-queue
 
@@ -38,7 +37,7 @@
         .queue (GFX.ClearQueue)
         .ui-queue (GFX.ClearQueue)
 
-        .drawables (GFX.Draw .queue)
+        (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor base-color}) (GFX.Draw .queue)
 
         (UI .ui-queue
             (-> ; UI Content

--- a/src/tests/gfx-ui-rt.edn
+++ b/src/tests/gfx-ui-rt.edn
@@ -15,8 +15,7 @@
          "<text>" >= .text1
 
          (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
-         (Float3 0 0 0) (Math.Translation) >= .transform-0
-         
+
          (GFX.DrawQueue) >= .queue
          (GFX.DrawQueue) >= .ui-queue
 
@@ -32,12 +31,12 @@
         .view-transform (FreeCamera) > .view-transform
 
         .time (Math.Add timestep) > .time
-        (spin-transform .time (Float3 -0.6 0 0)) > .transform-0
 
         .queue (GFX.ClearQueue)
         .ui-queue (GFX.ClearQueue)
 
-        (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor base-color}) (GFX.Draw .queue)
+        (spin-transform .time (Float3 -0.6 0 0))
+        (GFX.Drawable :Mesh .mesh :Params {:baseColor base-color}) (GFX.Draw .queue)
 
         (UI .ui-queue
             (-> ; UI Content
@@ -108,8 +107,7 @@
            (GFX.RenderInto :Textures {:color .rt-1} :WindowRegion .rt-region :Contents (Step inner-wire-1))
            .rt-1 (UI.RenderTarget)
 
-           (UI.Separator) "Footer" (UI.Label)))
-         ))
+           (UI.Separator) "Footer" (UI.Label)))))
 
     (GFX.Render :Steps .render-steps))))
 

--- a/src/tests/physics.edn
+++ b/src/tests/physics.edn
@@ -16,28 +16,13 @@
    (GFX.BuiltinMesh :Type BuiltinMeshType.Plane) = .plane
    (GFX.BuiltinMesh :Type BuiltinMeshType.Sphere) = .sphere
 
-   ; instantiate cubes and spheres
-   (map
-    (fn* [n]
-         (-> (float3 0 n 0) (Math.Translation)
-             >= (ContextVar (str "transform-" n))
-
-             {:Mesh (if (= (% n 2) 0) .cube .cube)
-              :Params
-              {:baseColor (float4 (* (/ n obj-count) 2.0) (* (- 1.0 (/ n obj-count)) 2.0) 0 1)}}
-             (GFX.Drawable :Transform (ContextVar (str "transform-" n)))
-             >> .drawable))
-    (range 1 obj-count))
-
    ; ground
    [(float4 ground-extent 0 0 0)
     (float4 0 0 (- ground-extent) 0)
     (float4 0 1 0 0)
     (float4 0 (+ ground-thickness ground-y) 0 1)] = .ground-t
-   {:Mesh .plane
-    :Params
-    {:baseColor (float4 0.8 0.55 0.95 1)}}
-   (GFX.Drawable :Transform .ground-t) >> .drawable
+   (GFX.Drawable :Transform .ground-t :Mesh .plane
+                 :Params {:baseColor (float4 0.8 0.55 0.95 1)}) >= .ground-drawable
 
    ; define some physics shapes
    (Physics.Cuboid :HalfExtents (float3 0.5)) = .cube-pshape
@@ -61,17 +46,33 @@
     (Physics.Simulation)
     (Physics.KinematicBody .ground-pshape (float3 0 ground-y 0))
 
-    ; associate a physics body to each shape
+    ; initialize transforms and  associate a physics body to each shape
     (map
      (fn* [n]
-          (-> (Physics.DynamicBody
-               :Position (float3 0 n 0)
-               :Shapes (if (= (% n 2) 0) .cube-pshape .cube-pshape)
-               :Name (str "rb" n)) > (ContextVar (str "transform-" n))))
+          (->
+           (float3 0 n 0) (Math.Translation)
+           >= (ContextVar (str "transform-" n))
+
+           (Physics.DynamicBody
+            :Position (float3 0 n 0)
+            :Shapes (if (= (% n 2) 0) .cube-pshape .cube-pshape)
+            :Name (str "rb" n)) > (ContextVar (str "transform-" n))))
      (range 1 obj-count))
 
     ; draw everything
-    .drawable (GFX.Draw)
+    .ground-drawable (GFX.Draw)
+
+    ; cubes and spheres instances
+    (map
+     (fn* [n]
+          (-> (GFX.Drawable :Transform (ContextVar (str "transform-" n))
+                            :Mesh (if (= (% n 2) 0) .cube .cube)
+                            :Params
+                            {:baseColor (float4 (* (/ n obj-count) 2.0) (* (- 1.0 (/ n obj-count)) 2.0) 0 1)})
+
+              >> .drawables))
+     (range 1 obj-count))
+    .drawables (GFX.Draw)
 
     ; final render
     (GFX.Render :Steps .render-steps :View .view))))

--- a/src/tests/physics.edn
+++ b/src/tests/physics.edn
@@ -20,8 +20,8 @@
    [(float4 ground-extent 0 0 0)
     (float4 0 0 (- ground-extent) 0)
     (float4 0 1 0 0)
-    (float4 0 (+ ground-thickness ground-y) 0 1)] = .ground-t
-   (GFX.Drawable :Transform .ground-t :Mesh .plane
+    (float4 0 (+ ground-thickness ground-y) 0 1)]
+   (GFX.Drawable :Mesh .plane
                  :Params {:baseColor (float4 0.8 0.55 0.95 1)}) >= .ground-drawable
 
    ; define some physics shapes
@@ -65,10 +65,11 @@
     ; cubes and spheres instances
     (map
      (fn* [n]
-          (-> (GFX.Drawable :Transform (ContextVar (str "transform-" n))
-                            :Mesh (if (= (% n 2) 0) .cube .cube)
-                            :Params
-                            {:baseColor (float4 (* (/ n obj-count) 2.0) (* (- 1.0 (/ n obj-count)) 2.0) 0 1)})
+          (-> (ContextVar (str "transform-" n))
+              (GFX.Drawable
+               :Mesh (if (= (% n 2) 0) .cube .cube)
+               :Params
+               {:baseColor (float4 (* (/ n obj-count) 2.0) (* (- 1.0 (/ n obj-count)) 2.0) 0 1)})
 
               >> .drawables))
      (range 1 obj-count))

--- a/src/tests/spatial.edn
+++ b/src/tests/spatial.edn
@@ -9,7 +9,7 @@
 
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
    (Float3 0 0 0) (Math.Translation) >= .transform-0
-   {:Mesh .mesh :Params {:baseColor (Float4 1 0 1 1)}} (GFX.Drawable :Transform .transform-0) >> .drawables
+   (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 1 1)}) >> .drawables
 
     ; Create render steps
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features

--- a/src/tests/spatial.edn
+++ b/src/tests/spatial.edn
@@ -8,8 +8,7 @@
    (GFX.DrawQueue) >= .screen-ui-queue
 
    (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
-   (Float3 0 0 0) (Math.Translation) >= .transform-0
-   (GFX.Drawable :Transform .transform-0 :Mesh .mesh :Params {:baseColor (Float4 1 0 1 1)}) >> .drawables
+   (Math.MatIdentity) (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0 1 1)}) >> .drawables
 
     ; Create render steps
    (GFX.BuiltinFeature :Id BuiltinFeatureId.Transform) >> .features


### PR DESCRIPTION
Changing the API of `GFX.Drawable` shard so they're attached to their state and they should be ran from a loop to update parameters/transform/etc.

- Make loopable, no longer return unique instances
- Remove table input, use parameters
- Merge Params and Textures (this means you can no longer have texture and basic parameters with the same name)
- Added helpers that will iterate over parameters defined with PARAM macros and insert references into requiredVariable()