### PR TITLE
Add gizmo handles for object translation within a single plane

### DIFF
--- a/src/gfx/gizmos/gizmo_math.hpp
+++ b/src/gfx/gizmos/gizmo_math.hpp
@@ -30,6 +30,23 @@ inline float3 hitOnPlane(float3 eyeLocation, float3 rayDirection, float3 axisPoi
 
   return axisPoint;
 }
+
+// Intersects a view ray with a plane based on eye location
+// this is used for draging handles within a single plane
+inline float3 hitOnPlaneUnprojected(float3 eyeLocation, float3 rayDirection, float3 planePoint, float3 planeNormal) {
+  // float3 planeT0 = planeNormal;
+  // float3 planeNormal = eyeLocation - planePoint;
+  // planeNormal -= linalg::dot(planeNormal, planeT0) * planeT0;
+  // planeNormal = linalg::normalize(planeNormal);
+
+  float d;
+  if (intersectPlane(eyeLocation, rayDirection, planePoint, planeNormal, d)) {
+    return eyeLocation + d * rayDirection;
+  }
+
+  return planePoint;
+}
+
 } // namespace gizmos
 } // namespace gfx
 

--- a/src/gfx/gizmos/gizmo_math.hpp
+++ b/src/gfx/gizmos/gizmo_math.hpp
@@ -34,11 +34,6 @@ inline float3 hitOnPlane(float3 eyeLocation, float3 rayDirection, float3 axisPoi
 // Intersects a view ray with a plane based on eye location
 // this is used for draging handles within a single plane
 inline float3 hitOnPlaneUnprojected(float3 eyeLocation, float3 rayDirection, float3 planePoint, float3 planeNormal) {
-  // float3 planeT0 = planeNormal;
-  // float3 planeNormal = eyeLocation - planePoint;
-  // planeNormal -= linalg::dot(planeNormal, planeT0) * planeT0;
-  // planeNormal = linalg::normalize(planeNormal);
-
   float d;
   if (intersectPlane(eyeLocation, rayDirection, planePoint, planeNormal, d)) {
     return eyeLocation + d * rayDirection;

--- a/src/gfx/gizmos/shapes.cpp
+++ b/src/gfx/gizmos/shapes.cpp
@@ -263,7 +263,26 @@ void ShapeRenderer::addPoint(float3 center, float4 color, uint32_t thickness) {
   }
 }
 
-void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, uint32_t thickness) {}
+void ShapeRenderer::addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, uint32_t thickness) {
+  float2 halfSize = size / 2.0f;
+  float3 verts[] = {
+      center - halfSize.x * xBase - halfSize.y * yBase,
+      center + halfSize.x * xBase - halfSize.y * yBase,
+      center + halfSize.x * xBase + halfSize.y * yBase,
+      center - halfSize.x * xBase + halfSize.y * yBase,
+  };
+
+  addSolidQuad(verts[0], verts[1], verts[2], verts[3], color);
+}
+
+void ShapeRenderer::addSolidQuad(float3 a, float3 b, float3 c, float3 d, float4 color) {
+  solidVertices.push_back(SolidVertex{.position = UNPACK3(a), .color = UNPACK4(color)});
+  solidVertices.push_back(SolidVertex{.position = UNPACK3(b), .color = UNPACK4(color)});
+  solidVertices.push_back(SolidVertex{.position = UNPACK3(c), .color = UNPACK4(color)});
+  solidVertices.push_back(SolidVertex{.position = UNPACK3(d), .color = UNPACK4(color)});
+  solidVertices.push_back(SolidVertex{.position = UNPACK3(a), .color = UNPACK4(color)});
+  solidVertices.push_back(SolidVertex{.position = UNPACK3(c), .color = UNPACK4(color)});
+}
 
 void ShapeRenderer::begin() {
   lineVertices.clear();

--- a/src/gfx/gizmos/shapes.hpp
+++ b/src/gfx/gizmos/shapes.hpp
@@ -61,6 +61,7 @@ public:
   void addPoint(float3 center, float4 color, uint32_t thickness);
 
   void addSolidRect(float3 center, float3 xBase, float3 yBase, float2 size, float4 color, uint32_t thickness);
+  void addSolidQuad(float3 a, float3 b, float3 c, float3 d, float4 color);
 
   void begin();
   void end(DrawQueuePtr queue);

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -109,7 +109,6 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
           dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(1, dragStartTransform));
           break;
       }
-      SPDLOG_DEBUG("Drag start point: {}", dragStartPoint);
     }
   }
 
@@ -129,7 +128,20 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
     delta = linalg::dot(delta, fwd) * fwd;
     transform = linalg::mul(linalg::translation_matrix(delta), dragStartTransform);
     } else {
-      // TODO
+      float3 hitPoint;
+      switch (index) {
+        case 3:
+          hitPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(2, dragStartTransform));
+          break;
+        case 4:
+          hitPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(0, dragStartTransform));
+          break;
+        case 5:
+          hitPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(1, dragStartTransform));
+          break;
+      }
+      float3 delta = hitPoint - dragStartPoint;
+      transform = linalg::mul(linalg::translation_matrix(delta), dragStartTransform);
     }
   }
 

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -184,7 +184,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
         float3 center;
         float3 xBase;
         float3 yBase;
