### PR TITLE
Add RotationGizmo

### DIFF
--- a/src/extra/gizmos/gizmos.cpp
+++ b/src/extra/gizmos/gizmos.cpp
@@ -166,9 +166,9 @@ struct RotationGizmo : public Base {
   }
 };
 
-void registerGizmoShards() { 
-  REGISTER_SHARD("Gizmos.Translation", TranslationGizmo); 
-  REGISTER_SHARD("Gizmos.Rotation", RotationGizmo); 
+void registerGizmoShards() {
+  REGISTER_SHARD("Gizmos.Translation", TranslationGizmo);
+  REGISTER_SHARD("Gizmos.Rotation", RotationGizmo);
 }
 } // namespace Gizmos
 } // namespace shards

--- a/src/extra/gizmos/shapes.cpp
+++ b/src/extra/gizmos/shapes.cpp
@@ -261,8 +261,9 @@ struct SolidRectShard : public Base {
                  {CoreInfo::Float3Type, CoreInfo::Float3VarType});
   PARAM_PARAMVAR(_size, "Size", "Size of the rectange", {CoreInfo::Float2Type, CoreInfo::Float2VarType});
   PARAM_PARAMVAR(_color, "Color", "Rectanglear color of the rectangle", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
-  PARAM_IMPL(RectShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), PARAM_IMPL_FOR(_size),
-             PARAM_IMPL_FOR(_color));
+  PARAM_PARAMVAR(_culling, "Culling", "Back-face culling of the rectangle", {CoreInfo::BoolType, CoreInfo::BoolVarType});
+  PARAM_IMPL(SolidRectShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), PARAM_IMPL_FOR(_size),
+             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_culling));
 
   SHTypeInfo compose(SHInstanceData &data) {
     gfx::composeCheckGfxThread(data);
@@ -283,9 +284,11 @@ struct SolidRectShard : public Base {
 
     Var sizeVar(_size.get());
     float2 size = sizeVar.isNone() ? float2(1.0f, 1.0f) : toFloat2(sizeVar);
-
+    Var cullingVar(_culling.get());
+    bool culling = cullingVar.isNone() ? true : bool(cullingVar);
+    
     shapeRenderer.addSolidRect(toFloat3(_center.get()), toFloat3(_xBase.get()), toFloat3(_yBase.get()), size,
-                               colorOrDefault(_color.get()));
+                               colorOrDefault(_color.get()), culling);
 
     return SHVar{};
   }
@@ -313,8 +316,9 @@ struct DiscShard : public Base {
   PARAM_PARAMVAR(_innerRadius, "InnerRadius", "Radius of the inner circle of the disc",
                  {CoreInfo::FloatType, CoreInfo::FloatVarType});
   PARAM_PARAMVAR(_color, "Color", "Linear color of the disc", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
+  PARAM_PARAMVAR(_culling, "Culling", "Back-face culling of the disc", {CoreInfo::BoolType, CoreInfo::BoolVarType});
   PARAM_IMPL(DiscShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), 
-             PARAM_IMPL_FOR(_outerRadius), PARAM_IMPL_FOR(_innerRadius), PARAM_IMPL_FOR(_color), );
+             PARAM_IMPL_FOR(_outerRadius), PARAM_IMPL_FOR(_innerRadius), PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_culling));
 
   SHTypeInfo compose(SHInstanceData &data) {
     gfx::composeCheckGfxThread(data);
@@ -337,6 +341,8 @@ struct DiscShard : public Base {
     Var innerRadiusVar(_innerRadius.get());
     float outerRadius = outerRadiusVar.isNone() ? 1.0f : float(outerRadiusVar);
     float innerRadius = innerRadiusVar.isNone() ? outerRadius / 2 : float(innerRadiusVar);
+    Var cullingVar(_culling.get());
+    bool culling = cullingVar.isNone() ? true : bool(cullingVar);
 
     // currently ensures there will never be an issue where inneradius is larger than outer radius
     // may want to handle differently in the future
@@ -345,7 +351,7 @@ struct DiscShard : public Base {
     }
 
     shapeRenderer.addDisc(toFloat3(_center.get()), toFloat3(_xBase.get()), toFloat3(_yBase.get()), outerRadius, innerRadius,
-                          colorOrDefault(_color.get()), 64);
+                          colorOrDefault(_color.get()), culling, 64);
 
     return SHVar{};
   }

--- a/src/extra/gizmos/shapes.cpp
+++ b/src/extra/gizmos/shapes.cpp
@@ -73,7 +73,7 @@ struct CircleShard : public Base {
   PARAM_PARAMVAR(_color, "Color", "Linear color of the circle", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
   PARAM_VAR(_thickness, "Thickness", "Width of the circle in screen space", {CoreInfo::IntType});
   PARAM_IMPL(CircleShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), PARAM_IMPL_FOR(_radius),
-             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_thickness), );
+             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_thickness));
 
   SHTypeInfo compose(SHInstanceData &data) {
     gfx::composeCheckGfxThread(data);
@@ -125,7 +125,7 @@ struct RectShard : public Base {
   PARAM_PARAMVAR(_color, "Color", "Rectanglear color of the rectangle", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
   PARAM_VAR(_thickness, "Thickness", "Width of the rectangle in screen space", {CoreInfo::IntType});
   PARAM_IMPL(RectShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), PARAM_IMPL_FOR(_size),
-             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_thickness), );
+             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_thickness));
 
   SHTypeInfo compose(SHInstanceData &data) {
     gfx::composeCheckGfxThread(data);

--- a/src/extra/gizmos/shapes.cpp
+++ b/src/extra/gizmos/shapes.cpp
@@ -261,9 +261,8 @@ struct SolidRectShard : public Base {
                  {CoreInfo::Float3Type, CoreInfo::Float3VarType});
   PARAM_PARAMVAR(_size, "Size", "Size of the rectange", {CoreInfo::Float2Type, CoreInfo::Float2VarType});
   PARAM_PARAMVAR(_color, "Color", "Rectanglear color of the rectangle", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
-  PARAM_VAR(_thickness, "Thickness", "Not currently in use. May be removed in the future", {CoreInfo::IntType});
   PARAM_IMPL(RectShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), PARAM_IMPL_FOR(_size),
-             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_thickness), );
+             PARAM_IMPL_FOR(_color));
 
   SHTypeInfo compose(SHInstanceData &data) {
     gfx::composeCheckGfxThread(data);
@@ -286,7 +285,7 @@ struct SolidRectShard : public Base {
     float2 size = sizeVar.isNone() ? float2(1.0f, 1.0f) : toFloat2(sizeVar);
 
     shapeRenderer.addSolidRect(toFloat3(_center.get()), toFloat3(_xBase.get()), toFloat3(_yBase.get()), size,
-                               colorOrDefault(_color.get()), thicknessOrDefault(_thickness));
+                               colorOrDefault(_color.get()));
 
     return SHVar{};
   }

--- a/src/extra/gizmos/shapes.cpp
+++ b/src/extra/gizmos/shapes.cpp
@@ -249,12 +249,126 @@ struct PointShard : public Base {
   }
 };
 
