### PR TITLE
Explicitly link ntdll when building test-gfx on Windows

### DIFF
--- a/src/gfx/tests/CMakeLists.txt
+++ b/src/gfx/tests/CMakeLists.txt
@@ -32,5 +32,8 @@ target_link_libraries(gfx-test-utils gfx gfx-texture-file Catch2)
 add_asset_path_definition(gfx-test-utils PRIVATE GFX_TEST_DATA_PATH ${GFX_TEST_DATA_PATH})
 
 target_link_libraries(test-gfx gfx gfx-test-utils gfx-texture-file gfx-gltf Catch2Main Catch2)
+if(WIN32)
+  target_link_libraries(test-gfx ntdll)
+endif()
 target_precompile_headers(test-gfx PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp>")
 add_asset_path_definition(test-gfx PUBLIC GFX_TEST_DATA_PATH ${GFX_TEST_DATA_PATH})


### PR DESCRIPTION
Following changes introduced by rust-lang/rust#108262