-        float2 size = float2(0.15f, 0.15f);
+        float2 size = float2(getGlobalAxisLength() * 0.3f, getGlobalAxisLength() * 0.3f);
         float4 color;
         switch (i) {
           case 3:

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -50,11 +50,11 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       auto &min = handle.selectionBox.min;
       auto &max = handle.selectionBox.max;
       if (i < 3) {
-      min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.6f;
-      max =
-          (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.8f;
+        // The size of the selection box for the axis handles is reduced to avoid overlapping with the hitboxes of the plane handles
+        min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.6f;
+        max =
+            (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.8f;
       } else {
-        // TODO
         float hitboxSize = 0.15f;
         float hitboxThickness = 0.05f;
         switch (i) {
@@ -97,15 +97,17 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
     dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform),
                                 getAxisDirection(index, dragStartTransform));
     } else {
-      // TODO
       switch (index) {
         case 3:
+          // Intersects a view ray with the xy-plane
           dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(2, dragStartTransform));
           break;
         case 4:
+          // Intersects a view ray with the yz-plane
           dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(0, dragStartTransform));
           break;
         case 5:
+          // Intersects a view ray with the xz-plane
           dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(1, dragStartTransform));
           break;
       }
@@ -131,12 +133,15 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       float3 hitPoint;
       switch (index) {
         case 3:
+          // Intersects a view ray with the xy-plane
           hitPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(2, dragStartTransform));
           break;
         case 4:
+          // Intersects a view ray with the yz-plane
           hitPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(0, dragStartTransform));
           break;
         case 5:
+          // Intersects a view ray with the xz-plane
           hitPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(1, dragStartTransform));
           break;
       }
@@ -151,7 +156,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
 
       bool hovering = inputContext.hovering && inputContext.hovering == &handle;
 
-// #if 0
+#if 0
       // Debug draw
       float4 color = float4(.7, .7, .7, 1.);
       uint32_t thickness = 1;
@@ -166,15 +171,15 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       float3 size = max - min;
 
       renderer.getShapeRenderer().addBox(handle.selectionBoxTransform, center, size, color, thickness);