+struct SolidRectShard : public Base {
+  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString help() { return SHCCSTR("Draws a filled rectangle in 3d space"); }
+
+  PARAM_PARAMVAR(_center, "Center", "Starting position of the rectangle", {CoreInfo::Float3Type, CoreInfo::Float3VarType});
+  PARAM_PARAMVAR(_xBase, "XBase", "X direction of the plane the rectangle is on",
+                 {CoreInfo::Float3Type, CoreInfo::Float3VarType});
+  PARAM_PARAMVAR(_yBase, "YBase", "Y direction of the plane the rectangle is on",
+                 {CoreInfo::Float3Type, CoreInfo::Float3VarType});
+  PARAM_PARAMVAR(_size, "Size", "Size of the rectange", {CoreInfo::Float2Type, CoreInfo::Float2VarType});
+  PARAM_PARAMVAR(_color, "Color", "Rectanglear color of the rectangle", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
+  PARAM_VAR(_thickness, "Thickness", "Not currently in use. May be removed in the future", {CoreInfo::IntType});
+  PARAM_IMPL(RectShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), PARAM_IMPL_FOR(_size),
+             PARAM_IMPL_FOR(_color), PARAM_IMPL_FOR(_thickness), );
+
+  SHTypeInfo compose(SHInstanceData &data) {
+    gfx::composeCheckGfxThread(data);
+
+    if (_center->valueType == SHType::None)
+      throw ComposeError("Center is required");
+    if (_xBase->valueType == SHType::None)
+      throw ComposeError("XBase is required");
+    if (_yBase->valueType == SHType::None)
+      throw ComposeError("YBase is required");
+
+    return shards::CoreInfo::NoneType;
+  }
+
+  SHVar activate(SHContext *shContext, const SHVar &input) {
+    auto &gizmoRenderer = _gizmoContext->gfxGizmoContext.renderer;
+    auto &shapeRenderer = gizmoRenderer.getShapeRenderer();
+
+    Var sizeVar(_size.get());
+    float2 size = sizeVar.isNone() ? float2(1.0f, 1.0f) : toFloat2(sizeVar);
+
+    shapeRenderer.addSolidRect(toFloat3(_center.get()), toFloat3(_xBase.get()), toFloat3(_yBase.get()), size,
+                               colorOrDefault(_color.get()), thicknessOrDefault(_thickness));
+
+    return SHVar{};
+  }
+
+  void warmup(SHContext *context) {
+    baseWarmup(context);
+    PARAM_WARMUP(context);
+  }
+  void cleanup() {
+    baseCleanup();
+    PARAM_CLEANUP();
+  }
+};
+
+struct DiscShard : public Base {
+  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString help() { return SHCCSTR("Draws a filled disc in 3d space"); }
+
+  PARAM_PARAMVAR(_center, "Center", "Center of the disc", {CoreInfo::Float3Type, CoreInfo::Float3VarType});
+  PARAM_PARAMVAR(_xBase, "XBase", "X direction of the plane the disc is on", {CoreInfo::Float3Type, CoreInfo::Float3VarType});
+  PARAM_PARAMVAR(_yBase, "YBase", "Y direction of the plane the disc is on", {CoreInfo::Float3Type, CoreInfo::Float3VarType})
+  PARAM_PARAMVAR(_outerRadius, "OuterRadius", "Radius of the outer circle of the disc",
+                 {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_PARAMVAR(_innerRadius, "InnerRadius", "Radius of the inner circle of the disc",
+                 {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_PARAMVAR(_color, "Color", "Linear color of the disc", {CoreInfo::Float4Type, CoreInfo::Float4VarType});
+  PARAM_IMPL(DiscShard, PARAM_IMPL_FOR(_center), PARAM_IMPL_FOR(_xBase), PARAM_IMPL_FOR(_yBase), 
+             PARAM_IMPL_FOR(_outerRadius), PARAM_IMPL_FOR(_innerRadius), PARAM_IMPL_FOR(_color), );
+
+  SHTypeInfo compose(SHInstanceData &data) {
+    gfx::composeCheckGfxThread(data);
+
+    if (_center->valueType == SHType::None)
+      throw ComposeError("Center is required");
+    if (_xBase->valueType == SHType::None)
+      throw ComposeError("XBase is required");
+    if (_yBase->valueType == SHType::None)
+      throw ComposeError("YBase is required");
+
+    return shards::CoreInfo::NoneType;
+  }
+
+  SHVar activate(SHContext *shContext, const SHVar &input) {
+    auto &gizmoRenderer = _gizmoContext->gfxGizmoContext.renderer;
+    auto &shapeRenderer = gizmoRenderer.getShapeRenderer();
+
+    Var outerRadiusVar(_outerRadius.get());
+    Var innerRadiusVar(_innerRadius.get());
+    float outerRadius = outerRadiusVar.isNone() ? 1.0f : float(outerRadiusVar);
+    float innerRadius = innerRadiusVar.isNone() ? outerRadius / 2 : float(innerRadiusVar);
+
+    // currently ensures there will never be an issue where inneradius is larger than outer radius
+    // may want to handle differently in the future
+    if (innerRadius > outerRadius) {
+      std::swap(innerRadius, outerRadius);
+    }
+
+    shapeRenderer.addDisc(toFloat3(_center.get()), toFloat3(_xBase.get()), toFloat3(_yBase.get()), outerRadius, innerRadius,
+                          colorOrDefault(_color.get()), 64);
+
+    return SHVar{};
+  }
+
+  void warmup(SHContext *context) {
+    baseWarmup(context);
+    PARAM_WARMUP(context);
+  }
+  void cleanup() {
+    baseCleanup();
+    PARAM_CLEANUP();
+  }
+};
+
 void registerShapeShards() {
   REGISTER_SHARD("Gizmos.Line", LineShard);
   REGISTER_SHARD("Gizmos.Circle", CircleShard);
   REGISTER_SHARD("Gizmos.Rect", RectShard);
   REGISTER_SHARD("Gizmos.Box", BoxShard);
   REGISTER_SHARD("Gizmos.Point", PointShard);
+  REGISTER_SHARD("Gizmos.SolidRect", SolidRectShard);
+  REGISTER_SHARD("Gizmos.Disc", DiscShard);
 }
 } // namespace Gizmos
 } // namespace shards

--- a/src/gfx/gizmos/gizmo_input.cpp
+++ b/src/gfx/gizmos/gizmo_input.cpp
@@ -18,10 +18,7 @@ void InputContext::begin(const InputState &inputState, ViewPtr view) {
   heldHandleUpdated = false;
 }
 
-// TODO: move raycasting out of updateHandle, maybe even call it with a distance parameter
-// let the gizmo itself handle the raycasting however it needs to instead perhaps
-
-// call with hit distance from raycast
+// Call with hit distance from raycast
 void InputContext::updateHandle(Handle &handle, float hitDistance) {
   bool isHeld = &handle == held;
 

--- a/src/gfx/gizmos/gizmo_input.cpp
+++ b/src/gfx/gizmos/gizmo_input.cpp
@@ -92,5 +92,13 @@ void InputContext::updateView(ViewPtr view) {
   rayDirection = linalg::normalize(unprojected.xyz() - eyeLocation);
 }
 
+float3x2 InputContext::getScreenSpacePlaneAxes() {
+  float3 yBase = cachedViewProjInv[1].xyz() / cachedViewProjInv[3].w; // also upDir
+  float3 viewDir = cachedViewProjInv[2].xyz() / cachedViewProjInv[3].w;
+  float3 xBase = linalg::cross(yBase, viewDir);
+
+  return {linalg::normalize(xBase), linalg::normalize(yBase)};
+}
+
 } // namespace gizmos
 } // namespace gfx

--- a/src/gfx/gizmos/gizmo_input.cpp
+++ b/src/gfx/gizmos/gizmo_input.cpp
@@ -1,5 +1,6 @@
 #include "gizmo_input.hpp"
 #include <float.h>
+#include <spdlog/spdlog.h>
 
 namespace gfx {
 namespace gizmos {
@@ -17,20 +18,18 @@ void InputContext::begin(const InputState &inputState, ViewPtr view) {
   heldHandleUpdated = false;
 }
 
+// TODO: move raycasting out of updateHandle, maybe even call it with a distance parameter
+// let the gizmo itself handle the raycasting however it needs to instead perhaps
 void InputContext::updateHandle(Handle &handle) {
   bool isHeld = &handle == held;
 
-  auto &box = handle.selectionBox;
-  float4x4 invHandleTransform = linalg::inverse(handle.selectionBoxTransform);
-  float3 rayLoc1 = linalg::mul(invHandleTransform, float4(eyeLocation, 1)).xyz();
-  float3 rayDir1 = linalg::mul(invHandleTransform, float4(rayDirection, 0)).xyz();
-  float2 hit = intersectAABB(rayLoc1, rayDir1, box.min, box.max);
-  if (hit.x < hit.y) {
-    if (hit.x < hitDistance) {
-      hitDistance = hit.x;
-      hovering = &handle;
-    }
-  }
+  //auto &box = handle.selectionBox;
+  //float4x4 invHandleTransform = linalg::inverse(handle.selectionBoxTransform);
+  //float3 rayLoc1 = linalg::mul(invHandleTransform, float4(eyeLocation, 1)).xyz();
+  //float3 rayDir1 = linalg::mul(invHandleTransform, float4(rayDirection, 0)).xyz();
+  //float2 hit = intersectAABB(rayLoc1, rayDir1, box.min, box.max);
+
+  handle.resolveHover(*this);
 
   // Movement callback for held handle
   if (isHeld) {
@@ -95,6 +94,49 @@ void InputContext::updateView(ViewPtr view) {
 
   eyeLocation = viewInv.w.xyz();
   rayDirection = linalg::normalize(unprojected.xyz() - eyeLocation);
+}
+
+void BoxHandle::resolveHover(InputContext &context) {
+  auto &box = selectionBox;
+  float4x4 invHandleTransform = linalg::inverse(selectionBoxTransform);
+  float3 rayLoc1 = linalg::mul(invHandleTransform, float4(context.eyeLocation, 1)).xyz();
+  float3 rayDir1 = linalg::mul(invHandleTransform, float4(context.rayDirection, 0)).xyz();
+  float2 hit = intersectAABB(rayLoc1, rayDir1, box.min, box.max);
+
+  if (hit.x < hit.y) {
+    if (hit.x < context.hitDistance) {
+      context.hitDistance = hit.x;
+      context.hovering = this;
+    }
+  }
+}
+
+void DiscHandle::resolveHover(InputContext &context) {
+  float3 axisDir{};
+  axisDir[size_t(userData)] = 1.0f;
+
+  // find a unit vector perpendicular to the forward axis and the camera direction
+  float3 rotPlaneX = linalg::normalize(linalg::cross(axisDir, context.rayDirection));
+  //float3 hitLoc = hitOnPlane(context.eyeLocation, context.rayDirection, selectionDisc.center, rotPlaneX);
+  float3 hitLoc = hitOnPlane(selectionDisc.center + axisDir, context.rayDirection, selectionDisc.center, rotPlaneX);
+  float distanceFromCenter = linalg::distance(hitLoc, selectionDisc.center);
+
+  static int debugged{};
+  if (axisDir[0] == 1.0f) {
+    debugged++;
+    if (debugged % 300 == 0) {
+      SPDLOG_DEBUG("axisDir: {} {} {}    rotplaneX: {} {} {}    hitLoc: {} {} {}  distance: {}", axisDir.x, axisDir.y, axisDir.z,
+                   rotPlaneX.x, rotPlaneX.y, rotPlaneX.z, hitLoc.x, hitLoc.y, hitLoc.z, distanceFromCenter);
+      SPDLOG_DEBUG("discRadii: {} {}", selectionDisc.innerRadius, selectionDisc.outerRadius);
+    }
+  }
+  
+  if (distanceFromCenter <= selectionDisc.outerRadius && distanceFromCenter >= selectionDisc.innerRadius) {
+    if (distanceFromCenter < context.hitDistance) {
+      context.hitDistance = distanceFromCenter;
+      context.hovering = this;
+    }
+  }
 }
 
 } // namespace gizmos

--- a/src/gfx/gizmos/gizmo_input.cpp
+++ b/src/gfx/gizmos/gizmo_input.cpp
@@ -92,12 +92,24 @@ void InputContext::updateView(ViewPtr view) {
   rayDirection = linalg::normalize(unprojected.xyz() - eyeLocation);
 }
 
-float3x2 InputContext::getScreenSpacePlaneAxes() {
-  float3 yBase = cachedViewProjInv[1].xyz() / cachedViewProjInv[3].w; // also upDir
-  float3 viewDir = cachedViewProjInv[2].xyz() / cachedViewProjInv[3].w;
-  float3 xBase = linalg::cross(yBase, viewDir);
+float3x3 InputContext::getScreenSpacePlaneAxes() const {
+  float3 yBase = getUpVector();
+  float3 normal = getForwardVector();
+  float3 xBase = linalg::normalize(linalg::cross(yBase, normal));
 
-  return {linalg::normalize(xBase), linalg::normalize(yBase)};
+  return {xBase, yBase, normal};
+}
+
+float3 InputContext::getRightVector() const {
+  return linalg::normalize(cachedViewProjInv[0].xyz() / cachedViewProjInv[3].w);
+}
+
+float3 InputContext::getUpVector() const {
+  return linalg::normalize(cachedViewProjInv[1].xyz() / cachedViewProjInv[3].w);
+}
+
+float3 InputContext::getForwardVector() const {
+  return linalg::normalize(cachedViewProjInv[2].xyz() / cachedViewProjInv[3].w);
 }
 
 } // namespace gizmos

--- a/src/gfx/gizmos/gizmo_input.cpp
+++ b/src/gfx/gizmos/gizmo_input.cpp
@@ -100,17 +100,11 @@ float3x3 InputContext::getScreenSpacePlaneAxes() const {
   return {xBase, yBase, normal};
 }
 
-float3 InputContext::getRightVector() const {
-  return linalg::normalize(cachedViewProjInv[0].xyz() / cachedViewProjInv[3].w);
-}
+float3 InputContext::getRightVector() const { return linalg::normalize(cachedViewProjInv[0].xyz() / cachedViewProjInv[3].w); }
 
-float3 InputContext::getUpVector() const {
-  return linalg::normalize(cachedViewProjInv[1].xyz() / cachedViewProjInv[3].w);
-}
+float3 InputContext::getUpVector() const { return linalg::normalize(cachedViewProjInv[1].xyz() / cachedViewProjInv[3].w); }
 
-float3 InputContext::getForwardVector() const {
-  return linalg::normalize(cachedViewProjInv[2].xyz() / cachedViewProjInv[3].w);
-}
+float3 InputContext::getForwardVector() const { return linalg::normalize(cachedViewProjInv[2].xyz() / cachedViewProjInv[3].w); }
 
 } // namespace gizmos
 } // namespace gfx

--- a/src/gfx/gizmos/gizmo_input.hpp
+++ b/src/gfx/gizmos/gizmo_input.hpp
@@ -79,8 +79,12 @@ public:
   // Call to end input update and run input callbacks
   void end();
 
-  // Returns a direction vector ray from the middle of the viewport into the eye
-  float3x2 getScreenSpacePlaneAxes();
+  // Returns normalized world direction vectors of the 3 axes relative to the screen
+  float3x3 getScreenSpacePlaneAxes() const;
+  // Returns the normalized up vector of the camera in world space
+  float3 getUpVector() const;
+  // Returns the normalized forward vector of the camera in world space
+  float3 getForwardVector() const;
 
 private:
   // Computes eye location and cursor ray direction
@@ -89,6 +93,10 @@ private:
   void updateHeldHandle();
   // Updates `hitLocation` variable based on hovered/held handle
   void updateHitLocation();
+
+  // Set to private to prevent using the cached inverse view projection matrix for the 3 axes
+  // Forces the user to use the `getScreenSpacePlaneAxes` function
+  float3 getRightVector() const;
 };
 } // namespace gizmos
 

