### PR TITLE
Fix DragAndDrop ID, response, highlight, and add Selectable shard

### DIFF
--- a/docs/samples/shards/UI/Selectable/1.shs
+++ b/docs/samples/shards/UI/Selectable/1.shs
@@ -1,0 +1,53 @@
+@template(is-selected [idx] {
+  currently-selected | Is(idx)
+})
+
+@template(select [idx] {
+  idx > currently-selected | Log
+})
+
+GFX.MainWindow(
+  Contents: {
+    Once({
+      GFX.DrawQueue >= ui-draw-queue
+      GFX.UIPass(ui-draw-queue) >> render-steps
+      1 >= currently-selected
+      "" >= currently-selected-str
+    })
+    UI(
+      ui-draw-queue
+      UI.CentralPanel(
+        Contents: {
+          UI.Selectable(
+            Contents: { UI.Button("Select Button 1" { "Select Button 1 Clicked" | Log }) }
+            IsSelected: { @is-selected(1) }
+            Clicked: { @select(1) }
+          )
+          UI.Selectable(
+            Contents: { 
+              UI.Frame(
+                InnerMargin: @f4(10) OuterMargin: @f4(0) Rounding: @f4(5)
+                FillColor: @color(40 40 40)
+                StrokeColor: @color(90 90 32) StrokeWidth: 2.0
+                Contents: {
+                  UI.Button("Select Button 2" { "Select Button 2 Clicked" | Log })
+                  "Another part of the same selectable as Select Button 2" | UI.Label(Wrap: true)
+                }
+              )
+            }
+            IsSelected: { @is-selected(2) }
+            Clicked: { @select(2) }
+          )
+
+          currently-selected | ToString > currently-selected-str
+          [
+            "Currently selected: "
+            currently-selected-str
+          ] | String.Join | UI.Label
+        }
+      )
+    )
+
+    GFX.Render(Steps: render-steps)
+  }
+)

