### PR TITLE
Add ScalingGizmo

### DIFF
--- a/src/extra/gizmos/gizmos.cpp
+++ b/src/extra/gizmos/gizmos.cpp
@@ -5,6 +5,7 @@
 #include <params.hpp>
 #include <gfx/gizmos/translation_gizmo.hpp>
 #include <gfx/gizmos/rotation_gizmo.hpp>
+#include <gfx/gizmos/scaling_gizmo.hpp>
 #include <stdexcept>
 #include <type_traits>
 
@@ -19,7 +20,7 @@ struct TranslationGizmo : public Base {
     return inputTypes;
   }
   static SHTypesInfo outputTypes() { return CoreInfo::Float4x4Type; }
-  static SHOptionalString help() { return SHCCSTR("Shows a translation gizmo "); }
+  static SHOptionalString help() { return SHCCSTR("Shows a translation gizmo"); }
 
   PARAM_VAR(_scale, "Scale", "Gizmo scale", {CoreInfo::NoneType, CoreInfo::FloatType, CoreInfo::FloatVarType});
   PARAM_IMPL(TranslationGizmo, PARAM_IMPL_FOR(_scale));
@@ -91,7 +92,7 @@ struct RotationGizmo : public Base {
     return inputTypes;
   }
   static SHTypesInfo outputTypes() { return CoreInfo::Float4x4Type; }
-  static SHOptionalString help() { return SHCCSTR("Shows a rotation gizmo "); }
+  static SHOptionalString help() { return SHCCSTR("Shows a rotation gizmo"); }
 
   // declare parameter named scale
   PARAM_VAR(_scale, "Scale", "Gizmo scale", {CoreInfo::NoneType, CoreInfo::FloatType, CoreInfo::FloatVarType});
@@ -130,7 +131,84 @@ struct RotationGizmo : public Base {
       break;
     }
     default:
-      // unexpected input type
+      throw std::invalid_argument("input type");
+      break;
+    }
+
+    _gizmo.transform = inputMat;
+
+    // Scale based on screen distance
+    float3 gizmoLocation = gfx::extractTranslation(_gizmo.transform);
+    _gizmo.scale = _gizmoContext->gfxGizmoContext.renderer.getSize(gizmoLocation) * 0.3f;
+
+    _gizmoContext->gfxGizmoContext.updateGizmo(_gizmo);
+
+    // if valid applyOutputMat function, apply the new transform calculated by _gizmo to the drawable
+    if (applyOutputMat)
+      applyOutputMat(_gizmo.transform);
+
+    return reinterpret_cast<Mat4 &>(_gizmo.transform);
+  }
+
+  void warmup(SHContext *context) {
+    PARAM_WARMUP(context);
+    baseWarmup(context);
+  }
+
+  void cleanup() {
+    PARAM_CLEANUP();
+    baseCleanup();
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    gfx::composeCheckGfxThread(data);
+    return outputTypes().elements[0];
+  }
+};
+
+struct ScalingGizmo : public Base {
+  static SHTypesInfo inputTypes() {
+    static Types inputTypes = {{CoreInfo::Float4x4Type, gfx::Types::Drawable}};
+    return inputTypes;
+  }
+  static SHTypesInfo outputTypes() { return CoreInfo::Float4x4Type; }
+  static SHOptionalString help() { return SHCCSTR("Shows a scaling gizmo"); }
+
+  PARAM_VAR(_scale, "Scale", "Gizmo scale", {CoreInfo::NoneType, CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_IMPL(ScalingGizmo, PARAM_IMPL_FOR(_scale));
+
+  gfx::gizmos::ScalingGizmo _gizmo{};
+
+  SHVar activate(SHContext *shContext, const SHVar &input) {
+    float4x4 inputMat;
+    std::function<void(float4x4 & mat)> applyOutputMat;
+
+    switch (input.valueType) {
+    // if sequence given (transform matrix)
+    case SHType::Seq:
+      inputMat = (shards::Mat4)input;
+      break;
+    // if object given (drawable)
+    case SHType::Object: {
+      gfx::SHDrawable *drawable = reinterpret_cast<gfx::SHDrawable *>(input.payload.objectValue);
+      std::visit(
+          [&](auto &drawable) {
+            // let T be the type of the drawable
+            using T = std::decay_t<decltype(drawable)>;
+            // if same type as MeshTreeDrawable
+            if constexpr (std::is_same_v<T, gfx::MeshTreeDrawable::Ptr>) {
+              // get the transform matrix from drawable, and set applyOutputMat to a function that sets the transform
+              inputMat = drawable->trs.getMatrix();
+              applyOutputMat = [&](float4x4 &outMat) { drawable->trs = outMat; };
+            } else { // not sure what type this is expecting, just a type with transform member variable?
+              inputMat = drawable->transform;
+              applyOutputMat = [&](float4x4 &outMat) { drawable->transform = outMat; };
+            }
+          },
+          drawable->drawable);
+      break;
+    }
+    default:
       throw std::invalid_argument("input type");
       break;
     }
@@ -169,6 +247,7 @@ struct RotationGizmo : public Base {
 void registerGizmoShards() {
   REGISTER_SHARD("Gizmos.Translation", TranslationGizmo);
   REGISTER_SHARD("Gizmos.Rotation", RotationGizmo);
+  REGISTER_SHARD("Gizmos.Scaling", ScalingGizmo);
 }
 } // namespace Gizmos
 } // namespace shards

--- a/src/gfx/gizmos/gizmo_input.hpp
+++ b/src/gfx/gizmos/gizmo_input.hpp
@@ -30,6 +30,8 @@ struct IGizmoCallbacks {
 struct Handle {
   IGizmoCallbacks *callbacks{};
   void *userData{};
+  bool grabbed{};
+  float grabOffset{};
 };
 
 struct InputState {

--- a/src/gfx/gizmos/scaling_gizmo.hpp
+++ b/src/gfx/gizmos/scaling_gizmo.hpp
@@ -1,0 +1,231 @@
+#ifndef IDENTIFIER_TO_BE_REPLACED
+#define IDENTIFIER_TO_BE_REPLACED
+
+#include "gizmos.hpp"
+#include <gfx/linalg.hpp>
+
+namespace gfx {
+namespace gizmos {
+struct ScalingGizmo : public IGizmo, public IGizmoCallbacks {
+  float4x4 transform = linalg::identity; // load identity matrix
+
+  Handle handles[4];
+  Box handleSelectionBoxes[4];
+
+  // The sensitivities of the axes and the centered cube vary due to different methods of calculating delta.
+  // The axes utilize the delta of the ray intersection with the axis plane, whereas the centered cube relies on the delta of the
+  // cursor position.
+  const float axisSensitivity = 1.5f;
+  const float centeredCubeSensitivity = 0.003f;
+  const float4 centeredCubeColor = float4(0.3f, 0.3f, 0.3f, 1.0f);
+  float4x4 dragStartTransform;
+  float3 dragStartPoint;
+  float2 dragStartCursor;
+
+  float scale = 1.0f;
+  const float axisRadius = 0.05f;
+  const float axisLength = 0.55f;
+
+  float getGlobalAxisRadius() const { return axisRadius * scale; }
+  float getGlobalAxisLength() const { return axisLength * scale; }
+
+  ScalingGizmo() {
+    for (size_t i = 0; i < 4; i++) {
+      handles[i].userData = (void *)i;
+      handles[i].callbacks = this;
+    }
+  }
+
+  void update(InputContext &inputContext) {
+    float3x3 invTransform = linalg::inverse(extractRotationMatrix(transform));
+    float3 localRayDir = linalg::mul(invTransform, inputContext.rayDirection);
+
+    for (size_t i = 0; i < 3; i++) {
+      auto &handle = handles[i];
+      auto &selectionBox = handleSelectionBoxes[i];
+
+      float3 fwd{};
+      fwd[i] = 1.0f;
+      float3 t1 = float3(-fwd.z, -fwd.x, fwd.y);
+      float3 t2 = linalg::cross(fwd, t1);
+
+      // Slightly decrease hitbox size if view direction is parallel
+      // e.g. looking towards +z you are less likely to want to click on the z axis
+      float dotThreshold = 0.8f;
+      float angleFactor = std::max(0.0f, (linalg::abs(linalg::dot(localRayDir, fwd)) - dotThreshold) / (1.0f - dotThreshold));
+
+      // Make hitboxes slightly bigger than the actual visuals
+      const float2 hitboxScale = linalg::lerp(float2(2.2f, 1.2f), float2(0.8f, 1.0f), angleFactor);
+
+      // The size of the selection box for the axis handles is reduced to avoid overlapping with the hitbox of the centered cube.
+      selectionBox.min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x +
+                         fwd * getGlobalAxisLength() * hitboxScale.y * (angleFactor + 0.18f);
+      selectionBox.max =
+          (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y;
+
+      // The selection box of the axis handle remains unchanged during object scaling.
+      selectionBox.transform = linalg::identity;
+
+      inputContext.updateHandle(handle, intersectBox(inputContext.eyeLocation, inputContext.rayDirection, selectionBox));
+    }
+
+    // The center cube
+    {
+      auto &handle = handles[3];
+      auto &selectionBox = handleSelectionBoxes[3];
+
+      float hitbox_size = getGlobalAxisLength() * 0.2f;
+      selectionBox.min = float3(-hitbox_size, -hitbox_size, -hitbox_size);
+      selectionBox.max = float3(hitbox_size, hitbox_size, hitbox_size);
+      selectionBox.transform = linalg::identity;
+
+      inputContext.updateHandle(handle, intersectBox(inputContext.eyeLocation, inputContext.rayDirection, selectionBox));
+    }
+  }
+
+  size_t getHandleIndex(Handle &inHandle) { return size_t(inHandle.userData); }
+
+  float3 getAxisDirection(size_t index, float4x4 transform) {
+    float3 base{};
+    base[index] = 1.0f;
+    return linalg::normalize(linalg::mul(transform, float4(base, 0)).xyz());
+  }
+
+  /*
+    The centred cube is implemented as a handle with a cube-shaped selection box.
+    Its behavior draws inspiration from the scaling gizmo in Unity, where the direction of dragging determines how the object
+    scales.
+
+    Two different solutions for the centred cube were considered.
+    The first solution involved intersecting the view ray with a plane parallel to the viewport and passing through the object's
+    center. The second solution relied on the change in cursor position.
+
+    The second solution was chosen for the following reasons:
+      - The first solution proved more challenging to implement since the ray casting depended on the camera direction, which was
+    not available in the input context.
+      - The second solution offers a more intuitive reasoning as the direction of dragging is directly reflected in the cursor
+    position changes.
+  */
+  virtual void grabbed(InputContext &context, Handle &handle) {
+    handle.grabbed = true;
+    dragStartTransform = transform;
+
+    size_t index = getHandleIndex(handle);
+    SPDLOG_DEBUG("Handle {} ({}) grabbed", index, getAxisDirection(index, dragStartTransform));
+
+    if (index == 3) {
+      dragStartCursor = context.inputState.cursorPosition;
+    } else {
+      dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform),
+                                  getAxisDirection(index, dragStartTransform));
+    }
+  }
+
+  virtual void released(InputContext &context, Handle &handle) {
+    size_t index = getHandleIndex(handle);
+    if (index == 3) {
+      for (size_t i = 0; i < 3; i++) {
+        handles[i].grabbed = false;
+        handles[i].grabOffset = 0.0f;
+      }
+    } else {
+      handle.grabbed = false;
+      handle.grabOffset = 0.0f;
+    }
+    SPDLOG_DEBUG("Handle {} ({}) released", index, getAxisDirection(index, dragStartTransform));
+  }
+
+  virtual void move(InputContext &context, Handle &inHandle) {
+    size_t index = getHandleIndex(inHandle);
+    float3 fwd = getAxisDirection(index, dragStartTransform);
+
+    float3 delta;
+    float3 scaling;
+    if (index == 3) {
+      float2 hitPoint = context.inputState.cursorPosition;
+      delta = float3((hitPoint - dragStartCursor), 0);
+      for (size_t i = 0; i < 3; i++) {
+        handles[i].grabbed = true;
+        handles[i].grabOffset = centeredCubeSensitivity * delta.x;
+      }
+      // Dragging the centered cube to the right increases the object's scale, while dragging it to the left decreases the
+      // object's scale.
+      float diameter = centeredCubeSensitivity * std::abs(delta.x);
+      if (delta.x > 0) {
+        scaling = float3(1 + diameter, 1 + diameter, 1 + diameter);
+      } else {
+        scaling = float3(1 - diameter, 1 - diameter, 1 - diameter);
+      }
+    } else {
+      float3 hitPoint = hitOnPlane(context.eyeLocation, context.rayDirection, dragStartPoint, fwd);
+      delta = hitPoint - dragStartPoint;
+      handles[index].grabOffset = delta[index];
+      scaling = float3(1.0f);
+      scaling[index] = 1 + delta[index] * axisSensitivity;
+    }
+    transform = linalg::mul(linalg::scaling_matrix(scaling), dragStartTransform);
+  }
+
+  void render(InputContext &inputContext, GizmoRenderer &renderer) {
+    for (size_t i = 0; i < 3; i++) {
+      auto &handle = handles[i];
+      auto &selectionBox = handleSelectionBoxes[i];
+
+      bool hovering = inputContext.hovering && inputContext.hovering == &handle;
+
+#if 0
+      // Debug draw
+      float4 color = float4(.7, .7, .7, 1.);
+      uint32_t thickness = 1;
+      if (hovering) {
+        color = float4(.5, 1., .5, 1.);
+        thickness = 2;
+      }
+
+      auto &min = handle.selectionBox.min;
+      auto &max = handle.selectionBox.max;
+      float3 center = (max + min) / 2.0f;
+      float3 size = max - min;
+
+      renderer.getShapeRenderer().addBox(handle.selectionBoxTransform, center, size, color, thickness);
+#endif
+
+      float3 loc = extractTranslation(selectionBox.transform);
+      float3 dir = getAxisDirection(i, selectionBox.transform);
+
+      float4 cubeColor = axisColors[i];
+      cubeColor = float4(cubeColor.xyz() * (hovering ? 1.1f : 0.9f), 1.0f);
+
+      if (handles[i].grabbed) {
+        float modifiedLength = getGlobalAxisLength() + handles[i].grabOffset * 0.5f;
+
+        if (modifiedLength < 0.0f) {
+          renderer.addHandle(loc, -dir, getGlobalAxisRadius(), -modifiedLength, cubeColor, GizmoRenderer::CapType::Cube,
+                             cubeColor);
+        } else {
+          renderer.addHandle(loc, dir, getGlobalAxisRadius(), modifiedLength, cubeColor, GizmoRenderer::CapType::Cube, cubeColor);
+        }
+      } else {
+        renderer.addHandle(loc, dir, getGlobalAxisRadius(), getGlobalAxisLength(), cubeColor, GizmoRenderer::CapType::Cube,
+                           cubeColor);
+      }
+    }
+
+    // The centered cube
+    {
+      auto &handle = handles[3];
+      auto &selectionBox = handleSelectionBoxes[3];
+
+      bool hovering = inputContext.hovering && inputContext.hovering == &handle;
+
+      float3 loc = extractTranslation(selectionBox.transform);
+      float4 cubeColor = float4(centeredCubeColor.xyz() * (hovering ? 1.1f : 0.9f), 1.0f);
+
+      renderer.addCubeHandle(loc, getGlobalAxisLength() * 0.15f, cubeColor);
+    }
+  }
+};
+} // namespace gizmos
+} // namespace gfx
+
+#endif /* IDENTIFIER_TO_BE_REPLACED */

--- a/src/gfx/gizmos/shapes.cpp
+++ b/src/gfx/gizmos/shapes.cpp
@@ -418,6 +418,14 @@ void GizmoRenderer::addHandle(float3 origin, float3 direction, float radius, flo
   drawables.push_back(cap);
 }
 
+void GizmoRenderer::addCubeHandle(float3 center, float size, float4 color) {
+  MeshDrawable::Ptr drawable = std::make_shared<MeshDrawable>(cubeMesh);
+  drawable->transform = linalg::mul(linalg::translation_matrix(center), linalg::scaling_matrix(float3(size)));
+  drawable->parameters.set("baseColor", color);
+  drawable->features.push_back(gizmoLightingFeature);
+  drawables.push_back(drawable);
+}
+
 void GizmoRenderer::begin(ViewPtr view, float2 viewportSize) {
   this->view = view;
   this->viewportSize = viewportSize;

--- a/src/gfx/gizmos/shapes.hpp
+++ b/src/gfx/gizmos/shapes.hpp
@@ -104,6 +104,7 @@ public:
   enum class CapType { Cube, Arrow, Sphere };
 
   void addHandle(float3 origin, float3 direction, float radius, float length, float4 bodyColor, CapType capType, float4 capColor);
+  void addCubeHandle(float3 center, float size, float4 color);
 
   void begin(ViewPtr view, float2 viewportSize);
   void end(DrawQueuePtr queue);

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -7,7 +7,7 @@
 namespace gfx {
 namespace gizmos {
 // Note: If multiple gizmos are to be active at any time, ensure that they are created in the same Gizmos.Context
-//       This is to prevent multiple handles from different gizmos being selected at the same time, 
+//       This is to prevent multiple handles from different gizmos being selected at the same time,
 //       resulting in unexpected behaviour.
 struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
   float4x4 transform = linalg::identity;
@@ -52,16 +52,14 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       // Make hitboxes slightly bigger than the actual visuals
       const float2 hitboxScale = linalg::lerp(float2(2.2f, 1.2f), float2(0.8f, 1.0f), angleFactor);
 
-      auto &min = selectionBox.min;
-      auto &max = selectionBox.max;
-      min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
-      max =
+      selectionBox.min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
+      selectionBox.max =
           (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y;
 
       selectionBox.transform = transform;
 
-      float hitDistance = intersectBox(inputContext.eyeLocation, inputContext.rayDirection, handleSelectionBoxes[i]);
-      inputContext.updateHandle(handle, hitDistance);
+      inputContext.updateHandle(handle,
+                                intersectBox(inputContext.eyeLocation, inputContext.rayDirection, handleSelectionBoxes[i]));
     }
   }
 

--- a/src/tests/gfx-gizmos-scaling.edn
+++ b/src/tests/gfx-gizmos-scaling.edn
@@ -1,0 +1,82 @@
+(def timestep (/ 1.0 120.0))
+(defmesh root)
+(def BlendAlphaPremul {:Operation BlendOperation.Add :Src BlendFactor.One :Dst BlendFactor.OneMinusSrcAlpha})
+(def BlendOne {:Operation BlendOperation.Add :Src BlendFactor.One :Dst BlendFactor.One})
+
+(defn spin-transform [t location]
+  (->
+   t >= .tmp-0
+   .tmp-0 (Math.Multiply 0.2) (Math.AxisAngleX) (Math.Rotation) >= .rotX
+   .tmp-0 (Math.Multiply 0.7) (Math.AxisAngleY) (Math.Rotation) >= .rotY
+   .tmp-0 (Math.Multiply 0.9) (Math.AxisAngleZ) (Math.Rotation) >= .rotZ
+   location (Math.Translation) (Math.MatMul .rotX) (Math.MatMul .rotY) (Math.MatMul .rotZ)))
+
+(defloop test-wire
+  (Setup
+   0.0 >= .time
+   (GFX.BuiltinMesh :Type BuiltinMeshType.Cube) >= .mesh
+   (Float3 0 0 0) (Math.Translation) >= .transform-0
+
+   (GFX.DrawQueue) >= .queue
+   (GFX.DrawQueue) >= .editor-queue
+   (GFX.DrawQueue) >= .editor-queue-no-depth
+
+    ; Create render steps
+   (GFX.BuiltinFeature BuiltinFeatureId.Transform) >> .features
+   (GFX.BuiltinFeature BuiltinFeatureId.BaseColor) >> .features
+
+   {:Features .features :Queue .queue} (GFX.DrawablePass) >> .render-steps
+   {:Features .features
+    :Queue .editor-queue} (GFX.DrawablePass) >> .render-steps
+   {:Features .features
+    :Queue .editor-queue-no-depth
+    :Outputs [{:Name "color"}
+              {:Name "depth" :Clear true}]} (GFX.DrawablePass) >> .render-steps
+
+    ;; Create view
+   {:Position (Float3 3 3 8) :Target (Float3 0 0 0)} (Math.LookAt) >= .view-transform
+   (GFX.View :View .view-transform) >= .view)
+  (GFX.MainWindow
+   :Title "SDL Window" :Width 1280 :Height 720 :Debug false
+   :Contents
+   (->
+    .time (Math.Add timestep) > .time
+
+    .transform-0 (GFX.Drawable :Mesh .mesh :Params {:baseColor (Float4 1 0 0 1)}) >= .drawable-0
+    (GFX.Draw .queue)
+
+    ; Draw helpers (using scene depth)
+    (Gizmos.Context :Queue .editor-queue :View .view
+                    :Content (->  .drawable-0 (Gizmos.Highlight)
+                                  (Float3 0 0 0) >= .a
+                                  (Float3 0 0 2) >= .z-2
+                                  (Gizmos.Line :A (Float3 0 0 0) :B (Float3 2 0 0) :Color (Float4 1 0 0 1) :Thickness 8)
+                                  (Gizmos.Line :A .a :B (Float3 0 2 0) :Color (Float4 0 1 0 1))
+                                  (Gizmos.Line :A .a :B .z-2 :Color (Float4 0 0 1 1) :Thickness 4)
+
+                                  (Float3 1 0 0) >= .xbase
+                                  (Float3 0 1 0) >= .ybase
+                                  (Float3 0 0 1) >= .zbase
+                                  (Gizmos.Circle :Center (Float3 1 1 1) :XBase .xbase :YBase .ybase)
+                                  (Gizmos.Circle :Center (Float3 1 1 1) :XBase .zbase :YBase .ybase :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 4)
+
+                                  (Gizmos.Rect :Center (Float3 1 1 1.2) :XBase .xbase :YBase .ybase :Color (Float4 0.2 1.0 0.2 1.0) :Thickness 4)
+
+                                  (Gizmos.Box :Center (Float3 1 1 1) :Size (Float3 0.5 0.2 0.3) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 4)
+
+                                  (Gizmos.Point :Center (Float3 1.4 1.4 1) :Color (Float4 0.4 0.4 1.0 1.0) :Thickness 16)
+                                  (Gizmos.Point :Center (Float3 -2 -0.2 1)  :Color (Float4 1.0 0.2 1.0 1.0) :Thickness 4)))
+
+    ; Draw on top of everything (ignore depth)
+    ;; (Gizmos.Context :Queue .editor-queue-no-depth :View .view
+    ;;                 :Content (->
+    ;;                           .transform-0 (Gizmos.Translation) > .transform-0))
+
+    (Gizmos.Context :Queue .editor-queue-no-depth :View .view
+                    :Content (->
+                              .transform-0 (Gizmos.Scaling) > .transform-0))
+
+    (GFX.Render :Steps .render-steps :View .view))))
+
+(schedule root test-wire)
+(if (run root timestep 100) nil (throw "Root tick failed"))


### PR DESCRIPTION
**Description**

Implemented a scaling gizmo with the following behaviours:

- Dragging the axis handles scales the object in the direction of the corresponding axis.
- Dragging the centred cube scales the object uniformly in all directions.

Please refer to the code comments for a detailed explanation.

**Test plan**
To test the scaling gizmo, use the `src/tests/gfx-gizmos-scaling.edn` file.