--- a/src/gfx/gizmos/gizmo_input.hpp
+++ b/src/gfx/gizmos/gizmo_input.hpp
@@ -79,6 +79,9 @@ public:
   // Call to end input update and run input callbacks
   void end();
 
+  // Returns a direction vector ray from the middle of the viewport into the eye
+  float3x2 getScreenSpacePlaneAxes();
+
 private:
   // Computes eye location and cursor ray direction
   void updateView(ViewPtr view);

--- a/src/gfx/gizmos/gizmo_input.hpp
+++ b/src/gfx/gizmos/gizmo_input.hpp
@@ -5,6 +5,7 @@
 #include "../linalg.hpp"
 #include "../math.hpp"
 #include "../view.hpp"
+#include "gizmo_math.hpp"
 #include <memory>
 #include <optional>
 
@@ -14,6 +15,12 @@ namespace gizmos {
 struct Box {
   float3 min{};
   float3 max{};
+};
+
+struct Disc {
+  float3 center{};
+  float outerRadius{};
+  float innerRadius{};
 };
 
 struct InputContext;
@@ -32,10 +39,35 @@ struct IGizmoCallbacks {
 };
 
 struct Handle {
-  Box selectionBox;
+  bool isBoxSelection{};
   float4x4 selectionBoxTransform;
   IGizmoCallbacks *callbacks{};
   void *userData{};
+
+  enum class SelectionType {
+    box,
+    disc,
+  } selectionType;
+
+  virtual ~Handle() = default;
+  // Checks if ray intersects handle and update hitDistance and hovering if so
+  virtual void resolveHover(InputContext &context) = 0;
+  virtual SelectionType getSelectionType() const = 0;
+};
+
+struct BoxHandle : public Handle {
+  Box selectionBox;
+
+  void resolveHover(InputContext &context) override;
+  SelectionType getSelectionType() const override { return SelectionType::box; }
+};
+
+struct DiscHandle : public Handle {
+  Disc selectionDisc;
+
+  DiscHandle(float3 center, float outerRadius, float innerRadius) : selectionDisc{center, outerRadius, innerRadius} {}
+  void resolveHover(InputContext &context) override;
+  SelectionType getSelectionType() const override { return SelectionType::disc; }
 };
 
 struct InputState {

--- a/src/gfx/gizmos/gizmo_input.hpp
+++ b/src/gfx/gizmos/gizmo_input.hpp
@@ -12,17 +12,6 @@
 namespace gfx {
 namespace gizmos {
 
-struct Box {
-  float3 min{};
-  float3 max{};
-};
-
-struct Disc {
-  float3 center{};
-  float outerRadius{};
-  float innerRadius{};
-};
-
 struct InputContext;
 struct Handle;
 
@@ -39,35 +28,8 @@ struct IGizmoCallbacks {
 };
 
 struct Handle {
-  bool isBoxSelection{};
-  float4x4 selectionBoxTransform;
   IGizmoCallbacks *callbacks{};
   void *userData{};
-
-  enum class SelectionType {
-    box,
-    disc,
-  } selectionType;
-
-  virtual ~Handle() = default;
-  // Checks if ray intersects handle and update hitDistance and hovering if so
-  virtual void resolveHover(InputContext &context) = 0;
-  virtual SelectionType getSelectionType() const = 0;
-};
-
-struct BoxHandle : public Handle {
-  Box selectionBox;
-
-  void resolveHover(InputContext &context) override;
-  SelectionType getSelectionType() const override { return SelectionType::box; }
-};
-
-struct DiscHandle : public Handle {
-  Disc selectionDisc;
-
-  DiscHandle(float3 center, float outerRadius, float innerRadius) : selectionDisc{center, outerRadius, innerRadius} {}
-  void resolveHover(InputContext &context) override;
-  SelectionType getSelectionType() const override { return SelectionType::disc; }
 };
 
 struct InputState {
@@ -113,7 +75,7 @@ public:
   // Call this within the update for each handle in view
   //  when a handle is grabbed, this is allowed to run the move callback directly
   //  since no raycast needs to be performed on the entire set of handles
-  void updateHandle(Handle &handle);
+  void updateHandle(Handle &handle, float hitDistance);
   // Call to end input update and run input callbacks
   void end();
 

--- a/src/gfx/gizmos/gizmo_math.hpp
+++ b/src/gfx/gizmos/gizmo_math.hpp
@@ -14,6 +14,8 @@ struct Box {
 
 struct Disc {
   float3 center{};
+  float3 xBase{};
+  float3 yBase{};
   float3 normal{};
   float outerRadius{};
   float innerRadius{};

--- a/src/gfx/gizmos/gizmo_math.hpp
+++ b/src/gfx/gizmos/gizmo_math.hpp
@@ -65,7 +65,8 @@ inline float intersectBox(const float3 &eyeLocation, const float3 &rayDirection,
 // Returns infinity if the ray does not intersect the plane.
 inline float intersectDisc(const float3 &eyeLocation, const float3 &rayDirection, const Disc &disc) {
   float d;
-  if (intersectPlane(eyeLocation, rayDirection, disc.center, disc.normal, d)) {
+  if (intersectPlane(eyeLocation, rayDirection, disc.center, disc.normal, d) || 
+    intersectPlane(eyeLocation, rayDirection, disc.center, -disc.normal, d)) {
     float3 hitPoint = eyeLocation + d * rayDirection;
     float3 hitVector = hitPoint - disc.center;
     float hitDist = linalg::length(hitVector);

--- a/src/gfx/gizmos/gizmo_math.hpp
+++ b/src/gfx/gizmos/gizmo_math.hpp
@@ -67,8 +67,8 @@ inline float intersectBox(const float3 &eyeLocation, const float3 &rayDirection,
 // Returns infinity if the ray does not intersect the plane.
 inline float intersectDisc(const float3 &eyeLocation, const float3 &rayDirection, const Disc &disc) {
   float d;
-  if (intersectPlane(eyeLocation, rayDirection, disc.center, disc.normal, d) || 
-    intersectPlane(eyeLocation, rayDirection, disc.center, -disc.normal, d)) {
+  if (intersectPlane(eyeLocation, rayDirection, disc.center, disc.normal, d) ||
+      intersectPlane(eyeLocation, rayDirection, disc.center, -disc.normal, d)) {
     float3 hitPoint = eyeLocation + d * rayDirection;
     float3 hitVector = hitPoint - disc.center;
     float hitDist = linalg::length(hitVector);

--- a/src/gfx/gizmos/gizmo_math.hpp
+++ b/src/gfx/gizmos/gizmo_math.hpp
@@ -5,6 +5,20 @@
 
 namespace gfx {
 namespace gizmos {
+
+struct Box {
+  float3 min{};
+  float3 max{};
+  float4x4 transform{};
+};
+
+struct Disc {
+  float3 center{};
+  float3 normal{};
+  float outerRadius{};
+  float innerRadius{};
+};
+
 // Projects a point onto a 3D line by projecting it
 inline float3 projectOntoAxis(float3 point, float3 axisPoint, float3 axisForward) {
   float3 T0 = generateTangent(axisForward);
@@ -29,6 +43,38 @@ inline float3 hitOnPlane(float3 eyeLocation, float3 rayDirection, float3 axisPoi
   }
 
   return axisPoint;
+}
+
+// Returns the straight-line distance from the eye to the intersection point
+// Returns infinity if the ray does not intersect the box
+inline float intersectBox(const float3 &eyeLocation, const float3 &rayDirection, const Box &box) {
+  float4x4 invHandleTransform = linalg::inverse(box.transform);
+  float3 rayLoc1 = linalg::mul(invHandleTransform, float4(eyeLocation, 1)).xyz();
+  float3 rayDir1 = linalg::mul(invHandleTransform, float4(rayDirection, 0)).xyz();
+  float2 hit = intersectAABB(rayLoc1, rayDir1, box.min, box.max);
+
+  // If there is an intersection with the box
+  if (hit.x <= hit.y) {
+    return hit.x;
+  }
+
+  return std::numeric_limits<float>::infinity();
+}
+
+// Returns the straight-line distance from the eye to the intersection point of the disc's plane.
+// Returns infinity if the ray does not intersect the plane.
+inline float intersectDisc(const float3 &eyeLocation, const float3 &rayDirection, const Disc &disc) {
+  float d;
+  if (intersectPlane(eyeLocation, rayDirection, disc.center, disc.normal, d)) {
+    float3 hitPoint = eyeLocation + d * rayDirection;
+    float3 hitVector = hitPoint - disc.center;
+    float hitDist = linalg::length(hitVector);
+    // if hit is within the disc
+    if (hitDist <= disc.outerRadius && hitDist >= disc.innerRadius) {
+      return d;
+    }
+  }
+  return std::numeric_limits<float>::infinity();
 }
 } // namespace gizmos
 } // namespace gfx

--- a/src/gfx/gizmos/gizmos.hpp
+++ b/src/gfx/gizmos/gizmos.hpp
@@ -35,10 +35,11 @@ public:
   void end(DrawQueuePtr drawQueue);
 };
 
-inline constexpr Colorf axisColors[3] = {
+inline constexpr Colorf axisColors[4] = {
     colorToFloat(colorFromRGBA(0xCD453DFF)) * 1.1f,
     colorToFloat(colorFromRGBA(0x298C0AFF)) * 1.1f,
     colorToFloat(colorFromRGBA(0x1D7EC5FF)) * 1.1f,
+    colorToFloat(colorFromRGBA(0x7D7D7DFF)) * 1.1f,
 };
 
 } // namespace gizmos

--- a/src/gfx/gizmos/rotation_gizmo.hpp
+++ b/src/gfx/gizmos/rotation_gizmo.hpp
@@ -176,9 +176,9 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
 
       float4 axisColor = axisColors[i];
       axisColor = float4(axisColor.xyz() * (hovering ? 1.1f : 0.9f), 1.0f);
-      // The xbase and ybase of each disc is the normal of the other discs (for discs 1-3)
+      // Render without culling so it can be seen from either sides
       renderer.getShapeRenderer().addDisc(selectionDisc.center, selectionDisc.xBase, selectionDisc.yBase,
-                                          selectionDisc.outerRadius, selectionDisc.innerRadius, axisColor);
+                                          selectionDisc.outerRadius, selectionDisc.innerRadius, axisColor, false);
     }
   }
 };

--- a/src/gfx/gizmos/rotation_gizmo.hpp
+++ b/src/gfx/gizmos/rotation_gizmo.hpp
@@ -152,15 +152,14 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
       case 1:
       case 2:
         axis[handleIndex] = 1.0f;
-        rotationMat = linalg::rotation_matrix(linalg::rotation_quat(axis, delta));
         break;
       case 3:
         float3x3 startRotation = extractRotationMatrix(dragStartTransform);
         axis = linalg::normalize(linalg::mul(linalg::inverse(startRotation), dragNormalDir));
-        rotationMat = linalg::rotation_matrix(linalg::rotation_quat(axis, delta));
         break;
       }
 
+      rotationMat = linalg::rotation_matrix(linalg::rotation_quat(axis, delta));
       transform = linalg::mul(dragStartTransform, rotationMat);
     }
   }

--- a/src/gfx/gizmos/rotation_gizmo.hpp
+++ b/src/gfx/gizmos/rotation_gizmo.hpp
@@ -9,10 +9,9 @@ namespace gizmos {
 // A gizmo that allows the rotation of an object about the 3 axes. The gizmo is composed of 3
 // handles, each of which allows rotation about a single axis.
 //
-// Note: While only a single handle of the RotationGizmo may be selected at any point in time,
-// handles from multiple different gizmos may be selected at the same time and manipulated.
-// In such a case, do be forewarned that some awkward behaviour may occur as multiple gizmos
-// are not expected to be active and used at the same time.
+// Note: If multiple gizmos are to be active at any time, ensure that they are created in the same Gizmos.Context
+//       This is to prevent multiple handles from different gizmos being selected at the same time, 
+//       resulting in unexpected behaviour.
 struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
 
@@ -60,9 +59,6 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   // update from IGizmo, seems to update gizmo based on inputcontext
   // updates mainly the hitbox for the handle and calls updateHandle to check if the handle is selected (via raycasting)
   virtual void update(InputContext &inputContext) {
-    // float3x3 invTransform = linalg::inverse(extractRotationMatrix(transform));
-    // float3 localRayDir = linalg::mul(invTransform, inputContext.rayDirection);
-
     // Rotate the 3 discs for x/y/z-axis according to the current transform of the object
     float3x3 rotationMat = extractRotationMatrix(transform);
     float3x3 axisDirs{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};

--- a/src/gfx/gizmos/rotation_gizmo.hpp
+++ b/src/gfx/gizmos/rotation_gizmo.hpp
@@ -1,11 +1,18 @@
-#ifndef TO_BE_REPLACED
-#define TO_BE_REPLACED
+#ifndef ROTATION_GIZMO_HPP
+#define ROTATION_GIZMO_HPP
 
 #include "gizmos.hpp"
 #include <gfx/linalg.hpp>
 
 namespace gfx {
 namespace gizmos {
+// A gizmo that allows the rotation of an object about the 3 axes. The gizmo is composed of 3
+// handles, each of which allows rotation about a single axis.
+//
+// Note: While only a single handle of the RotationGizmo may be selected at any point in time,
+// handles from multiple different gizmos may be selected at the same time and manipulated.
+// In such a case, do be forewarned that some awkward behaviour may occur as multiple gizmos
+// are not expected to be active and used at the same time.
 struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
 
@@ -108,8 +115,8 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
 
       float delta = linalg::dot(deltaVec, dragTangentDir);
       // Use this to check direction vector of tangent and delta for the effective distance moved along the tangent
-      //SPDLOG_DEBUG("dragTangentDir {} {} {}", dragTangentDir.x, dragTangentDir.y, dragTangentDir.z);
-      //SPDLOG_DEBUG("Delta: {}", delta);
+      // SPDLOG_DEBUG("dragTangentDir {} {} {}", dragTangentDir.x, dragTangentDir.y, dragTangentDir.z);
+      // SPDLOG_DEBUG("Delta: {}", delta);
       float sinTheta = std::sin(delta);
       float cosTheta = std::cos(delta);
 
@@ -174,4 +181,4 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
 } // namespace gizmos
 } // namespace gfx
 
-#endif /* TO_BE_REPLACED */
+#endif

--- a/src/gfx/gizmos/rotation_gizmo.hpp
+++ b/src/gfx/gizmos/rotation_gizmo.hpp
@@ -9,7 +9,8 @@ namespace gizmos {
 struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
 
-  std::unique_ptr<Handle> handles[3];
+  Handle handles[3];
+  Disc handleSelectionDiscs[3];
   float4x4 dragStartTransform;
   float3 dragStartPoint;
 
@@ -19,14 +20,18 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   const float outerRadius = 1.0f;
   const float innerRadius = 0.8f;
 
-   float getGlobalAxisRadius() const { return axisRadius * scale; }
-   float getGlobalAxisLength() const { return axisLength * scale; }
+  float getGlobalAxisRadius() const { return axisRadius * scale; }
+  float getGlobalAxisLength() const { return axisLength * scale; }
 
   RotationGizmo() {
-     for (int i = 0; i < 3; ++i) {
-      handles[i] = std::make_unique<DiscHandle>(float3(0.0f, 0.0f, 0.0f), outerRadius, innerRadius);
-      handles[i]->userData = reinterpret_cast<void *>(i);
-      handles[i]->callbacks = this;
+    for (int i = 0; i < 3; ++i) {
+      handles[i].userData = reinterpret_cast<void *>(i);
+      handles[i].callbacks = this;
+      handleSelectionDiscs[i].outerRadius = 1.0f;
+      handleSelectionDiscs[i].innerRadius = 0.9f;
+      float3 normal{};
+      normal[i] = 1.0f;
+      handleSelectionDiscs[i].normal = normal;
     }
   }
 
@@ -37,12 +42,13 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
     float3 localRayDir = linalg::mul(invTransform, inputContext.rayDirection);
 
     for (size_t i = 0; i < 3; i++) {
-      auto &handle = *handles[i];
+      auto &handle = handles[i];
+      auto &selectionDisc = handleSelectionDiscs[i];
 
       float3 fwd{};
       fwd[i] = 1.0f;
-      float3 t1 = float3(-fwd.z, -fwd.x, fwd.y);
-      float3 t2 = linalg::cross(fwd, t1);
+      // float3 t1 = float3(-fwd.z, -fwd.x, fwd.y);
+      // float3 t2 = linalg::cross(fwd, t1);
 
       // Slightly decrease hitbox size if view direction is parallel
       // e.g. looking towards +z you are less likely to want to click on the z axis
@@ -50,31 +56,33 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
       float angleFactor = std::max(0.0f, (linalg::abs(linalg::dot(localRayDir, fwd)) - dotThreshold) / (1.0f - dotThreshold));
 
       // Make hitboxes slightly bigger than the actual visuals
-      const float2 hitboxScale = linalg::lerp(float2(2.2f, 1.2f), float2(0.8f, 1.0f), angleFactor);
+      // const float2 hitboxScale = linalg::lerp(float2(2.2f, 1.2f), float2(0.8f, 1.0f), angleFactor);
 
-      //// TODO: the handle shouldn't be using a collision box, it should be using a sphere or ring 
+      //// TODO: the handle shouldn't be using a collision box, it should be using a sphere or ring
       // (probably a 2D ring projected onto the plane perpendicular to the axis)
       // what is left is to adjust whether it should scale the radius less or more
       // currently its same scale as for a box, but scaling radius may have a lot more impact
       /*auto& innerRadius = handle.selectionBox.innerRadius;
       auto& outerRadius = handle.selectionBox.outerRadius;*/
-      //innerRadius = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
-      //outerRadius = (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + 
-      //              fwd * getGlobalAxisLength() * hitboxScale.y;
+      // innerRadius = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
+      // outerRadius = (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x +
+      //               fwd * getGlobalAxisLength() * hitboxScale.y;
 
-      handle.selectionBoxTransform = transform;
+      // selectionDisc.transform = transform;
 
-      inputContext.updateHandle(handle);
+      float hitDistance = intersectDisc(inputContext.eyeLocation, inputContext.rayDirection, selectionDisc);
+      inputContext.updateHandle(handle, hitDistance);
 
-      //auto &min = handle.selectionBox.min;
-      //auto &max = handle.selectionBox.max;
-      //min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
-      //max =
-      //    (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y;
+      // auto &min = handle.selectionBox.min;
+      // auto &max = handle.selectionBox.max;
+      // min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
+      // max =
+      //     (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() *
+      //     hitboxScale.y;
 
-      //handle.selectionBoxTransform = transform;
+      // handle.selectionBoxTransform = transform;
 
-      //inputContext.updateHandle(handle);
+      // inputContext.updateHandle(handle);
     }
   }
 
@@ -93,19 +101,12 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
     size_t index = getHandleIndex(handle);
     SPDLOG_DEBUG("Handle {} ({}) grabbed", index, getAxisDirection(index, dragStartTransform));
 
-    
     float3 fwd = getAxisDirection(index, dragStartTransform);
     // find a unit vector perpendicular to the forward axis and the camera direction
     float3 rotPlaneX = linalg::normalize(linalg::cross(fwd, context.rayDirection));
     float3 loc = extractTranslation(dragStartTransform);
 
-    /*dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform),
-                                getAxisDirection(index, dragStartTransform));*/
-    //dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, loc, fwd);
-
-    
     dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, loc, rotPlaneX);
-    // log drag start point
     SPDLOG_DEBUG("Drag start point: {} {} {}", dragStartPoint.x, dragStartPoint.y, dragStartPoint.z);
   }
 
@@ -118,10 +119,9 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   /*
     for x-axis: x axis is to the right, means rotation circle is on y-z plane
     only half the circle needs to be coloured, based on the direction of the camera
-    once clicked, find the point on the circle clicked, then project new mouse position onto the tangent on the point of the circle
-    then find the angle between the tangent and the x axis, and rotate the object by that angle
-    rotate anti-clockwise:
-      click left, pull down 
+    once clicked, find the point on the circle clicked, then project new mouse position onto the tangent on the point of the
+    circle then find the angle between the tangent and the x axis, and rotate the object by that angle rotate anti-clockwise:
+      click left, pull down
       click top pull left
       click right pull up
       click bottom pull right
@@ -147,53 +147,53 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
     // find a unit vector perpendicular to the forward axis and the camera direction
     float3 rotPlaneX = linalg::normalize(linalg::cross(fwd, context.rayDirection));
     float3 rotPlaneY = linalg::normalize(linalg::cross(rotPlaneX, fwd));
-    
+
     float3 loc = extractTranslation(dragStartTransform);
 
     // instead of dragStartPoint as the axisPoint, it should use the point in the middle of the gizmo
     float3 hitPoint = hitOnPlane(context.eyeLocation, context.rayDirection, loc, rotPlaneX);
 
-    //float rotRad = linalg::angle(rotPlaneY, hitPoint);
+    // float rotRad = linalg::angle(rotPlaneY, hitPoint);
 
     // hitPoint and loc are on the same plane, but the "xy" axes of the plane may not be along those axes
     // positive xDelta = rotate clockwise. negative yDelta = same direction, rotate clockwise
     float3 delta = hitPoint - dragStartPoint;
     float xDelta = linalg::dot(delta, rotPlaneX);
     float yDelta = linalg::dot(delta, rotPlaneY);
-    
+
     // flip sign of yDelta
-    float rotRadians = (xDelta - yDelta) / 5; // arbitrary amount to rotate
-    
+    float rotRadians = xDelta - yDelta; // to adjust amount to rotate, multiply this by a constant
+
     float sinTheta = std::sin(rotRadians);
     float cosTheta = std::cos(rotRadians);
     float4x4 rotationMat;
 
-    switch (handleIndex) { 
+    switch (handleIndex) {
     case 0:
       // rotating about x-axis
-      rotationMat = float4x4 {
-        {1, 0, 0, 0}, 
-        {0, cosTheta, -sinTheta, 0}, 
-        {0, sinTheta, cosTheta, 0}, 
-        {0, 0, 0, 1},
+      rotationMat = float4x4{
+          {1, 0, 0, 0},
+          {0, cosTheta, -sinTheta, 0},
+          {0, sinTheta, cosTheta, 0},
+          {0, 0, 0, 1},
       };
       break;
     case 1:
       // rotating about y-axis
-      rotationMat = float4x4 {
-        {cosTheta, 0, sinTheta, 0}, 
-        {0, 1, 0, 0}, 
-        {-sinTheta, 0, cosTheta, 0}, 
-        {0, 0, 0, 1},
+      rotationMat = float4x4{
+          {cosTheta, 0, sinTheta, 0},
+          {0, 1, 0, 0},
+          {-sinTheta, 0, cosTheta, 0},
+          {0, 0, 0, 1},
       };
       break;
     case 2:
       // rotating about z-axis
-      rotationMat = float4x4 {
-        {cosTheta, -sinTheta, 0, 0}, 
-        {sinTheta, cosTheta, 0, 0}, 
-        {0, 0, 1, 0}, 
-        {0, 0, 0, 1},
+      rotationMat = float4x4{
+          {cosTheta, -sinTheta, 0, 0},
+          {sinTheta, cosTheta, 0, 0},
+          {0, 0, 1, 0},
+          {0, 0, 0, 1},
       };
       break;
     }
@@ -207,22 +207,19 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
     float3 axisDirs[]{{1.0, 0, 0}, {0, 1.0, 0}, {0, 0, 1.0}};
 
     for (size_t i = 0; i < 3; i++) {
-      auto &handle = *handles[i];
+      auto &handle = handles[i];
+      auto &selectionDisc = handleSelectionDiscs[i];
 
       bool hovering = inputContext.hovering && inputContext.hovering == &handle;
 
-      //render based on size of selection box?
+      // render based on size of selection box?
       float3 center = extractTranslation(transform);
       float4 axisColor = axisColors[i];
       axisColor = float4(axisColor.xyz() * (hovering ? 1.1f : 0.9f), 1.0f);
-      renderer.getShapeRenderer().addDisc(center, axisDirs[(i + 1) % 3], axisDirs[(i + 2) % 3], outerRadius, innerRadius,
-                                          axisColor);
-
-      // no addHandle unlike translation_gizmo
-
+      renderer.getShapeRenderer().addDisc(selectionDisc.center, axisDirs[(i + 1) % 3], axisDirs[(i + 2) % 3],
+                                          selectionDisc.outerRadius, selectionDisc.innerRadius, axisColor);
     }
   }
-
 };
 } // namespace gizmos
 } // namespace gfx

--- a/src/gfx/gizmos/rotation_gizmo.hpp
+++ b/src/gfx/gizmos/rotation_gizmo.hpp
@@ -83,6 +83,7 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
       //     hitboxScale.y;
 
       // handle.selectionBoxTransform = transform;
+      selectionDisc.center = extractTranslation(transform);
 
       // inputContext.updateHandle(handle);
     }
@@ -119,14 +120,6 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
 
       SPDLOG_DEBUG("Drag start point: {} {} {}", dragStartPoint.x, dragStartPoint.y, dragStartPoint.z);
     }
-
-    // float3 fwd = getAxisDirection(index, dragStartTransform);
-    //// find a unit vector perpendicular to the forward axis and the camera direction
-    // float3 rotPlaneX = linalg::normalize(linalg::cross(fwd, context.rayDirection));
-    // float3 loc = extractTranslation(dragStartTransform);
-
-    // dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, loc, rotPlaneX);
-    // SPDLOG_DEBUG("Drag start point: {} {} {}", dragStartPoint.x, dragStartPoint.y, dragStartPoint.z);
   }
 
   // Called when handle released from IGizmoCallbacks
@@ -151,12 +144,7 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
   */
 
   // Called every update while handle is being held from IGizmoCallbacks
-  // TODO: Check behaviour
   virtual void move(InputContext &context, Handle &handle) {
-
-    // for rotating each disc: Find the point on the disc clicked, and then get the direction of the tangent to the disc
-    // on that point. then, depending on the distance dragged along the axis of that tangent, rotate the object by some
-    // angle relative to that distance moved
 
     auto handleIndex = getHandleIndex(handle);
     auto &selectionDisc = handleSelectionDiscs[handleIndex];
@@ -164,7 +152,6 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
     float d;
     // if (intersectPlane(context.eyeLocation, context.rayDirection, selectionDisc.center, selectionDisc.normal, d)) {
     if (intersectPlane(context.eyeLocation, context.rayDirection, selectionDisc.center, dragNormalDir, d)) {
-      // SPDLOG_DEBUG("Hit plane at {}", d);
       float3 hitPoint = context.eyeLocation + d * context.rayDirection;
       float3 deltaVec = dragStartPoint - hitPoint;
 
@@ -221,7 +208,6 @@ struct RotationGizmo : public IGizmo, public IGizmoCallbacks {
 
       bool hovering = inputContext.hovering && inputContext.hovering == &handle;
 
-      // render based on size of selection box?
       float3 center = extractTranslation(transform);
       float4 axisColor = axisColors[i];
       axisColor = float4(axisColor.xyz() * (hovering ? 1.1f : 0.9f), 1.0f);

--- a/src/gfx/gizmos/shapes.cpp
+++ b/src/gfx/gizmos/shapes.cpp
@@ -289,24 +289,20 @@ void ShapeRenderer::addDisc(float3 center, float3 xBase, float3 yBase, float out
                             uint32_t resolution) {
 
   float3 prevPos;
-  float3 prevDelta;
   float3 innerPrevPos;
-  float3 innerPrevDelta;
   for (size_t i = 0; i < resolution; i++) {
     float t = i / float(resolution - 1) * pi2;
     float tCos = std::cos(t);
     float tSin = std::sin(t);
     float3 pos = center + tCos * xBase * outerRadius + tSin * yBase * outerRadius;
-    float3 delta = center + -tSin * xBase + tCos * yBase;
     float3 innerPos = center + tCos * xBase * innerRadius + tSin * yBase * innerRadius;
-    float3 innerDelta = center + -tSin * xBase + tCos * yBase;
     if (i > 0) {
+      // draw both sides of the quad to avoid culling
       addSolidQuad(prevPos, pos, innerPos, innerPrevPos, color);
+      addSolidQuad(prevPos, innerPrevPos, innerPos, pos, color );
     }
     prevPos = pos;
-    prevDelta = delta;
     innerPrevPos = innerPos;
-    innerPrevDelta = innerDelta;
   }
 }
 

--- a/src/gfx/gizmos/shapes.cpp
+++ b/src/gfx/gizmos/shapes.cpp
@@ -264,7 +264,7 @@ void ShapeRenderer::addPoint(float3 center, float4 color, uint32_t thickness) {
   }
 }
 
-void ShapeRenderer::addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, uint32_t thickness) {
+void ShapeRenderer::addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color) {
   float2 halfSize = size / 2.0f;
   float3 verts[] = {
       center - halfSize.x * xBase - halfSize.y * yBase,

--- a/src/gfx/gizmos/shapes.cpp
+++ b/src/gfx/gizmos/shapes.cpp
@@ -299,7 +299,7 @@ void ShapeRenderer::addDisc(float3 center, float3 xBase, float3 yBase, float out
     if (i > 0) {
       // draw both sides of the quad to avoid culling
       addSolidQuad(prevPos, pos, innerPos, innerPrevPos, color);
-      addSolidQuad(prevPos, innerPrevPos, innerPos, pos, color );
+      addSolidQuad(prevPos, innerPrevPos, innerPos, pos, color);
     }
     prevPos = pos;
     innerPrevPos = innerPos;
@@ -354,7 +354,7 @@ float GizmoRenderer::getSize(float3 position) const {
   float minPerspective = std::min(projMatrix[0][0], projMatrix[1][1]);
 
   float distanceFromCamera = std::abs(projected.z);
-  float scalingFactor = distanceFromCamera / minPerspective; 
+  float scalingFactor = distanceFromCamera / minPerspective;
   return scalingFactor;
 }
 

--- a/src/gfx/gizmos/shapes.hpp
+++ b/src/gfx/gizmos/shapes.hpp
@@ -61,6 +61,9 @@ public:
   void addPoint(float3 center, float4 color, uint32_t thickness);
 
   void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, uint32_t thickness);
+  void addSolidQuad(float3 a, float3 b, float3 c, float3 d, float4 color);
+  void addDisc(float3 center, float3 xBase, float3 yBase, float outerRadius, float innerRadius, float4 color,
+               uint32_t resolution = 64);
 
   void begin();
   void end(DrawQueuePtr queue);

--- a/src/gfx/gizmos/shapes.hpp
+++ b/src/gfx/gizmos/shapes.hpp
@@ -13,6 +13,10 @@ struct ScreenSpaceSizeFeature {
   static FeaturePtr create();
 };
 
+struct NoCullingFeature {
+  static FeaturePtr create();
+};
+
 struct GizmoLightingFeature {
   static FeaturePtr create();
 };
@@ -45,11 +49,14 @@ public:
 
 private:
   FeaturePtr screenSpaceSizeFeature = ScreenSpaceSizeFeature::create();
+  FeaturePtr noCullingFeature = NoCullingFeature::create();
 
   std::vector<LineVertex> lineVertices;
   std::vector<SolidVertex> solidVertices;
+  std::vector<SolidVertex> unculledSolidVertices;
   MeshPtr lineMesh;
   MeshPtr solidMesh;
+  MeshPtr unculledSolidMesh;
 
 public:
   void addLine(float3 a, float3 b, float3 dirA, float3 dirB, float4 color, uint32_t thickness);
@@ -60,9 +67,9 @@ public:
   void addBox(float4x4 transform, float3 center, float3 size, float4 color, uint32_t thickness);
   void addPoint(float3 center, float4 color, uint32_t thickness);
 
-  void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color);
-  void addSolidQuad(float3 a, float3 b, float3 c, float3 d, float4 color);
-  void addDisc(float3 center, float3 xBase, float3 yBase, float outerRadius, float innerRadius, float4 color,
+  void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, bool culling = true);
+  void addSolidQuad(float3 a, float3 b, float3 c, float3 d, float4 color, bool culling = true);
+  void addDisc(float3 center, float3 xBase, float3 yBase, float outerRadius, float innerRadius, float4 color, bool culling = true,
                uint32_t resolution = 64);
 
   void begin();

--- a/src/gfx/gizmos/shapes.hpp
+++ b/src/gfx/gizmos/shapes.hpp
@@ -60,7 +60,7 @@ public:
   void addBox(float4x4 transform, float3 center, float3 size, float4 color, uint32_t thickness);
   void addPoint(float3 center, float4 color, uint32_t thickness);
 
-  void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, uint32_t thickness);
+  void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color);
   void addSolidQuad(float3 a, float3 b, float3 c, float3 d, float4 color);
   void addDisc(float3 center, float3 xBase, float3 yBase, float outerRadius, float innerRadius, float4 color,
                uint32_t resolution = 64);

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -6,10 +6,9 @@
 
 namespace gfx {
 namespace gizmos {
-// Note: While only a single handle of the TranslationGizmo may be selected at any point in time,
-// handles from multiple different gizmos may be selected at the same time and manipulated.
-// In such a case, do be forewarned that some awkward behaviour may occur as multiple gizmos
-// are not expected to be active and used at the same time.
+// Note: If multiple gizmos are to be active at any time, ensure that they are created in the same Gizmos.Context
+//       This is to prevent multiple handles from different gizmos being selected at the same time, 
+//       resulting in unexpected behaviour.
 struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
 

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -6,6 +6,10 @@
 
 namespace gfx {
 namespace gizmos {
+// Note: While only a single handle of the TranslationGizmo may be selected at any point in time,
+// handles from multiple different gizmos may be selected at the same time and manipulated.
+// In such a case, do be forewarned that some awkward behaviour may occur as multiple gizmos
+// are not expected to be active and used at the same time.
 struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
 

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -9,7 +9,7 @@ namespace gizmos {
 struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
 
-  Handle handles[3];
+  std::unique_ptr<Handle> handles[3];
   float4x4 dragStartTransform;
   float3 dragStartPoint;
 
@@ -22,8 +22,9 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
 
   TranslationGizmo() {
     for (size_t i = 0; i < 3; i++) {
-      handles[i].userData = (void *)i;
-      handles[i].callbacks = this;
+      handles[i] = std::make_unique<BoxHandle>();
+      handles[i]->userData = (void *)i;
+      handles[i]->callbacks = this;
     }
   }
 
@@ -32,7 +33,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
     float3 localRayDir = linalg::mul(invTransform, inputContext.rayDirection);
 
     for (size_t i = 0; i < 3; i++) {
-      auto &handle = handles[i];
+      auto &handle = *(reinterpret_cast<BoxHandle *>(handles[i].get()));
 
       float3 fwd{};
       fwd[i] = 1.0f;
@@ -93,7 +94,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
 
   void render(InputContext &inputContext, GizmoRenderer &renderer) {
     for (size_t i = 0; i < 3; i++) {
-      auto &handle = handles[i];
+      auto &handle = *(reinterpret_cast<BoxHandle *>(handles[i].get()));
 
       bool hovering = inputContext.hovering && inputContext.hovering == &handle;
 

--- a/src/tests/gfx-gizmos-rotation.edn
+++ b/src/tests/gfx-gizmos-rotation.edn
@@ -95,9 +95,9 @@
 
     ; Draw on top of everything (ignore depth)
     ;; translation gizmo itself, attached to .translation-0
-    ;; (Gizmos.Context :Queue .editor-queue-no-depth :View .view
-    ;;                 :Content (->
-    ;;                           .transform-0 (Gizmos.Translation) > .transform-0))
+    (Gizmos.Context :Queue .editor-queue-no-depth :View .view
+                    :Content (->
+                              .transform-0 (Gizmos.Translation) > .transform-0))
 
     (Gizmos.Context :Queue .editor-queue-no-depth :View .view
                     :Content (->

--- a/src/tests/gfx-gizmos-rotation.edn
+++ b/src/tests/gfx-gizmos-rotation.edn
@@ -1,0 +1,111 @@
+(def timestep (/ 1.0 120.0))
+(defmesh root)
+(def BlendAlphaPremul {:Operation BlendOperation.Add :Src BlendFactor.One :Dst BlendFactor.OneMinusSrcAlpha})
+(def BlendOne {:Operation BlendOperation.Add :Src BlendFactor.One :Dst BlendFactor.One})
+
+(defn spin-transform [t location]
+  (->
+   t >= .tmp-0
+   .tmp-0 (Math.Multiply 0.2) (Math.AxisAngleX) (Math.Rotation) >= .rotX
+   .tmp-0 (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
+   .tmp-0 (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
+   location (Math.Translation) (Math.MatMul .rotX) (Math.MatMul .rotY) (Math.MatMul .rotZ)))
+
+(defloop test-wire
+  (Setup
+   0.0 >= .time
+   (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
+   (Float3 0 0 0) (Math.Translation) >= .transform-0
+
+   (GFX.DrawQueue) >= .queue
+   (GFX.DrawQueue) >= .editor-queue
+   (GFX.DrawQueue) >= .editor-queue-no-depth
+
+    ; Create render steps
+   (GFX.BuiltinFeature BuiltinFeatureId.Transform) >> .features
+   (GFX.BuiltinFeature BuiltinFeatureId.BaseColor) >> .features
+
+   {:Features .features :Queue .queue} (GFX.DrawablePass) >> .render-steps
+   {:Features .features
+    :Queue .editor-queue} (GFX.DrawablePass) >> .render-steps
+   {:Features .features
+    :Queue .editor-queue-no-depth
+    :Outputs [{:Name "color"}
+              {:Name "depth" :Clear true}]} (GFX.DrawablePass) >> .render-steps
+
+    ;; Create view
+   {:Position (Float3 3 3 8) :Target (Float3 0 0 0)} (Math.LookAt) >= .view-transform
+   (GFX.View :View .view-transform) >= .view)
+  ;; end setup
+  (GFX.MainWindow
+   :Title "SDL Window" :Width 1280 :Height 720 :Debug false
+   :Contents
+   (->
+    .time (Math.Add timestep) > .time
+
+    ;; link the transform (?) to the cube mesh and get a drawable 
+    ;; not linked, transform-0 value is updated by Gizmos.Translation every loop
+    .transform-0 (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0 0 1)}) >= .drawable-0
+    (GFX.Draw .queue)
+
+    ; Draw helpers (using scene depth)
+    ;; provides a context for rendering gizmos
+    (Gizmos.Context :Queue .editor-queue :View .view
+                    :Content (->
+                              ;; highlights the object (drawable) attached to gizmo, show wireframe
+                              .drawable-0 (Gizmos.Highlight)
+                              (Float3 0 0 0) >= .a
+                              (Float3 0 0 2) >= .z-2
+                              ;; draws the 3 axes
+                              (Gizmos.Line :A (Float3 0 0 0) :B (Float3 2 0 0) :Color (Float4 1 0 0 1) :Thickness 8)
+                              (Gizmos.Line :A .a :B (Float3 0 2 0) :Color (Float4 0 1 0 1))
+                              (Gizmos.Line :A .a :B .z-2 :Color (Float4 0 0 1 1) :Thickness 4)
+
+                              (Float3 1 0 0) >= .xbase
+                              (Float3 0 1 0) >= .ybase
+                              (Float3 0 0 1) >= .zbase
+                              (Float3 -1 1 -1) (Math.Cross (Float3 1 0 0)) >= .norm
+
+                              (Gizmos.Line :A (Float3 0 0 0) :B (Float3 -1 1 -1) :Color (Float4 1 1 1 1) :Thickness 4)
+                              ;; (Gizmos.Disc :Center (Float3 0 0 0) :XBase (Float3 1 0 0) :YBase (Float3 0 1 0) :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.5 0.5 0.5 1.0))
+
+                              ;; (Gizmos.Disc :Center (Float3 0 0 0) :XBase .xbase :YBase .ybase :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.2 1.0 0.2 1.0))
+
+                              ;; draws 2 rotation circles around imaginary object
+                              (Gizmos.Circle :Center (Float3 1 1 1) :XBase .xbase :YBase .ybase)
+                              ;; (Gizmos.Circle :Center (Float3 1 1 1) :XBase .zbase :YBase (Float3 -1 1 1) :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 4)
+                              (Gizmos.Circle :Center (Float3 1 1 1) :XBase .xbase :YBase .norm :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 1)
+                              ;; rect on xy plane
+
+                              (Gizmos.Rect :Center (Float3 0 0 0) :XBase .xbase :YBase .norm :Size (Float2 1 1) :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 4)
+
+                              ;; solid rect test on xy plane
+                              ;; (Gizmos.SolidRect :Center (Float3 1 1 0) :XBase .xbase :YBase .ybase :Size (Float2 2 2) :Color (Float4 0 0.5 0 1.0))
+
+                              ;; solid disc test on xy plane
+                              ;; (Gizmos.Disc :Center (Float3 1 1 0.5) :XBase .xbase :YBase .ybase :OuterRadius 5.0 :InnerRadius 3.0 :Color (Float4 0 0 0.5 1.0))
+
+                              ;; imaginary object (box)
+                              (Gizmos.Box :Center (Float3 1 1 1) :Size (Float3 0.5 0.2 0.3) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 4)
+
+                              ;; dot at top right of xy rect
+                              (Gizmos.Point :Center (Float3 1.4 1.4 1) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 16)
+                              ;; dot doing idk what, its out there 
+                              (Gizmos.Point :Center (Float3 -2 -0.2 1)  :Color (Float4 1.0 0.2 1.0 1.0) :Thickness 4)))
+
+    ; Draw on top of everything (ignore depth)
+    ;; translation gizmo itself, attached to .translation-0
+    ;; (Gizmos.Context :Queue .editor-queue-no-depth :View .view
+    ;;                 :Content (->
+    ;;                           .transform-0 (Gizmos.Translation) > .transform-0))
+                              ;; .transform-0 (Gizmos.Rotation) > .transform-0))
+
+    (Gizmos.Context :Queue .editor-queue-no-depth :View .view
+                    :Content (->
+                              ;; .transform-0 (Gizmos.Translation) > .transform-0))
+                              .transform-0 (Gizmos.Rotation) > .transform-0))
+
+    (GFX.Render :Steps .render-steps :View .view))))
+
+(schedule root test-wire)
+(if (run root timestep) nil (throw "Root tick failed"))

--- a/src/tests/gfx-gizmos-rotation.edn
+++ b/src/tests/gfx-gizmos-rotation.edn
@@ -98,11 +98,9 @@
     ;; (Gizmos.Context :Queue .editor-queue-no-depth :View .view
     ;;                 :Content (->
     ;;                           .transform-0 (Gizmos.Translation) > .transform-0))
-                              ;; .transform-0 (Gizmos.Rotation) > .transform-0))
 
     (Gizmos.Context :Queue .editor-queue-no-depth :View .view
                     :Content (->
-                              ;; .transform-0 (Gizmos.Translation) > .transform-0))
                               .transform-0 (Gizmos.Rotation) > .transform-0))
 
     (GFX.Render :Steps .render-steps :View .view))))

--- a/src/tests/gfx-gizmos-rotation.edn
+++ b/src/tests/gfx-gizmos-rotation.edn
@@ -77,16 +77,14 @@
                               ;; This red disc renders even if back-face culling is enabled
                               (Gizmos.Disc :Center (Float3 2 0 0) :XBase (Float3 1 0 0) :YBase (Float3 0 1 0) :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 1.0 0.2 0.2 1.0))
 
-                              ;; This green disc does not render if back-face culling is enabled
-                              ;;;; NOTE: This renders at the moment because addDisc has been modified to draw both sides
-                              ;;;; of the quad since avoiding backface culling has yet to be implemented
-                              (Gizmos.Disc :Center (Float3 2 0 0) :XBase .xbase :YBase .norm :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.2 1.0 0.2 1.0))
+                              ;; This green disc does not render if back-face culling is enabled (which is true by default)
+                              (Gizmos.Disc :Center (Float3 2 0 0) :XBase .xbase :YBase .norm :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.2 1.0 0.2 1.0) :Culling false)
 
                               ;; This red solid rect renders even if back-face culling is enabled
                               (Gizmos.SolidRect :Center (Float3 -2 0 2) :XBase .norm :YBase .xbase :Size (Float2 1 1) :Color (Float4 1.0 0.2 0.2 1.0))
 
                               ;; This green solid rect does not render if back-face culling is enabled
-                              (Gizmos.SolidRect :Center (Float3 2 0 2) :XBase .xbase :YBase .norm :Size (Float2 1 1) :Color (Float4 0.2 1.0 0.2 1.0))
+                              (Gizmos.SolidRect :Center (Float3 2 0 2) :XBase .xbase :YBase .norm :Size (Float2 1 1) :Color (Float4 0.2 1.0 0.2 1.0) :Culling false)
                               
                               ;; imaginary object (box)
                               (Gizmos.Box :Center (Float3 1 1 1) :Size (Float3 0.5 0.2 0.3) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 4)))

--- a/src/tests/gfx-gizmos-rotation.edn
+++ b/src/tests/gfx-gizmos-rotation.edn
@@ -1,3 +1,8 @@
+;; This .edn file is for testing the rotation gizmo as well as the various shapes/etc added with the rotation gizmo
+;; In general, the base code is adapted from `gfx-gizmos.edn` which tests mainly the TranslationGizmo and various shapes
+;; In this script, the RotationGizmo is added to the same context as the TranslationGizmo with additional discs and solid rects
+;; Some of the shapes/shards/code already tested in `gfx-gizmos.edn` are left out.
+
 (def timestep (/ 1.0 120.0))
 (defmesh root)
 (def BlendAlphaPremul {:Operation BlendOperation.Add :Src BlendFactor.One :Dst BlendFactor.OneMinusSrcAlpha})
@@ -64,46 +69,36 @@
                               (Float3 1 0 0) >= .xbase
                               (Float3 0 1 0) >= .ybase
                               (Float3 0 0 1) >= .zbase
+                              ;; This yields a vector named norm that is facing the same direction as the camera
                               (Float3 -1 1 -1) (Math.Cross (Float3 1 0 0)) >= .norm
 
                               (Gizmos.Line :A (Float3 0 0 0) :B (Float3 -1 1 -1) :Color (Float4 1 1 1 1) :Thickness 4)
-                              ;; (Gizmos.Disc :Center (Float3 0 0 0) :XBase (Float3 1 0 0) :YBase (Float3 0 1 0) :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.5 0.5 0.5 1.0))
 