--- a/docs/samples/shards/UI/Selectable/1.shs
+++ b/docs/samples/shards/UI/Selectable/1.shs
@@ -25,15 +25,8 @@ GFX.MainWindow(
           )
           UI.Selectable(
             Contents: { 
-              UI.Frame(
-                InnerMargin: @f4(10) OuterMargin: @f4(0) Rounding: @f4(5)
-                FillColor: @color(40 40 40)
-                StrokeColor: @color(90 90 32) StrokeWidth: 2.0
-                Contents: {
-                  UI.Button("Select Button 2" { "Select Button 2 Clicked" | Log })
-                  "Another part of the same selectable as Select Button 2" | UI.Label(Wrap: true)
-                }
-              )
+              UI.Button("Select Button 2" { "Select Button 2 Clicked" | Log })
+              "Another part of the same selectable as Select Button 2" | UI.Label(Wrap: true)
             }
             IsSelected: { @is-selected(2) }
             Clicked: { @select(2) }

--- a/shards/egui/src/containers/mod.rs
+++ b/shards/egui/src/containers/mod.rs
@@ -161,15 +161,17 @@ struct CentralPanel {
 mod area;
 mod docking;
 mod panels;
-mod scope;
-mod window;
 mod popup_wrapper;
+mod scope;
+mod selectable;
+mod window;
 
 pub fn register_shards() {
   area::register_shards();
   docking::register_shards();
   window::register_shards();
   popup_wrapper::register_shards();
+  selectable::register_shards();
   register_enum::<PopupLocation>();
   register_legacy_shard::<Scope>();
   register_legacy_enum(FRAG_CC, WindowFlagsCC, WindowFlagsEnumInfo.as_ref().into());

--- a/shards/egui/src/containers/selectable.rs
+++ b/shards/egui/src/containers/selectable.rs
@@ -3,6 +3,7 @@ use crate::CONTEXTS_NAME;
 use crate::PARENTS_UI_NAME;
 use egui::Frame;
 use egui::Rgba;
+use egui::Stroke;
 use shards::core::register_shard;
 use shards::shard::Shard;
 use shards::types::BOOL_TYPES;
@@ -119,15 +120,22 @@ impl Shard for Selectable {
     }
     let is_selected: bool = (&is_selected_var).try_into().unwrap();
 
+    let style = ui.visuals().widgets.active;
     // Draw frame as either white or gray, depending on whether the contents are selected
-    let fill = if is_selected {
-      Rgba::WHITE
+    let stroke = if is_selected {
+      Stroke {
+        color: Rgba::WHITE.into(),
+        ..style.bg_stroke
+      }
     } else {
-      Rgba::from_gray(0.2)
+      Stroke {
+        color: Rgba::from_gray(0.2).into(),
+        ..style.bg_stroke
+      }
     };
 
     // Draw frame and contents
-    let inner_response = Frame::group(ui.style()).fill(fill.into()).show(ui, |ui| {
+    let inner_response = Frame::group(ui.style()).stroke(stroke).show(ui, |ui| {
       util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
     });
     // Check for errors

--- a/shards/egui/src/containers/selectable.rs
+++ b/shards/egui/src/containers/selectable.rs
@@ -1,16 +1,8 @@
 use crate::util;
-use crate::Context as UIContext;
-use crate::EguiId;
 use crate::CONTEXTS_NAME;
 use crate::PARENTS_UI_NAME;
-use egui::epaint;
 use egui::Frame;
-use egui::InnerResponse;
-use egui::Rect;
 use egui::Rgba;
-use egui::Shape;
-use egui::Stroke;
-use egui::Vec2;
 use shards::core::register_shard;
 use shards::shard::Shard;
 use shards::types::BOOL_TYPES;
@@ -143,10 +135,7 @@ impl Shard for Selectable {
     let response = inner_response.response;
 
     // Resolve Clicked
-    if ui.input(|i| {
-      i.pointer.primary_clicked()
-    }) && response.hovered() 
-    {
+    if ui.input(|i| i.pointer.primary_clicked()) && response.hovered() {
       let mut _unused = Var::default();
       if self
         .clicked_callback

--- a/shards/egui/src/containers/selectable.rs
+++ b/shards/egui/src/containers/selectable.rs
@@ -1,0 +1,167 @@
+use crate::util;
+use crate::Context as UIContext;
+use crate::EguiId;
+use crate::CONTEXTS_NAME;
+use crate::PARENTS_UI_NAME;
+use egui::epaint;
+use egui::Frame;
+use egui::InnerResponse;
+use egui::Rect;
+use egui::Rgba;
+use egui::Shape;
+use egui::Stroke;
+use egui::Vec2;
+use shards::core::register_shard;
+use shards::shard::Shard;
+use shards::types::BOOL_TYPES;
+use shards::types::*;
+
+#[derive(shards::shard)]
+#[shard_info(
+  "UI.Selectable",
+  "A wrapper that detects selection over the provided contents."
+)]
+struct Selectable {
+  #[shard_param(
+    "Contents",
+    "The UI contents to wrap, contain, and detect for selection.",
+    SHARDS_OR_NONE_TYPES
+  )]
+  contents: ShardsVar,
+  #[shard_param(
+    "IsSelected",
+    "Callback function for checking if the contents are currently selected.",
+    SHARDS_OR_NONE_TYPES
+  )]
+  is_selected_callback: ShardsVar,
+  #[shard_param(
+    "Clicked",
+    "Callback function for the contents of this shard is clicked.",
+    SHARDS_OR_NONE_TYPES
+  )]
+  clicked_callback: ShardsVar,
+  #[shard_warmup]
+  contexts: ParamVar,
+  #[shard_warmup]
+  parents: ParamVar,
+  #[shard_required]
+  required: ExposedTypes,
+  inner_exposed: ExposedTypes,
+}
+
+impl Default for Selectable {
+  fn default() -> Self {
+    Self {
+      contents: ShardsVar::default(),
+      is_selected_callback: ShardsVar::default(),
+      clicked_callback: ShardsVar::default(),
+      contexts: ParamVar::new_named(CONTEXTS_NAME),
+      parents: ParamVar::new_named(PARENTS_UI_NAME),
+      required: ExposedTypes::new(),
+      inner_exposed: ExposedTypes::new(),
+    }
+  }
+}
+
+#[shard_impl]
+impl Shard for Selectable {
+  fn input_types(&mut self) -> &Types {
+    &ANY_TYPES
+  }
+  fn output_types(&mut self) -> &Types {
+    &BOOL_TYPES
+  }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+
+    if self.contents.is_empty() {
+      return Err("Contents are required");
+    }
+
+    let contents_composed = self.contents.compose(data)?;
+    shards::util::merge_exposed_types(&mut self.inner_exposed, &contents_composed.exposedInfo);
+    shards::util::merge_exposed_types(&mut self.required, &contents_composed.requiredInfo);
+
+    let clicked_data = shards::SHInstanceData {
+      inputType: common_type::any,
+      ..*data
+    };
+    self.clicked_callback.compose(&clicked_data)?;
+    shards::util::require_shards_contents(&mut self.required, &self.clicked_callback);
+
+    let is_selected_data = shards::SHInstanceData {
+      inputType: common_type::any,
+      ..*data
+    };
+    let cr = self.is_selected_callback.compose(&is_selected_data)?;
+    if cr.outputType != common_type::bool {
+      return Err("IsSelected should return a boolean");
+    }
+    shards::util::require_shards_contents(&mut self.required, &self.is_selected_callback);
+
+    Ok(contents_composed.outputType)
+  }
+  fn warmup(&mut self, context: &Context) -> Result<(), &str> {
+    self.warmup_helper(context)?;
+    Ok(())
+  }
+  fn cleanup(&mut self) -> Result<(), &str> {
+    self.cleanup_helper()?;
+    Ok(())
+  }
+  fn exposed_variables(&mut self) -> Option<&ExposedTypes> {
+    Some(&self.inner_exposed)
+  }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Var, &str> {
+    let ui = util::get_parent_ui(self.parents.get())?;
+    let ui_ctx = util::get_current_context(&self.contexts)?;
+
+    // Resolve IsSelected
+    let mut is_selected_var = Var::default();
+    if self
+      .is_selected_callback
+      .activate(context, &input, &mut is_selected_var)
+      == WireState::Error
+    {
+      return Err("IsSelected callback failed");
+    }
+    let is_selected: bool = (&is_selected_var).try_into().unwrap();
+
+    // Draw frame as either white or gray, depending on whether the contents are selected
+    let fill = if is_selected {
+      Rgba::WHITE
+    } else {
+      Rgba::from_gray(0.2)
+    };
+
+    // Draw frame and contents
+    let inner_response = Frame::group(ui.style()).fill(fill.into()).show(ui, |ui| {
+      util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
+    });
+    // Check for errors
+    inner_response.inner?;
+    let response = inner_response.response;
+
+    // Resolve Clicked
+    if ui.input(|i| {
+      i.pointer.primary_clicked()
+    }) && response.hovered() 
+    {
+      let mut _unused = Var::default();
+      if self
+        .clicked_callback
+        .activate(context, &input, &mut _unused)
+        == WireState::Error
+      {
+        return Err("Clicked callback failed");
+      }
+    }
+
+    // Outputs whether the contents are selected or not
+    Ok(is_selected.into())
+  }
+}
+
+pub fn register_shards() {
+  register_shard::<Selectable>();
+}

