### PR TITLE
Doc: fix index titles

### DIFF
--- a/docs/docs/contact-us/index.md
+++ b/docs/docs/contact-us/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Contact Us
 ---
 
 ![](assets/ContactUsLogo.png){ width=180 }

--- a/docs/docs/contribute/index.md
+++ b/docs/docs/contribute/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Contribute
 ---
 
 ![](assets/ContributeLogo.png){ width=180 }

--- a/docs/docs/download/index.md
+++ b/docs/docs/download/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Download
 ---
 
 ![](assets/DownloadLogo.png){ width=180 }

--- a/docs/docs/learn/index.md
+++ b/docs/docs/learn/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Learn
 ---
 
 ![](assets/LearnLogo.png){ width=180 }

--- a/docs/docs/learn/shards/index.md
+++ b/docs/docs/learn/shards/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Learn Shards
 ---
 
 ![](assets/ShardsLogo.png){ width=180 }

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Fragnova reference
 ---
 
 ![](assets/ReferenceLogo.png){ width=180 }

--- a/docs/docs/reference/shards/index.md
+++ b/docs/docs/reference/shards/index.md
@@ -1,6 +1,7 @@
 ---
 authors: Fragcolor & contributors
 license: CC-BY-SA-4.0
+title: Shards reference
 ---
 
 ![](assets/ShardsLogo.png){ width=180 }


### PR DESCRIPTION
`Mkdocs` is not able to override "index" when the page starts with an image.