-                              ;; (Gizmos.Disc :Center (Float3 0 0 0) :XBase .xbase :YBase .ybase :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.2 1.0 0.2 1.0))
+                              ;; This red disc renders even if back-face culling is enabled
+                              (Gizmos.Disc :Center (Float3 2 0 0) :XBase (Float3 1 0 0) :YBase (Float3 0 1 0) :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 1.0 0.2 0.2 1.0))
 
-                              ;; draws 2 rotation circles around imaginary object
-                              (Gizmos.Circle :Center (Float3 1 1 1) :XBase .xbase :YBase .ybase)
-                              ;; (Gizmos.Circle :Center (Float3 1 1 1) :XBase .zbase :YBase (Float3 -1 1 1) :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 4)
-                              (Gizmos.Circle :Center (Float3 1 1 1) :XBase .xbase :YBase .norm :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 1)
-                              ;; rect on xy plane
+                              ;; This green disc does not render if back-face culling is enabled
+                              ;;;; NOTE: This renders at the moment because addDisc has been modified to draw both sides
+                              ;;;; of the quad since avoiding backface culling has yet to be implemented
+                              (Gizmos.Disc :Center (Float3 2 0 0) :XBase .xbase :YBase .norm :OuterRadius 1.0 :InnerRadius 0.5 :Color (Float4 0.2 1.0 0.2 1.0))
 