-// #endif
+#endif
 
       float3 loc = extractTranslation(handle.selectionBoxTransform);
       float3 dir = getAxisDirection(i, handle.selectionBoxTransform);
       float4 axisColor = axisColors[i];
       axisColor = float4(axisColor.xyz() * (hovering ? 1.1f : 0.9f), 1.0f);
       if (i < 3) {
-      renderer.addHandle(loc, dir, getGlobalAxisRadius(), getGlobalAxisLength(), axisColor, GizmoRenderer::CapType::Arrow,
-                         axisColor);
+        renderer.addHandle(loc, dir, getGlobalAxisRadius(), getGlobalAxisLength(), axisColor, GizmoRenderer::CapType::Arrow,
+                          axisColor);
       } else {
         float3 center;
         float3 xBase;

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -127,30 +127,34 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
                          axisColor);
       } else {
         // TODO
+        float3 center;
         float3 xBase;
         float3 yBase;
         float2 size = float2(0.15f, 0.15f);
-        
-        // float3 center = loc + float3(size.x / 2, size.y / 2, 0.0f);
-        float3 center;
+        float4 color;
         switch (i) {
           case 3:
+            // handle on the xy-plane
             xBase = float3(1.0f, 0.0f, 0.0f);
             yBase = float3(0.0f, 1.0f, 0.0f);
             center = loc + float3(size.x / 2, size.y / 2, 0.0f);
+            color = float4(axisColors[2].xyz() * (hovering ? 1.1f : 0.9f), 0.8f);
             break;
           case 4:
+            // handle on the yz-plane
             xBase = float3(0.0f, 1.0f, 0.0f);
             yBase = float3(0.0f, 0.0f, 1.0f);
             center = loc + float3(0.0f, size.x / 2, size.y / 2);
+            color = float4(axisColors[0].xyz() * (hovering ? 1.1f : 0.9f), 0.8f);
             break;
           case 5:
+            // handle on the xz-plane
             xBase = float3(0.0f, 0.0f, 1.0f);
             yBase = float3(1.0f, 0.0f, 0.0f);
             center = loc + float3(size.y / 2, 0.0f, size.x / 2);
+            color = float4(axisColors[1].xyz() * (hovering ? 1.1f : 0.9f), 0.8f);
             break;
         }
-        float4 color = float4(1.0f, 1.0f, 1.0f, 1.0f);
         uint32_t thickness = 1;
         renderer.getShapeRenderer().addSolidRect(center, xBase, yBase, size, color, thickness);
       }

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -55,8 +55,8 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
         max =
             (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.8f;
       } else {
-        float hitboxSize = 0.15f;
-        float hitboxThickness = 0.05f;
+        float hitboxSize = getGlobalAxisLength() * 0.3f;
+        float hitboxThickness = getGlobalAxisLength() * 0.1f;
         switch (i) {
           case 3:
             min = float3(0, 0, hitboxThickness);
@@ -156,7 +156,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
 
       bool hovering = inputContext.hovering && inputContext.hovering == &handle;
 
-#if 0
+// #if 0
       // Debug draw
       float4 color = float4(.7, .7, .7, 1.);
       uint32_t thickness = 1;
@@ -171,7 +171,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       float3 size = max - min;
 
       renderer.getShapeRenderer().addBox(handle.selectionBoxTransform, center, size, color, thickness);
-#endif
+// #endif
 
       float3 loc = extractTranslation(handle.selectionBoxTransform);
       float3 dir = getAxisDirection(i, handle.selectionBoxTransform);

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -50,11 +50,27 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       auto &min = handle.selectionBox.min;
       auto &max = handle.selectionBox.max;
       if (i < 3) {
-      min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x;
+      min = (-t1 * getGlobalAxisRadius() - t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.6f;
       max =
-          (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y;
+          (t1 * getGlobalAxisRadius() + t2 * getGlobalAxisRadius()) * hitboxScale.x + fwd * getGlobalAxisLength() * hitboxScale.y * 0.8f;
       } else {
         // TODO
+        float hitboxSize = 0.15f;
+        float hitboxThickness = 0.05f;
+        switch (i) {
+          case 3:
+            min = float3(0, 0, hitboxThickness);
+            max = float3(hitboxSize, hitboxSize, -hitboxThickness);
+            break;
+          case 4:
+            min = float3(-hitboxThickness, 0, hitboxSize);
+            max = float3(hitboxThickness, hitboxSize, 0);
+            break;
+          case 5:
+            min = float3(0, -hitboxThickness, hitboxSize);
+            max = float3(hitboxSize, hitboxThickness, 0);
+            break;
+        }
       }
 
       handle.selectionBoxTransform = transform;
@@ -101,7 +117,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
 
       bool hovering = inputContext.hovering && inputContext.hovering == &handle;
 
-#if 0
+// #if 0
       // Debug draw
       float4 color = float4(.7, .7, .7, 1.);
       uint32_t thickness = 1;
@@ -116,7 +132,7 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       float3 size = max - min;
 
       renderer.getShapeRenderer().addBox(handle.selectionBoxTransform, center, size, color, thickness);
-#endif
+// #endif
 
       float3 loc = extractTranslation(handle.selectionBoxTransform);
       float3 dir = getAxisDirection(i, handle.selectionBoxTransform);

--- a/src/gfx/gizmos/translation_gizmo.hpp
+++ b/src/gfx/gizmos/translation_gizmo.hpp
@@ -93,8 +93,24 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
     size_t index = getHandleIndex(handle);
     SPDLOG_DEBUG("Handle {} ({}) grabbed", index, getAxisDirection(index, dragStartTransform));
 
+    if (index < 3) {
     dragStartPoint = hitOnPlane(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform),
                                 getAxisDirection(index, dragStartTransform));
+    } else {
+      // TODO
+      switch (index) {
+        case 3:
+          dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(2, dragStartTransform));
+          break;
+        case 4:
+          dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(0, dragStartTransform));
+          break;
+        case 5:
+          dragStartPoint = hitOnPlaneUnprojected(context.eyeLocation, context.rayDirection, extractTranslation(dragStartTransform), getAxisDirection(1, dragStartTransform));
+          break;
+      }
+      SPDLOG_DEBUG("Drag start point: {}", dragStartPoint);
+    }
   }
 
   virtual void released(InputContext &context, Handle &handle) {
@@ -103,12 +119,18 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
   }
 
   virtual void move(InputContext &context, Handle &inHandle) {
+    size_t index = getHandleIndex(inHandle);
     float3 fwd = getAxisDirection(getHandleIndex(inHandle), dragStartTransform);
+    
+    if (index < 3) {
     float3 hitPoint = hitOnPlane(context.eyeLocation, context.rayDirection, dragStartPoint, fwd);
 
     float3 delta = hitPoint - dragStartPoint;
     delta = linalg::dot(delta, fwd) * fwd;
     transform = linalg::mul(linalg::translation_matrix(delta), dragStartTransform);
+    } else {
+      // TODO
+    }
   }
 
   void render(InputContext &inputContext, GizmoRenderer &renderer) {
@@ -142,7 +164,6 @@ struct TranslationGizmo : public IGizmo, public IGizmoCallbacks {
       renderer.addHandle(loc, dir, getGlobalAxisRadius(), getGlobalAxisLength(), axisColor, GizmoRenderer::CapType::Arrow,
                          axisColor);
       } else {
-        // TODO
         float3 center;
         float3 xBase;
         float3 yBase;


### PR DESCRIPTION
**Description**

Implemented three additional handles to the translation gizmo. Dragging the handles can move the object freely within a single plane (xy-plane, yz-plane or xz-plane).

**Test plan**
To test the translation gizmo, use the `src/tests/gfx-gizmos.edn` file.