--- a/shards/egui/src/dnd/mod.rs
+++ b/shards/egui/src/dnd/mod.rs
@@ -31,11 +31,10 @@ pub fn drag_source<R>(
     is_dropped || ui.output(|x| x.cursor_icon == egui::CursorIcon::NotAllowed);
 
   if !is_being_dragged {
-    let inner = ui.scope(body);
-    let response = &inner.response;
+    let rect = ui.available_rect_before_wrap();
 
     // Check for drags:
-    let response = ui.interact(response.rect, id, egui::Sense::drag());
+    let response = ui.interact(rect, id, egui::Sense::drag());
     if response.hovered() && !cursor_already_set {
       ui.ctx().set_cursor_icon(egui::CursorIcon::Grab);
     }
@@ -45,11 +44,13 @@ pub fn drag_source<R>(
       ctx.dnd_value.borrow_mut().assign(payload);
     }
 
+    let inner = ui.scope(body);
+
     inner
   } else {
     if !cursor_already_set {
       ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
-    } 
+    }
 
     // Paint the body to a new layer:
     let layer_id = egui::LayerId::new(egui::Order::Tooltip, id);

--- a/shards/egui/src/dnd/mod.rs
+++ b/shards/egui/src/dnd/mod.rs
@@ -75,6 +75,7 @@ pub fn drag_source<R>(
 
 pub fn drop_target<R>(
   ui: &mut egui::Ui,
+  ctx: &UIContext,
   can_accept_what_is_being_dragged: bool,
   body: impl FnOnce(&mut egui::Ui) -> R,
 ) -> InnerResponse<R> {
@@ -96,7 +97,7 @@ pub fn drop_target<R>(
     ui.visuals().widgets.inactive
   };
 
-  if is_being_dragged {
+  if is_being_dragged && !ctx.dnd_value.borrow().0.is_none() {
     let style = ui.visuals().widgets.active;
     let mut fill: Rgba = style.bg_fill.into();
     let mut stroke_color = style.bg_stroke.color.into();
@@ -280,7 +281,7 @@ impl Shard for DragDrop {
         true
       };
 
-      let inner = drop_target(ui, accepts_value, |ui| {
+      let inner = drop_target(ui, ui_ctx, accepts_value, |ui| {
         util::activate_ui_contents(context, input, ui, &mut self.parents, &mut self.contents)
       });
 


### PR DESCRIPTION
- Add custom ID parameter to drag and drop
- Change drag and drop to use the area of the whole layout it is in instead of its size in the previous frame (due to issue regarding unknown placement of next widget at cursor position)
- Fix drag and drop target rendering highlight when no drag and drop source is being dragged (but something else is being dragged. e.g. window)
- Add selectable shard (with white and grey frames for selected/not-selected states respectively)