-                              (Gizmos.Rect :Center (Float3 0 0 0) :XBase .xbase :YBase .norm :Size (Float2 1 1) :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 4)
+                              ;; This red solid rect renders even if back-face culling is enabled
+                              (Gizmos.SolidRect :Center (Float3 -2 0 2) :XBase .norm :YBase .xbase :Size (Float2 1 1) :Color (Float4 1.0 0.2 0.2 1.0))
 
-                              ;; solid rect test on xy plane
-                              ;; (Gizmos.SolidRect :Center (Float3 1 1 0) :XBase .xbase :YBase .ybase :Size (Float2 2 2) :Color (Float4 0 0.5 0 1.0))
-
-                              ;; solid disc test on xy plane
-                              ;; (Gizmos.Disc :Center (Float3 1 1 0.5) :XBase .xbase :YBase .ybase :OuterRadius 5.0 :InnerRadius 3.0 :Color (Float4 0 0 0.5 1.0))
-
+                              ;; This green solid rect does not render if back-face culling is enabled
+                              (Gizmos.SolidRect :Center (Float3 2 0 2) :XBase .xbase :YBase .norm :Size (Float2 1 1) :Color (Float4 0.2 1.0 0.2 1.0))
+                              
                               ;; imaginary object (box)
-                              (Gizmos.Box :Center (Float3 1 1 1) :Size (Float3 0.5 0.2 0.3) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 4)
-
-                              ;; dot at top right of xy rect
-                              (Gizmos.Point :Center (Float3 1.4 1.4 1) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 16)
-                              ;; dot doing idk what, its out there 
-                              (Gizmos.Point :Center (Float3 -2 -0.2 1)  :Color (Float4 1.0 0.2 1.0 1.0) :Thickness 4)))
+                              (Gizmos.Box :Center (Float3 1 1 1) :Size (Float3 0.5 0.2 0.3) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 4)))
 
     ; Draw on top of everything (ignore depth)
     ;; translation gizmo itself, attached to .translation-0
     (Gizmos.Context :Queue .editor-queue-no-depth :View .view
                     :Content (->
-                              .transform-0 (Gizmos.Translation) > .transform-0))
-
-    (Gizmos.Context :Queue .editor-queue-no-depth :View .view
-                    :Content (->
-                              .transform-0 (Gizmos.Rotation) > .transform-0))
+                              .transform-0 (Gizmos.Translation) > .transform-0
+                              (Gizmos.Rotation) > .transform-0))
 
     (GFX.Render :Steps .render-steps :View .view))))
 
 (schedule root test-wire)
-(if (run root timestep) nil (throw "Root tick failed"))
+(if (run root timestep 200) nil (throw "Root tick failed"))


### PR DESCRIPTION
This pull request adds additional functionality for ShapeRenderer to draw solid Quads and Discs (2D) and their respectively shards, as well as the RotationGizmo and its shard. Refactors Handles and its usage in TranslationGizmo.

Refer to the individual commit for comments and more details on each change to the repo in that commit.

Adjustments may need to be made in the future for the exact rotation per unit distance moved while a handle is selected.