### PR TITLE
refactor(core): optimize destroyVar and _destroyVarSlow

### DIFF
--- a/deps/sqlite/sqlite-vec-static/sqlite-vec.h
+++ b/deps/sqlite/sqlite-vec-static/sqlite-vec.h
@@ -3,6 +3,16 @@
 
 #include "sqlite3ext.h"
 
+#ifdef SQLITE_VEC_STATIC
+#define SQLITE_VEC_API
+#else
+#ifdef _WIN32
+#define SQLITE_VEC_API __declspec(dllexport)
+#else
+#define SQLITE_VEC_API
+#endif
+#endif
+
 #define SQLITE_VEC_VERSION "v0.1shards"
 #define SQLITE_VEC_DATE ""
 #define SQLITE_VEC_SOURCE ""
@@ -23,9 +33,8 @@ __declspec(dllexport)
 int sqlite3_vec_fs_read_init(sqlite3 *db, char **pzErrMsg,
                           const sqlite3_api_routines *pApi);
 
-
 #ifdef __cplusplus
-}  /* end of the 'extern "C"' block */
+} /* end of the 'extern "C"' block */
 #endif
 
 #endif /* ifndef SQLITE_VEC_H */

--- a/docker/benchmarking/Dockerfile
+++ b/docker/benchmarking/Dockerfile
@@ -1,9 +1,9 @@
 # --- BASE STAGE ---
-FROM ubuntu:latest
+FROM debian:latest as base
 
-# Update and install dependencies
+# Installing dependencies
 RUN apt-get update -y && \
-    apt-get install -y gnupg git cmake pkg-config libssl-dev build-essential clang libclang-dev curl protobuf-compiler wget ninja-build xorg-dev libdbus-1-dev lcov mesa-utils lld linux-tools-generic valgrind ca-certificates && \
+    apt-get install -y git cmake pkg-config libssl-dev build-essential clang libclang-dev curl protobuf-compiler wget ninja-build xorg-dev libdbus-1-dev lcov mesa-utils lld linux-perf valgrind && \
     rm -rf /var/lib/apt/lists/*
 
 # Setting up Rust environment
@@ -25,8 +25,7 @@ RUN rustup --version && cargo --version && rustc --version
 # Cloning shards repository with submodules
 RUN git clone --recursive https://github.com/fragcolor-xyz/shards.git /shards
 
-# Update CA certificates
-RUN update-ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 
 # Updating shards with specified version
 RUN cd /shards && \

--- a/include/shards/math_ops.hpp
+++ b/include/shards/math_ops.hpp
@@ -208,6 +208,11 @@ template <> struct enum_range<shards::Math::DispatchType> {
 namespace shards::Math {
 constexpr bool hasDispatchType(DispatchType a, DispatchType b) { return (uint8_t(a) & uint8_t(b)) != 0; }
 
+[[noreturn]] inline __attribute__((noinline)) void throwDispatchError(SHType type, int dispatchType) {
+  throw std::out_of_range(fmt::format(
+      "dispatchType<{}>({})", magic_enum::enum_flags_name(static_cast<DispatchType>(dispatchType)), magic_enum::enum_name(type)));
+}
+
 template <DispatchType DispatchType, typename T, typename... TArgs> void dispatchType(SHType type, T v, TArgs &&...args) {
   switch (type) {
   case SHType::Int:
@@ -261,8 +266,7 @@ template <DispatchType DispatchType, typename T, typename... TArgs> void dispatc
   default:
     break;
   }
-  throw std::out_of_range(
-      fmt::format("dispatchType<{}>({})", magic_enum::enum_flags_name(DispatchType), magic_enum::enum_name(type)));
+  throwDispatchError(type, static_cast<int>(DispatchType));
 }
 
 struct ModOp final {

--- a/shards/egui/src/util.rs
+++ b/shards/egui/src/util.rs
@@ -129,6 +129,7 @@ where
   with_object_var(stack_var, object, object_type, inner)
 }
 
+#[inline(always)]
 pub fn activate_ui_contents(
   context: &Context,
   input: &Var,

--- a/shards/modules/core/inlined.cpp
+++ b/shards/modules/core/inlined.cpp
@@ -77,8 +77,6 @@ ALWAYS_INLINE bool SHARDS_MODULE_FN(setInlineShardId)(Shard *shard, std::string_
     shard->inlineShardId = InlineShard::MathLShift;
   } else if (name == "Math.RShift") {
     shard->inlineShardId = InlineShard::MathRShift;
-  } else if (name == "Memoize") {
-    shard->inlineShardId = InlineShard::CoreMemoize;
   }
   return shard->inlineShardId != 0;
 }
@@ -216,10 +214,6 @@ ALWAYS_INLINE bool SHARDS_MODULE_FN(activateShardInline)(Shard *blk, SHContext *
     auto shard = reinterpret_cast<Math::RShiftRuntime *>(blk);
     output = shard->core.activate(context, input);
   } break;
-  case InlineShard::CoreMemoize: {
-    auto shard = reinterpret_cast<shards::ShardWrapper<Memoize> *>(blk);
-    output = shard->shard.activate(context, input);
-  }
   default:
     return false;
   }

--- a/shards/modules/network/network_kcp.cpp
+++ b/shards/modules/network/network_kcp.cpp
@@ -436,7 +436,9 @@ struct ServerShard : public NetworkBase {
     auto endpointInfo = ExposedInfo::Variable("Network.Peer", SHCCSTR("The active peer."), Types::Peer);
     _sharedCopy.push_back(endpointInfo);
 
-    return NetworkBase::compose(data);
+    NetworkBase::compose(data);
+
+    return Types::Server;
   }
 
   void gcWires(SHContext *context) {

--- a/shards/modules/network/network_ws.cpp
+++ b/shards/modules/network/network_ws.cpp
@@ -73,7 +73,6 @@ struct WSPeer : public Peer {
   void send(boost::span<const uint8_t> data) override { pollnet_send_binary(ctx, socket, data.data(), data.size()); }
   bool disconnected() const override { return disconnected_; }
 };
-
 struct WSHandler : public WSPeer {
   entt::connection onStopConnection;
   std::shared_ptr<SHWire> wire;
@@ -178,14 +177,10 @@ struct WSServerShard {
   WSServerShard() : _composer(*this) {}
 
   std::string _serverDebugName;
-
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
     _mesh = context->main->mesh.lock();
-
     _serverVarRef = referenceVariable(context, "Network.Server");
-    assignVariableValue(*_serverVarRef, Var::Object(_server.get(), CoreCC, ServerCC));
-
     _peerVarRef = referenceVariable(context, "Network.Peer");
   }
 

--- a/shards/modules/network/network_ws.cpp
+++ b/shards/modules/network/network_ws.cpp
@@ -73,6 +73,7 @@ struct WSPeer : public Peer {
   void send(boost::span<const uint8_t> data) override { pollnet_send_binary(ctx, socket, data.data(), data.size()); }
   bool disconnected() const override { return disconnected_; }
 };
+
 struct WSHandler : public WSPeer {
   entt::connection onStopConnection;
   std::shared_ptr<SHWire> wire;
@@ -177,10 +178,14 @@ struct WSServerShard {
   WSServerShard() : _composer(*this) {}
 
   std::string _serverDebugName;
+
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
     _mesh = context->main->mesh.lock();
+
     _serverVarRef = referenceVariable(context, "Network.Server");
+    assignVariableValue(*_serverVarRef, Var::Object(_server.get(), CoreCC, ServerCC));
+
     _peerVarRef = referenceVariable(context, "Network.Peer");
   }
 

--- a/shards/rust/src/core.rs
+++ b/shards/rust/src/core.rs
@@ -153,7 +153,7 @@ pub fn init() {
 #[inline(always)]
 pub fn sleep(seconds: f64) {
   unsafe {
-    (*Core).sleep.unwrap()(seconds);
+    (*Core).sleep.unwrap_unchecked()(seconds);
   }
 }
 
@@ -161,7 +161,7 @@ pub fn sleep(seconds: f64) {
 pub fn step_count(context: &SHContext) -> u64 {
   unsafe {
     let ctx = context as *const SHContext as *mut SHContext;
-    (*Core).getStepCount.unwrap()(ctx)
+    (*Core).getStepCount.unwrap_unchecked()(ctx)
   }
 }
 
@@ -169,7 +169,7 @@ pub fn step_count(context: &SHContext) -> u64 {
 pub fn suspend(context: &SHContext, seconds: f64) -> WireState {
   unsafe {
     let ctx = context as *const SHContext as *mut SHContext;
-    (*Core).suspend.unwrap()(ctx, seconds).into()
+    (*Core).suspend.unwrap_unchecked()(ctx, seconds).into()
   }
 }
 
@@ -177,7 +177,7 @@ pub fn suspend(context: &SHContext, seconds: f64) -> WireState {
 pub fn getState(context: &SHContext) -> WireState {
   unsafe {
     let ctx = context as *const SHContext as *mut SHContext;
-    (*Core).getState.unwrap()(ctx).into()
+    (*Core).getState.unwrap_unchecked()(ctx).into()
   }
 }
 
@@ -189,14 +189,14 @@ pub fn abortWire(context: &SHContext, message: &str) {
   };
   unsafe {
     let ctx = context as *const SHContext as *mut SHContext;
-    (*Core).abortWire.unwrap()(ctx, msg);
+    (*Core).abortWire.unwrap_unchecked()(ctx, msg);
   }
 }
 
 #[inline(always)]
 pub fn register_legacy_shard<T: Default + LegacyShard>() {
   unsafe {
-    (*Core).registerShard.unwrap()(
+    (*Core).registerShard.unwrap_unchecked()(
       T::registerName().as_ptr() as *const c_char,
       Some(legacy_shard_construct::<T>),
     );
@@ -206,7 +206,7 @@ pub fn register_legacy_shard<T: Default + LegacyShard>() {
 #[inline(always)]
 pub fn register_shard<T: Default + ShardGenerated + Shard + ShardGeneratedOverloads>() {
   unsafe {
-    (*Core).registerShard.unwrap()(
+    (*Core).registerShard.unwrap_unchecked()(
       T::register_name().as_ptr() as *const c_char,
       Some(shard_construct::<T>),
     );
@@ -223,14 +223,14 @@ pub fn register_enum<T: EnumRegister>() {
 
 pub fn getShards() -> Vec<&'static CStr> {
   unsafe {
-    let shard_names = (*Core).getShards.unwrap()();
+    let shard_names = (*Core).getShards.unwrap_unchecked()();
     let mut res = Vec::new();
     let len = shard_names.len;
     let slice = from_raw_parts_allow_null(shard_names.elements, len.try_into().unwrap());
     for name in slice.iter() {
       res.push(CStr::from_ptr(*name));
     }
-    (*Core).stringsFree.unwrap()(&shard_names as *const SHStrings as *mut SHStrings);
+    (*Core).stringsFree.unwrap_unchecked()(&shard_names as *const SHStrings as *mut SHStrings);
     res
   }
 }
@@ -238,7 +238,7 @@ pub fn getShards() -> Vec<&'static CStr> {
 #[inline(always)]
 pub fn getRootPath() -> &'static str {
   unsafe {
-    CStr::from_ptr((*Core).getRootPath.unwrap()())
+    CStr::from_ptr((*Core).getRootPath.unwrap_unchecked()())
       .to_str()
       .unwrap()
   }
@@ -250,47 +250,47 @@ pub fn createShardPtr(name: &str) -> ShardPtr {
     string: name.as_ptr() as *const c_char,
     len: name.len() as u64,
   };
-  unsafe { (*Core).createShard.unwrap()(name) }
+  unsafe { (*Core).createShard.unwrap_unchecked()(name) }
 }
 
 #[inline(always)]
 pub fn cloneVar(dst: &mut Var, src: &Var) {
   unsafe {
-    (*Core).cloneVar.unwrap()(dst, src);
+    (*Core).cloneVar.unwrap_unchecked()(dst, src);
   }
 }
 
 #[inline(always)]
 pub fn destroyVar(v: &mut Var) {
   unsafe {
-    (*Core).destroyVar.unwrap()(v);
+    (*Core).destroyVar.unwrap_unchecked()(v);
   }
 }
 
 pub fn readCachedString(id: u32) -> &'static str {
   unsafe {
-    let s = (*Core).readCachedString.unwrap()(id);
+    let s = (*Core).readCachedString.unwrap_unchecked()(id);
     CStr::from_ptr(s.string).to_str().unwrap()
   }
 }
 
 pub fn writeCachedString(id: u32, string: &'static str) -> &'static str {
   unsafe {
-    let s = (*Core).writeCachedString.unwrap()(id, string.as_ptr() as *const std::os::raw::c_char);
+    let s = (*Core).writeCachedString.unwrap_unchecked()(id, string.as_ptr() as *const std::os::raw::c_char);
     CStr::from_ptr(s.string).to_str().unwrap()
   }
 }
 
 pub fn readCachedString1(id: u32) -> SHOptionalString {
-  unsafe { (*Core).readCachedString.unwrap()(id) }
+  unsafe { (*Core).readCachedString.unwrap_unchecked()(id) }
 }
 
 pub fn writeCachedString1(id: u32, string: &'static str) -> SHOptionalString {
-  unsafe { (*Core).writeCachedString.unwrap()(id, string.as_ptr() as *const std::os::raw::c_char) }
+  unsafe { (*Core).writeCachedString.unwrap_unchecked()(id, string.as_ptr() as *const std::os::raw::c_char) }
 }
 
 pub fn deriveType(var: &Var, data: &InstanceData) -> DerivedType {
-  let t = unsafe { (*Core).deriveTypeInfo.unwrap()(var as *const _, data as *const _) };
+  let t = unsafe { (*Core).deriveTypeInfo.unwrap_unchecked()(var as *const _, data as *const _) };
   DerivedType(t)
 }
 
@@ -308,7 +308,7 @@ macro_rules! shccstr {
 pub fn referenceMutVariable(context: &SHContext, name: SHStringWithLen) -> &mut SHVar {
   unsafe {
     let ctx = context as *const SHContext as *mut SHContext;
-    let shptr = (*Core).referenceVariable.unwrap()(ctx, name);
+    let shptr = (*Core).referenceVariable.unwrap_unchecked()(ctx, name);
     shptr.as_mut().unwrap()
   }
 }
@@ -316,7 +316,7 @@ pub fn referenceMutVariable(context: &SHContext, name: SHStringWithLen) -> &mut 
 pub fn referenceVariable(context: &SHContext, name: SHStringWithLen) -> &SHVar {
   unsafe {
     let ctx = context as *const SHContext as *mut SHContext;
-    let shptr = (*Core).referenceVariable.unwrap()(ctx, name);
+    let shptr = (*Core).referenceVariable.unwrap_unchecked()(ctx, name);
     shptr.as_mut().unwrap()
   }
 }
@@ -324,25 +324,25 @@ pub fn referenceVariable(context: &SHContext, name: SHStringWithLen) -> &SHVar {
 pub fn releaseMutVariable(var: &mut SHVar) {
   unsafe {
     let v = var as *mut SHVar;
-    (*Core).releaseVariable.unwrap()(v);
+    (*Core).releaseVariable.unwrap_unchecked()(v);
   }
 }
 
 pub fn releaseVariable(var: &SHVar) {
   unsafe {
     let v = var as *const SHVar as *mut SHVar;
-    (*Core).releaseVariable.unwrap()(v);
+    (*Core).releaseVariable.unwrap_unchecked()(v);
   }
 }
 
 pub fn register_legacy_enum(vendorId: i32, typeId: i32, info: SHEnumInfo) {
   unsafe {
-    (*Core).registerEnumType.unwrap()(vendorId, typeId, info);
+    (*Core).registerEnumType.unwrap_unchecked()(vendorId, typeId, info);
   }
 }
 
 pub fn findEnumInfo(vendorId: i32, typeId: i32) -> Option<SHEnumInfo> {
-  let info = unsafe { (*Core).findEnumInfo.unwrap()(vendorId, typeId) };
+  let info = unsafe { (*Core).findEnumInfo.unwrap_unchecked()(vendorId, typeId) };
   if info == std::ptr::null() {
     None
   } else {
@@ -355,7 +355,7 @@ pub fn findEnumId(name: &str) -> Option<i64> {
     string: name.as_ptr() as *const c_char,
     len: name.len() as u64,
   };
-  let info = unsafe { (*Core).findEnumId.unwrap()(s) };
+  let info = unsafe { (*Core).findEnumId.unwrap_unchecked()(s) };
   if info == 0 {
     None
   } else {
@@ -364,11 +364,11 @@ pub fn findEnumId(name: &str) -> Option<i64> {
 }
 
 pub fn findObjectInfo(vendorId: i32, typeId: i32) -> *const SHObjectInfo {
-  unsafe { (*Core).findObjectInfo.unwrap()(vendorId, typeId) }
+  unsafe { (*Core).findObjectInfo.unwrap_unchecked()(vendorId, typeId) }
 }
 
 pub fn type2Name(t: SHType) -> *const c_char {
-  unsafe { (*Core).type2Name.unwrap()(t) }
+  unsafe { (*Core).type2Name.unwrap_unchecked()(t) }
 }
 
 impl WireRef {
@@ -382,7 +382,7 @@ impl WireRef {
         var: &var.0 as *const _ as *mut _,
         type_: std::ptr::null(),
       };
-      (*Core).setExternalVariable.unwrap()(self.0, name, &ev as *const _ as *mut _);
+      (*Core).setExternalVariable.unwrap_unchecked()(self.0, name, &ev as *const _ as *mut _);
     }
   }
 
@@ -392,12 +392,12 @@ impl WireRef {
       len: name.len() as u64,
     };
     unsafe {
-      (*Core).removeExternalVariable.unwrap()(self.0, name);
+      (*Core).removeExternalVariable.unwrap_unchecked()(self.0, name);
     }
   }
 
   pub fn get_result(&self) -> Result<Option<ClonedVar>, &str> {
-    let info = unsafe { (*Core).getWireInfo.unwrap()(self.0) };
+    let info = unsafe { (*Core).getWireInfo.unwrap_unchecked()(self.0) };
 
     if !info.isRunning {
       if info.failed {
@@ -501,7 +501,7 @@ pub fn run_future<
     let ctx = context as *const SHContext as *mut SHContext;
     let data_ptr = &f as *const F as *mut F as *mut c_void;
     // see note in activate_future_c_call
-    ClonedVar((*Core).asyncActivate.unwrap()(
+    ClonedVar((*Core).asyncActivate.unwrap_unchecked()(
       ctx,
       data_ptr,
       Some(activate_future_c_call::<F, R>),
@@ -521,7 +521,7 @@ where
     };
     let ctx = context as *const SHContext as *mut SHContext;
     let data_ptr = &data as *const AsyncCallData<T> as *mut AsyncCallData<T> as *mut c_void;
-    (*Core).asyncActivate.unwrap()(
+    (*Core).asyncActivate.unwrap_unchecked()(
       ctx,
       data_ptr,
       Some(activate_blocking_c_call::<T>),
@@ -665,7 +665,7 @@ use std::hash::{Hash, Hasher};
 
 impl Hash for Var {
   fn hash<H: Hasher>(&self, state: &mut H) {
-    let hash = unsafe { (*Core).hashVar.unwrap()(self as *const _) };
+    let hash = unsafe { (*Core).hashVar.unwrap_unchecked()(self as *const _) };
     unsafe {
       state.write_u64(hash.payload.__bindgen_anon_1.int2Value[0] as u64);
       state.write_u64(hash.payload.__bindgen_anon_1.int2Value[1] as u64);
@@ -674,7 +674,7 @@ impl Hash for Var {
 }
 
 pub fn hash_var(v: &Var) -> Var {
-  unsafe { (*Core).hashVar.unwrap()(v as *const _) }
+  unsafe { (*Core).hashVar.unwrap_unchecked()(v as *const _) }
 }
 
 /// A struct that will execute a closure when it goes out of scope.

--- a/shards/rust/src/types.rs
+++ b/shards/rust/src/types.rs
@@ -192,7 +192,7 @@ impl Ord for Var {
   fn cmp(&self, other: &Self) -> std::cmp::Ordering {
     unsafe {
       // Use partialOrder to determine the full ordering directly
-      match (*Core).compareVar.unwrap()(
+      match (*Core).compareVar.unwrap_unchecked()(
         self as *const SHVar as *mut SHVar,
         other as *const SHVar as *mut SHVar,
       ) {
@@ -308,7 +308,7 @@ impl Drop for ClonedVar {
   fn drop(&mut self) {
     unsafe {
       let rv = &self.0 as *const SHVar as *mut SHVar;
-      (*Core).destroyVar.unwrap()(rv);
+      (*Core).destroyVar.unwrap_unchecked()(rv);
     }
   }
 }
@@ -348,35 +348,35 @@ impl Drop for AutoShardRef {
 
 impl Default for Mesh {
   fn default() -> Self {
-    Mesh(unsafe { (*Core).createMesh.unwrap()() })
+    Mesh(unsafe { (*Core).createMesh.unwrap_unchecked()() })
   }
 }
 
 impl Drop for Mesh {
   fn drop(&mut self) {
-    unsafe { (*Core).destroyMesh.unwrap()(self.0) }
+    unsafe { (*Core).destroyMesh.unwrap_unchecked()(self.0) }
   }
 }
 
 impl Mesh {
   pub fn compose(&self, wire: WireRef) -> bool {
-    unsafe { (*Core).compose.unwrap()(self.0, wire.0) }
+    unsafe { (*Core).compose.unwrap_unchecked()(self.0, wire.0) }
   }
 
   pub fn schedule(&mut self, wire: WireRef, compose: bool) {
-    unsafe { (*Core).schedule.unwrap()(self.0, wire.0, compose) }
+    unsafe { (*Core).schedule.unwrap_unchecked()(self.0, wire.0, compose) }
   }
 
   pub fn tick(&mut self) -> bool {
-    unsafe { (*Core).tick.unwrap()(self.0) }
+    unsafe { (*Core).tick.unwrap_unchecked()(self.0) }
   }
 
   pub fn is_empty(&mut self) -> bool {
-    unsafe { (*Core).isEmpty.unwrap()(self.0) }
+    unsafe { (*Core).isEmpty.unwrap_unchecked()(self.0) }
   }
 
   pub fn terminate(&mut self) {
-    unsafe { (*Core).terminate.unwrap()(self.0) }
+    unsafe { (*Core).terminate.unwrap_unchecked()(self.0) }
   }
 }
 
@@ -385,7 +385,7 @@ pub struct MeshVar(pub ClonedVar);
 
 impl MeshVar {
   pub fn new() -> Self {
-    MeshVar(ClonedVar(unsafe { (*Core).createMeshVar.unwrap()() }))
+    MeshVar(ClonedVar(unsafe { (*Core).createMeshVar.unwrap_unchecked()() }))
   }
 
   pub fn mesh_ref(&self) -> SHMeshRef {
@@ -401,24 +401,24 @@ impl MeshVar {
   }
 
   pub fn compose(&self, wire: WireRef) -> bool {
-    unsafe { (*Core).compose.unwrap()(self.mesh_ref(), wire.0) }
+    unsafe { (*Core).compose.unwrap_unchecked()(self.mesh_ref(), wire.0) }
   }
 
   pub fn schedule(&mut self, wire: WireRef, compose: bool) {
-    unsafe { (*Core).schedule.unwrap()(self.mesh_ref(), wire.0, compose) }
+    unsafe { (*Core).schedule.unwrap_unchecked()(self.mesh_ref(), wire.0, compose) }
   }
 
   /// Returns false if we had any wire failure
   pub fn tick(&mut self) -> bool {
-    unsafe { (*Core).tick.unwrap()(self.mesh_ref()) }
+    unsafe { (*Core).tick.unwrap_unchecked()(self.mesh_ref()) }
   }
 
   pub fn is_empty(&mut self) -> bool {
-    unsafe { (*Core).isEmpty.unwrap()(self.mesh_ref()) }
+    unsafe { (*Core).isEmpty.unwrap_unchecked()(self.mesh_ref()) }
   }
 
   pub fn terminate(&mut self) {
-    unsafe { (*Core).terminate.unwrap()(self.mesh_ref()) }
+    unsafe { (*Core).terminate.unwrap_unchecked()(self.mesh_ref()) }
   }
 
   pub fn set_label(&mut self, str: &str) {
@@ -427,7 +427,7 @@ impl MeshVar {
         string: str.as_ptr() as *const c_char,
         len: str.len() as u64,
       };
-      (*Core).setMeshLabel.unwrap()(self.mesh_ref(), name)
+      (*Core).setMeshLabel.unwrap_unchecked()(self.mesh_ref(), name)
     }
   }
 }
@@ -436,7 +436,7 @@ pub struct Wire(pub WireRef);
 
 impl Drop for Wire {
   fn drop(&mut self) {
-    unsafe { (*Core).destroyWire.unwrap()(self.0 .0) }
+    unsafe { (*Core).destroyWire.unwrap_unchecked()(self.0 .0) }
   }
 }
 
@@ -452,7 +452,7 @@ impl Wire {
       string: name.as_ptr() as *const c_char,
       len: name.len() as u64,
     };
-    Wire(WireRef(unsafe { (*Core).createWire.unwrap()(name) }))
+    Wire(WireRef(unsafe { (*Core).createWire.unwrap_unchecked()(name) }))
   }
 
   pub fn set_debug_id(self, id: u64) -> Self {
@@ -461,35 +461,35 @@ impl Wire {
   }
 
   pub fn add_shard(&self, shard: ShardRef) {
-    unsafe { (*Core).addShard.unwrap()(self.0 .0, shard.0) }
+    unsafe { (*Core).addShard.unwrap_unchecked()(self.0 .0, shard.0) }
   }
 
   pub fn set_looped(&self, looped: bool) {
-    unsafe { (*Core).setWireLooped.unwrap()(self.0 .0, looped) }
+    unsafe { (*Core).setWireLooped.unwrap_unchecked()(self.0 .0, looped) }
   }
 
   pub fn set_traits(&self, traits: SHSeq) {
-    unsafe { (*Core).setWireTraits.unwrap()(self.0 .0, traits) }
+    unsafe { (*Core).setWireTraits.unwrap_unchecked()(self.0 .0, traits) }
   }
 
   pub fn set_unsafe(&self, unsafe_: bool) {
-    unsafe { (*Core).setWireUnsafe.unwrap()(self.0 .0, unsafe_) }
+    unsafe { (*Core).setWireUnsafe.unwrap_unchecked()(self.0 .0, unsafe_) }
   }
 
   pub fn set_pure(&self, pure: bool) {
-    unsafe { (*Core).setWirePure.unwrap()(self.0 .0, pure) }
+    unsafe { (*Core).setWirePure.unwrap_unchecked()(self.0 .0, pure) }
   }
 
   pub fn set_stack_size(&self, stack_size: usize) {
-    unsafe { (*Core).setWireStackSize.unwrap()(self.0 .0, stack_size as u64) }
+    unsafe { (*Core).setWireStackSize.unwrap_unchecked()(self.0 .0, stack_size as u64) }
   }
 
   pub fn stop(&self) -> ClonedVar {
-    unsafe { ClonedVar((*Core).stopWire.unwrap()(self.0 .0)) }
+    unsafe { ClonedVar((*Core).stopWire.unwrap_unchecked()(self.0 .0)) }
   }
 
   pub fn get_info(&self) -> SHWireInfo {
-    unsafe { (*Core).getWireInfo.unwrap()(self.0 .0) }
+    unsafe { (*Core).getWireInfo.unwrap_unchecked()(self.0 .0) }
   }
 }
 
@@ -524,7 +524,7 @@ unsafe extern "C" fn error_cb(
 impl ShardRef {
   pub fn output_types(&self) -> &[Type] {
     unsafe {
-      let info = (*self.0).outputTypes.unwrap()(self.0);
+      let info = (*self.0).outputTypes.unwrap_unchecked()(self.0);
       if info.len == 0 {
         return &[];
       }
@@ -534,7 +534,7 @@ impl ShardRef {
 
   pub fn input_types(&self) -> &[Type] {
     unsafe {
-      let info = (*self.0).inputTypes.unwrap()(self.0);
+      let info = (*self.0).inputTypes.unwrap_unchecked()(self.0);
       if info.len == 0 {
         return &[];
       }
@@ -544,7 +544,7 @@ impl ShardRef {
 
   pub fn create(name: &str, debug_info: Option<(u32, u32)>) -> Option<Self> {
     unsafe {
-      let ptr = (*Core).createShard.unwrap()(SHStringWithLen {
+      let ptr = (*Core).createShard.unwrap_unchecked()(SHStringWithLen {
         string: name.as_ptr() as *const c_char,
         len: name.len() as u64,
       });
@@ -555,7 +555,7 @@ impl ShardRef {
           (*ptr).line = debug_info.0;
           (*ptr).column = debug_info.1;
         }
-        (*ptr).setup.unwrap()(ptr);
+        (*ptr).setup.unwrap_unchecked()(ptr);
         Some(ShardRef(ptr))
       }
     }
@@ -563,20 +563,20 @@ impl ShardRef {
 
   pub fn name(&self) -> &str {
     unsafe {
-      let c_name = (*self.0).name.unwrap()(self.0);
+      let c_name = (*self.0).name.unwrap_unchecked()(self.0);
       CStr::from_ptr(c_name).to_str().unwrap()
     }
   }
 
   pub fn destroy(&self) {
     unsafe {
-      (*Core).releaseShard.unwrap()(self.0);
+      (*Core).releaseShard.unwrap_unchecked()(self.0);
     }
   }
 
   pub fn cleanup(&self, context: Option<&Context>) -> Result<(), &'static str> {
     unsafe {
-      let result = (*self.0).cleanup.unwrap()(
+      let result = (*self.0).cleanup.unwrap_unchecked()(
         self.0,
         if let Some(_ref) = context {
           &_ref as *const _ as *mut _
@@ -602,7 +602,7 @@ impl ShardRef {
   pub fn warmup(&self, context: &Context) -> Result<(), &'static str> {
     unsafe {
       if (*self.0).warmup.is_some() {
-        let result = (*self.0).warmup.unwrap()(self.0, context as *const _ as *mut _);
+        let result = (*self.0).warmup.unwrap_unchecked()(self.0, context as *const _ as *mut _);
         if result.code == 0 {
           Ok(())
         } else {
@@ -623,7 +623,7 @@ impl ShardRef {
 
   pub fn parameters(&self) -> &[ParameterInfo] {
     unsafe {
-      let params = (*self.0).parameters.unwrap()(self.0);
+      let params = (*self.0).parameters.unwrap_unchecked()(self.0);
       if params.len == 0 {
         return &[];
       } else {
@@ -634,18 +634,18 @@ impl ShardRef {
 
   pub fn set_parameter(&self, index: i32, value: Var) -> Result<(), &'static str> {
     unsafe {
-      let success = (*Core).validateSetParam.unwrap()(self.0, index, &value);
+      let success = (*Core).validateSetParam.unwrap_unchecked()(self.0, index, &value);
       if !success {
         Err("Set parameter validation failed")
       } else {
-        (*self.0).setParam.unwrap()(self.0, index, &value);
+        (*self.0).setParam.unwrap_unchecked()(self.0, index, &value);
         Ok(())
       }
     }
   }
 
   pub fn get_parameter(&self, index: i32) -> Var {
-    unsafe { (*self.0).getParam.unwrap()(self.0, index) }
+    unsafe { (*self.0).getParam.unwrap_unchecked()(self.0, index) }
   }
 
   pub fn get_line_info(&self) -> (u32, u32) {
@@ -671,7 +671,7 @@ impl Drop for DerivedType {
   fn drop(&mut self) {
     let ti = &mut self.0;
     unsafe {
-      (*Core).freeDerivedTypeInfo.unwrap()(ti as *mut _);
+      (*Core).freeDerivedTypeInfo.unwrap_unchecked()(ti as *mut _);
     }
   }
 }
@@ -1059,7 +1059,7 @@ pub mod common_type {
 
   pub fn type2name(value_type: SHType) -> &'static str {
     unsafe {
-      let ptr = (*crate::core::Core).type2Name.unwrap()(value_type);
+      let ptr = (*crate::core::Core).type2Name.unwrap_unchecked()(value_type);
       let s = CStr::from_ptr(ptr);
       s.to_str().unwrap()
     }
@@ -1879,7 +1879,7 @@ where
     unsafe {
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = &vt as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     res
   }
@@ -1896,7 +1896,7 @@ where
     unsafe {
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = &vt as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     // ensure this flag is set
     res.0.flags |= SHVAR_FLAGS_EXTERNAL as u16;
@@ -1910,7 +1910,7 @@ impl From<&Var> for ClonedVar {
     unsafe {
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = v as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     res
   }
@@ -1922,7 +1922,7 @@ impl From<&Var> for ExternalVar {
     unsafe {
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = v as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     // ensure this flag is set
     res.0.flags |= SHVAR_FLAGS_EXTERNAL as u16;
@@ -1937,7 +1937,7 @@ impl From<Vec<Var>> for ClonedVar {
     unsafe {
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = &tmp as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     res
   }
@@ -1951,7 +1951,7 @@ impl From<std::string::String> for ClonedVar {
     unsafe {
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = &tmp as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     res
   }
@@ -1965,7 +1965,7 @@ impl From<&[ClonedVar]> for ClonedVar {
       let vsrc: Var = src.into();
       let rv = &res.0 as *const SHVar as *mut SHVar;
       let sv = &vsrc as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     res
   }
@@ -1990,7 +1990,7 @@ impl ExternalVar {
     unsafe {
       let rv = &self.0 as *const SHVar as *mut SHVar;
       let sv = &vt as *const SHVar;
-      (*Core).cloneVar.unwrap()(rv, sv);
+      (*Core).cloneVar.unwrap_unchecked()(rv, sv);
     }
     // ensure this flag is set
     self.0.flags |= SHVAR_FLAGS_EXTERNAL as u16;
@@ -2002,7 +2002,7 @@ impl Drop for ExternalVar {
   fn drop(&mut self) {
     unsafe {
       let rv = &self.0 as *const SHVar as *mut SHVar;
-      (*Core).destroyVar.unwrap()(rv);
+      (*Core).destroyVar.unwrap_unchecked()(rv);
     }
   }
 }
@@ -3241,7 +3241,7 @@ impl Var {
     dst.flags |= SHVAR_FLAGS_USES_OBJINFO as u16 | SHVAR_FLAGS_WEAK_OBJECT as u16;
     dst.__bindgen_anon_1.objectInfo = src.__bindgen_anon_1.objectInfo;
     unsafe {
-      (*dst.__bindgen_anon_1.objectInfo).weakReference.unwrap()(
+      (*dst.__bindgen_anon_1.objectInfo).weakReference.unwrap_unchecked()(
         dst.payload.__bindgen_anon_1.__bindgen_anon_1.objectValue,
       );
     }
@@ -4634,7 +4634,7 @@ impl ParamVar {
   pub fn cleanup(&mut self, _ctx: Option<&Context>) {
     unsafe {
       if self.parameter.0.valueType == SHType_ContextVar {
-        (*Core).releaseVariable.unwrap()(self.pointee);
+        (*Core).releaseVariable.unwrap_unchecked()(self.pointee);
       }
       self.pointee = std::ptr::null_mut();
     }
@@ -4645,7 +4645,7 @@ impl ParamVar {
       assert_eq!(self.pointee, std::ptr::null_mut());
       unsafe {
         let ctx = context as *const SHContext as *mut SHContext;
-        self.pointee = (*Core).referenceVariable.unwrap()(
+        self.pointee = (*Core).referenceVariable.unwrap_unchecked()(
           ctx,
           SHStringWithLen {
             string: self
@@ -4687,7 +4687,7 @@ impl ParamVar {
   }
 
   pub fn set_cloning(&mut self, value: &Var) {
-    unsafe { (*Core).cloneVar.unwrap()(self.pointee, value) };
+    unsafe { (*Core).cloneVar.unwrap_unchecked()(self.pointee, value) };
     // notice we don't need to fix up ref-counting because cloning does not touch that
   }
 
@@ -4817,13 +4817,14 @@ impl ShardsVar {
     // clear old results if any
     if let Some(compose_result) = self.compose_result {
       unsafe {
-        (*Core).expTypesFree.unwrap()(&compose_result.exposedInfo as *const _ as *mut _);
-        (*Core).expTypesFree.unwrap()(&compose_result.requiredInfo as *const _ as *mut _);
+        (*Core).expTypesFree.unwrap_unchecked()(&compose_result.exposedInfo as *const _ as *mut _);
+        (*Core).expTypesFree.unwrap_unchecked()(&compose_result.requiredInfo as *const _ as *mut _);
       }
       self.compose_result = None;
     }
   }
 
+  #[inline(always)]
   pub fn cleanup(&mut self, ctx: Option<&Context>) {
     for shard in self.shards.iter().rev() {
       if let Err(e) = shard.cleanup(ctx) {
@@ -4832,6 +4833,7 @@ impl ShardsVar {
     }
   }
 
+  #[inline(always)]
   pub fn warmup(&self, context: &Context) -> Result<(), &'static str> {
     for shard in self.shards.iter() {
       if let Err(e) = shard.warmup(context) {
@@ -4869,16 +4871,18 @@ impl ShardsVar {
     Ok(())
   }
 
+  #[inline(always)]
   pub fn get_param(&self) -> Var {
     self.param.0
   }
 
+  #[inline(always)]
   pub fn compose(&mut self, data: &InstanceData) -> Result<&ComposeResult, &'static str> {
     // clear old results if any
     if let Some(compose_result) = self.compose_result {
       unsafe {
-        (*Core).expTypesFree.unwrap()(&compose_result.exposedInfo as *const _ as *mut _);
-        (*Core).expTypesFree.unwrap()(&compose_result.requiredInfo as *const _ as *mut _);
+        (*Core).expTypesFree.unwrap_unchecked()(&compose_result.exposedInfo as *const _ as *mut _);
+        (*Core).expTypesFree.unwrap_unchecked()(&compose_result.requiredInfo as *const _ as *mut _);
       }
       self.compose_result = None;
     }
@@ -4890,7 +4894,7 @@ impl ShardsVar {
 
     let failed = false;
 
-    let mut result = unsafe { (*Core).composeShards.unwrap()(self.native_shards, *data) };
+    let mut result = unsafe { (*Core).composeShards.unwrap_unchecked()(self.native_shards, *data) };
 
     if result.failed {
       let msg: &str = (&result.failureMessage).try_into().unwrap();
@@ -4905,13 +4909,14 @@ impl ShardsVar {
     }
   }
 
+  #[inline(always)]
   pub fn activate(&self, context: &Context, input: &Var, output: &mut Var) -> WireState {
     if self.param.0.is_none() {
       return WireState::Continue;
     }
 
     unsafe {
-      (*Core).runShards.unwrap()(
+      (*Core).runShards.unwrap_unchecked()(
         self.native_shards,
         context as *const _ as *mut _,
         input,
@@ -4921,6 +4926,7 @@ impl ShardsVar {
     }
   }
 
+  #[inline(always)]
   pub fn activate_handling_return(
     &self,
     context: &Context,
@@ -4932,7 +4938,7 @@ impl ShardsVar {
     }
 
     unsafe {
-      (*Core).runShards2.unwrap()(
+      (*Core).runShards2.unwrap_unchecked()(
         self.native_shards,
         context as *const _ as *mut _,
         input,
@@ -4942,10 +4948,12 @@ impl ShardsVar {
     }
   }
 
+  #[inline(always)]
   pub fn is_empty(&self) -> bool {
     self.param.0.is_none()
   }
 
+  #[inline(always)]
   pub fn get_exposing(&self) -> Option<&[ExposedInfo]> {
     self.compose_result.map(|compose_result| unsafe {
       let elems = compose_result.exposedInfo.elements;
@@ -4958,6 +4966,7 @@ impl ShardsVar {
     })
   }
 
+  #[inline(always)]
   pub fn get_requiring(&self) -> Option<&[ExposedInfo]> {
     self.compose_result.map(|compose_result| unsafe {
       let elems = compose_result.requiredInfo.elements;
@@ -5025,7 +5034,7 @@ impl IntoIterator for TableVar {
         table: self.0.payload.__bindgen_anon_1.tableValue,
         citer: [0; 64],
       };
-      (*it.table.api).tableGetIterator.unwrap()(it.table, &it.citer as *const _ as *mut _);
+      (*it.table.api).tableGetIterator.unwrap_unchecked()(it.table, &it.citer as *const _ as *mut _);
       it
     }
   }
@@ -5308,7 +5317,7 @@ impl Drop for Strings {
   fn drop(&mut self) {
     if self.owned {
       unsafe {
-        (*Core).stringsFree.unwrap()(&self.s as *const SHStrings as *mut SHStrings);
+        (*Core).stringsFree.unwrap_unchecked()(&self.s as *const SHStrings as *mut SHStrings);
       }
     }
   }
@@ -5328,7 +5337,7 @@ impl Strings {
 
   pub fn set_len(&mut self, len: usize) {
     unsafe {
-      (*Core).stringsResize.unwrap()(
+      (*Core).stringsResize.unwrap_unchecked()(
         &self.s as *const SHStrings as *mut SHStrings,
         len.try_into().unwrap(),
       );
@@ -5338,14 +5347,14 @@ impl Strings {
   pub fn push(&mut self, value: &str) {
     let str = value.as_ptr() as *const std::os::raw::c_char;
     unsafe {
-      (*Core).stringsPush.unwrap()(&self.s as *const SHStrings as *mut SHStrings, &str);
+      (*Core).stringsPush.unwrap_unchecked()(&self.s as *const SHStrings as *mut SHStrings, &str);
     }
   }
 
   pub fn insert(&mut self, index: usize, value: &str) {
     let str = value.as_ptr() as *const std::os::raw::c_char;
     unsafe {
-      (*Core).stringsInsert.unwrap()(
+      (*Core).stringsInsert.unwrap_unchecked()(
         &self.s as *const SHStrings as *mut SHStrings,
         index.try_into().unwrap(),
         &str,
@@ -5364,7 +5373,7 @@ impl Strings {
   pub fn pop(&mut self) -> Option<&str> {
     unsafe {
       if !self.is_empty() {
-        let v = (*Core).stringsPop.unwrap()(&self.s as *const SHStrings as *mut SHStrings);
+        let v = (*Core).stringsPop.unwrap_unchecked()(&self.s as *const SHStrings as *mut SHStrings);
         Some(CStr::from_ptr(v).to_str().unwrap())
       } else {
         None
@@ -5374,7 +5383,7 @@ impl Strings {
 
   pub fn clear(&mut self) {
     unsafe {
-      (*Core).stringsResize.unwrap()(&self.s as *const SHStrings as *mut SHStrings, 0);
+      (*Core).stringsResize.unwrap_unchecked()(&self.s as *const SHStrings as *mut SHStrings, 0);
     }
   }
 }
@@ -5591,7 +5600,7 @@ impl SeqVar {
   #[inline(always)]
   pub fn set_len(&mut self, len: usize) {
     unsafe {
-      (*Core).seqResize.unwrap()(
+      (*Core).seqResize.unwrap_unchecked()(
         &self.0.payload.__bindgen_anon_1.seqValue as *const SHSeq as *mut SHSeq,
         len.try_into().unwrap(),
       );
@@ -5623,7 +5632,7 @@ impl SeqVar {
     let mut tmp = SHVar::default();
     cloneVar(&mut tmp, &value);
     unsafe {
-      (*Core).seqInsert.unwrap()(
+      (*Core).seqInsert.unwrap_unchecked()(
         &self.0.payload.__bindgen_anon_1.seqValue as *const SHSeq as *mut SHSeq,
         index.try_into().unwrap(),
         &tmp,
@@ -5654,7 +5663,7 @@ impl SeqVar {
   pub fn pop(&mut self) -> Option<ClonedVar> {
     unsafe {
       if !self.is_empty() {
-        let v = (*Core).seqPop.unwrap()(
+        let v = (*Core).seqPop.unwrap_unchecked()(
           &self.0.payload.__bindgen_anon_1.seqValue as *const SHSeq as *mut SHSeq,
         );
         Some(transmute(v))
@@ -5667,7 +5676,7 @@ impl SeqVar {
   #[inline(always)]
   pub fn remove(&mut self, index: usize) {
     unsafe {
-      (*Core).seqSlowDelete.unwrap()(
+      (*Core).seqSlowDelete.unwrap_unchecked()(
         &self.0.payload.__bindgen_anon_1.seqValue as *const SHSeq as *mut SHSeq,
         index.try_into().unwrap(),
       );
@@ -5677,7 +5686,7 @@ impl SeqVar {
   #[inline(always)]
   pub fn remove_fast(&mut self, index: usize) {
     unsafe {
-      (*Core).seqFastDelete.unwrap()(
+      (*Core).seqFastDelete.unwrap_unchecked()(
         &self.0.payload.__bindgen_anon_1.seqValue as *const SHSeq as *mut SHSeq,
         index.try_into().unwrap(),
       );
@@ -5687,7 +5696,7 @@ impl SeqVar {
   #[inline(always)]
   pub fn clear(&mut self) {
     unsafe {
-      (*Core).seqResize.unwrap()(
+      (*Core).seqResize.unwrap_unchecked()(
         &self.0.payload.__bindgen_anon_1.seqValue as *const SHSeq as *mut SHSeq,
         0,
       );
@@ -5721,7 +5730,7 @@ impl Drop for Seq {
   fn drop(&mut self) {
     if self.owned {
       unsafe {
-        (*Core).seqFree.unwrap()(&self.s as *const SHSeq as *mut SHSeq);
+        (*Core).seqFree.unwrap_unchecked()(&self.s as *const SHSeq as *mut SHSeq);
       }
     }
   }
@@ -5819,7 +5828,7 @@ impl Seq {
 
   pub fn set_len(&mut self, len: usize) {
     unsafe {
-      (*Core).seqResize.unwrap()(
+      (*Core).seqResize.unwrap_unchecked()(
         &self.s as *const SHSeq as *mut SHSeq,
         len.try_into().unwrap(),
       );
@@ -5838,7 +5847,7 @@ impl Seq {
     let mut tmp = SHVar::default();
     cloneVar(&mut tmp, &value);
     unsafe {
-      (*Core).seqInsert.unwrap()(
+      (*Core).seqInsert.unwrap_unchecked()(
         &self.s as *const SHSeq as *mut SHSeq,
         index.try_into().unwrap(),
         &tmp,
@@ -5857,7 +5866,7 @@ impl Seq {
   pub fn pop(&mut self) -> Option<ClonedVar> {
     unsafe {
       if !self.is_empty() {
-        let v = (*Core).seqPop.unwrap()(&self.s as *const SHSeq as *mut SHSeq);
+        let v = (*Core).seqPop.unwrap_unchecked()(&self.s as *const SHSeq as *mut SHSeq);
         Some(transmute(v))
       } else {
         None
@@ -5867,7 +5876,7 @@ impl Seq {
 
   pub fn remove(&mut self, index: usize) {
     unsafe {
-      (*Core).seqSlowDelete.unwrap()(
+      (*Core).seqSlowDelete.unwrap_unchecked()(
         &self.s as *const SHSeq as *mut SHSeq,
         index.try_into().unwrap(),
       );
@@ -5876,7 +5885,7 @@ impl Seq {
 
   pub fn remove_fast(&mut self, index: usize) {
     unsafe {
-      (*Core).seqFastDelete.unwrap()(
+      (*Core).seqFastDelete.unwrap_unchecked()(
         &self.s as *const SHSeq as *mut SHSeq,
         index.try_into().unwrap(),
       );
@@ -5885,7 +5894,7 @@ impl Seq {
 
   pub fn clear(&mut self) {
     unsafe {
-      (*Core).seqResize.unwrap()(&self.s as *const SHSeq as *mut SHSeq, 0);
+      (*Core).seqResize.unwrap_unchecked()(&self.s as *const SHSeq as *mut SHSeq, 0);
     }
   }
 
@@ -5977,7 +5986,7 @@ impl TableVar {
       valueType: SHType_Table,
       payload: SHVarPayload {
         __bindgen_anon_1: SHVarPayload__bindgen_ty_1 {
-          tableValue: unsafe { (*Core).tableNew.unwrap()() },
+          tableValue: unsafe { (*Core).tableNew.unwrap_unchecked()() },
         },
       },
       ..Default::default()
@@ -5995,13 +6004,13 @@ impl TableVar {
   pub fn insert(&mut self, k: Var, v: &Var) -> Option<Var> {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      if (*t.api).tableContains.unwrap()(t, k) {
-        let p = (*t.api).tableAt.unwrap()(t, k);
+      if (*t.api).tableContains.unwrap_unchecked()(t, k) {
+        let p = (*t.api).tableAt.unwrap_unchecked()(t, k);
         let old = *p;
         cloneVar(&mut *p, &v);
         Some(old)
       } else {
-        let p = (*t.api).tableAt.unwrap()(t, k);
+        let p = (*t.api).tableAt.unwrap_unchecked()(t, k);
         cloneVar(&mut *p, &v);
         None
       }
@@ -6012,7 +6021,7 @@ impl TableVar {
   pub fn emplace(&mut self, k: Var, v: ClonedVar) {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      let p = (*t.api).tableAt.unwrap()(t, k);
+      let p = (*t.api).tableAt.unwrap_unchecked()(t, k);
       *p = v.0;
       std::mem::forget(v);
     }
@@ -6022,7 +6031,7 @@ impl TableVar {
   pub fn insert_fast(&mut self, k: Var, v: &Var) {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      let p = (*t.api).tableAt.unwrap()(t, k);
+      let p = (*t.api).tableAt.unwrap_unchecked()(t, k);
       cloneVar(&mut *p, &v);
     }
   }
@@ -6032,7 +6041,7 @@ impl TableVar {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
       let str_key = Var::ephemeral_string(k);
-      let p = (*t.api).tableAt.unwrap()(t, str_key);
+      let p = (*t.api).tableAt.unwrap_unchecked()(t, str_key);
       cloneVar(&mut *p, &v);
     }
   }
@@ -6041,8 +6050,8 @@ impl TableVar {
   pub fn get_mut(&self, k: Var) -> Option<&mut Var> {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      if (*t.api).tableContains.unwrap()(t, k) {
-        let p = (*t.api).tableAt.unwrap()(t, k);
+      if (*t.api).tableContains.unwrap_unchecked()(t, k) {
+        let p = (*t.api).tableAt.unwrap_unchecked()(t, k);
         Some(&mut *p)
       } else {
         None
@@ -6054,7 +6063,7 @@ impl TableVar {
   pub fn get_mut_fast(&mut self, k: Var) -> &mut Var {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      &mut *(*t.api).tableAt.unwrap()(t, k)
+      &mut *(*t.api).tableAt.unwrap_unchecked()(t, k)
     }
   }
 
@@ -6063,7 +6072,7 @@ impl TableVar {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
       let str_key = Var::ephemeral_string(k);
-      &mut *(*t.api).tableAt.unwrap()(t, str_key)
+      &mut *(*t.api).tableAt.unwrap_unchecked()(t, str_key)
     }
   }
 
@@ -6071,8 +6080,8 @@ impl TableVar {
   pub fn get(&self, k: Var) -> Option<&Var> {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      if (*t.api).tableContains.unwrap()(t, k) {
-        let p = (*t.api).tableAt.unwrap()(t, k);
+      if (*t.api).tableContains.unwrap_unchecked()(t, k) {
+        let p = (*t.api).tableAt.unwrap_unchecked()(t, k);
         Some(&*p)
       } else {
         None
@@ -6085,8 +6094,8 @@ impl TableVar {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
       let key_str = Var::ephemeral_string(k);
-      if (*t.api).tableContains.unwrap()(t, key_str) {
-        let p = (*t.api).tableAt.unwrap()(t, key_str);
+      if (*t.api).tableContains.unwrap_unchecked()(t, key_str) {
+        let p = (*t.api).tableAt.unwrap_unchecked()(t, key_str);
         Some(&*p)
       } else {
         None
@@ -6099,7 +6108,7 @@ impl TableVar {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
       let key_str = Var::ephemeral_string(k);
-      &*(*t.api).tableAt.unwrap()(t, key_str)
+      &*(*t.api).tableAt.unwrap_unchecked()(t, key_str)
     }
   }
 
@@ -6107,7 +6116,7 @@ impl TableVar {
   pub fn len(&self) -> usize {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      (*t.api).tableSize.unwrap()(t) as usize
+      (*t.api).tableSize.unwrap_unchecked()(t) as usize
     }
   }
 
@@ -6119,7 +6128,7 @@ impl TableVar {
         table: t,
         citer: [0; 64],
       };
-      (*t.api).tableGetIterator.unwrap()(t, &it.citer as *const _ as *mut _);
+      (*t.api).tableGetIterator.unwrap_unchecked()(t, &it.citer as *const _ as *mut _);
       it
     }
   }
@@ -6134,14 +6143,14 @@ impl TableVar {
   pub fn clear(&mut self) {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      (*t.api).tableClear.unwrap()(t);
+      (*t.api).tableClear.unwrap_unchecked()(t);
     }
   }
 
   pub fn remove(&mut self, k: Var) {
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      (*t.api).tableRemove.unwrap()(t, k);
+      (*t.api).tableRemove.unwrap_unchecked()(t, k);
     }
   }
 
@@ -6149,7 +6158,7 @@ impl TableVar {
     let k = Var::ephemeral_string(k);
     unsafe {
       let t = self.0.payload.__bindgen_anon_1.tableValue;
-      (*t.api).tableRemove.unwrap()(t, k);
+      (*t.api).tableRemove.unwrap_unchecked()(t, k);
     }
   }
 }
@@ -6165,7 +6174,7 @@ impl Drop for Table {
   fn drop(&mut self) {
     if self.owned {
       unsafe {
-        (*self.t.api).tableFree.unwrap()(self.t);
+        (*self.t.api).tableFree.unwrap_unchecked()(self.t);
       }
     }
   }
@@ -6199,7 +6208,7 @@ impl Table {
   pub fn new() -> Table {
     unsafe {
       Table {
-        t: (*Core).tableNew.unwrap()(),
+        t: (*Core).tableNew.unwrap_unchecked()(),
         owned: true,
       }
     }
@@ -6207,13 +6216,13 @@ impl Table {
 
   pub fn insert(&mut self, k: Var, v: &Var) -> Option<Var> {
     unsafe {
-      if (*self.t.api).tableContains.unwrap()(self.t, k) {
-        let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+      if (*self.t.api).tableContains.unwrap_unchecked()(self.t, k) {
+        let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
         let old = *p;
         cloneVar(&mut *p, &v);
         Some(old)
       } else {
-        let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+        let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
         cloneVar(&mut *p, &v);
         None
       }
@@ -6222,7 +6231,7 @@ impl Table {
 
   pub fn insert_fast(&mut self, k: Var, v: &Var) {
     unsafe {
-      let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+      let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
       cloneVar(&mut *p, &v);
     }
   }
@@ -6230,15 +6239,15 @@ impl Table {
   pub fn insert_fast_static(&mut self, k: &str, v: &Var) {
     unsafe {
       let k = Var::ephemeral_string(k);
-      let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+      let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
       cloneVar(&mut *p, &v);
     }
   }
 
   pub fn get_mut(&self, k: Var) -> Option<&mut Var> {
     unsafe {
-      if (*self.t.api).tableContains.unwrap()(self.t, k) {
-        let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+      if (*self.t.api).tableContains.unwrap_unchecked()(self.t, k) {
+        let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
         Some(&mut *p)
       } else {
         None
@@ -6247,20 +6256,20 @@ impl Table {
   }
 
   pub fn get_mut_fast(&mut self, k: Var) -> &mut Var {
-    unsafe { &mut *(*self.t.api).tableAt.unwrap()(self.t, k) }
+    unsafe { &mut *(*self.t.api).tableAt.unwrap_unchecked()(self.t, k) }
   }
 
   pub fn get_mut_fast_static(&mut self, k: &'static str) -> &mut Var {
     unsafe {
       let k = Var::ephemeral_string(k);
-      &mut *(*self.t.api).tableAt.unwrap()(self.t, k)
+      &mut *(*self.t.api).tableAt.unwrap_unchecked()(self.t, k)
     }
   }
 
   pub fn get(&self, k: Var) -> Option<&Var> {
     unsafe {
-      if (*self.t.api).tableContains.unwrap()(self.t, k) {
-        let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+      if (*self.t.api).tableContains.unwrap_unchecked()(self.t, k) {
+        let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
         Some(&*p)
       } else {
         None
@@ -6271,8 +6280,8 @@ impl Table {
   pub fn get_static(&self, k: &'static str) -> Option<&Var> {
     let k = Var::ephemeral_string(k);
     unsafe {
-      if (*self.t.api).tableContains.unwrap()(self.t, k) {
-        let p = (*self.t.api).tableAt.unwrap()(self.t, k);
+      if (*self.t.api).tableContains.unwrap_unchecked()(self.t, k) {
+        let p = (*self.t.api).tableAt.unwrap_unchecked()(self.t, k);
         Some(&*p)
       } else {
         None
@@ -6282,11 +6291,11 @@ impl Table {
 
   pub fn get_fast_static(&self, k: &'static str) -> &Var {
     let k = Var::ephemeral_string(k);
-    unsafe { &*(*self.t.api).tableAt.unwrap()(self.t, k) }
+    unsafe { &*(*self.t.api).tableAt.unwrap_unchecked()(self.t, k) }
   }
 
   pub fn len(&self) -> usize {
-    unsafe { (*self.t.api).tableSize.unwrap()(self.t) as usize }
+    unsafe { (*self.t.api).tableSize.unwrap_unchecked()(self.t) as usize }
   }
 
   pub fn iter(&self) -> TableIterator {
@@ -6295,21 +6304,21 @@ impl Table {
         table: self.t,
         citer: [0; 64],
       };
-      (*self.t.api).tableGetIterator.unwrap()(self.t, &it.citer as *const _ as *mut _);
+      (*self.t.api).tableGetIterator.unwrap_unchecked()(self.t, &it.citer as *const _ as *mut _);
       it
     }
   }
 
   pub fn remove(&mut self, k: Var) {
     unsafe {
-      (*self.t.api).tableRemove.unwrap()(self.t, k);
+      (*self.t.api).tableRemove.unwrap_unchecked()(self.t, k);
     }
   }
 
   pub fn remove_static(&mut self, k: &'static str) {
     let k = Var::ephemeral_string(k);
     unsafe {
-      (*self.t.api).tableRemove.unwrap()(self.t, k);
+      (*self.t.api).tableRemove.unwrap_unchecked()(self.t, k);
     }
   }
 }
@@ -6325,7 +6334,7 @@ impl Iterator for TableIterator {
     unsafe {
       let k: Var = Var::default();
       let v: Var = Var::default();
-      let hasValue = (*(self.table.api)).tableNext.unwrap()(
+      let hasValue = (*(self.table.api)).tableNext.unwrap_unchecked()(
         self.table,
         &self.citer as *const _ as *mut _,
         &k as *const _ as *mut _,
@@ -6394,7 +6403,7 @@ impl PartialEq for Var {
     if self.valueType != other.valueType {
       false
     } else {
-      unsafe { (*Core).isEqualVar.unwrap()(self as *const _, other as *const _) }
+      unsafe { (*Core).isEqualVar.unwrap_unchecked()(self as *const _, other as *const _) }
     }
   }
 }
@@ -6406,7 +6415,7 @@ impl PartialEq for Type {
     if self.basicType != other.basicType {
       false
     } else {
-      unsafe { (*Core).isEqualType.unwrap()(self as *const _, other as *const _) }
+      unsafe { (*Core).isEqualType.unwrap_unchecked()(self as *const _, other as *const _) }
     }
   }
 }

--- a/utils/shards_printer.py
+++ b/utils/shards_printer.py
@@ -1,0 +1,65 @@
+import lldb
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG, filename='lldb_plugin.log', filemode='w')
+logger = logging.getLogger(__name__)
+
+def seq_summary(valobj, internal_dict):
+    try:
+        logger.debug(f"Starting seq_summary for {valobj.GetName()}")
+
+        elements = valobj.GetChildMemberWithName('elements')
+        if not elements.IsValid():
+            logger.error("'elements' member not found")
+            return "Error: 'elements' member not found"
+
+        elements_address = elements.GetValueAsUnsigned()
+        length = valobj.GetChildMemberWithName('len').GetValueAsUnsigned()
+        capacity = valobj.GetChildMemberWithName('cap').GetValueAsUnsigned()
+
+        logger.debug(f"elements_address: 0x{elements_address:x}, length: {length}, capacity: {capacity}")
+
+        element_type = elements.GetType().GetPointeeType()
+        element_size = element_type.GetByteSize()
+
+        logger.debug(f"element_type: {element_type}, element_size: {element_size}")
+
+        elements_str = []
+        if length > 0:
+            for i in range(length):
+                element_address = elements_address + i * element_size
+
+                logger.debug(f"Attempting to print element at address: 0x{element_address:x}")
+
+                # Use LLDB's built-in 'p' command
+                res = lldb.SBCommandReturnObject()
+                interpreter = lldb.debugger.GetCommandInterpreter()
+                command = f'p (SHExposedTypeInfo*)0x{element_address:x}'
+                interpreter.HandleCommand(command, res)
+
+                if res.Succeeded():
+                    output = res.GetOutput().strip()
+                    elements_str.append(f"Element {i}: {output}")
+                else:
+                    error = res.GetError()
+                    logger.error(f"Command failed with error: {error}")
+                    elements_str.append(f"Element {i}: Error - {error}")
+
+        elements_summary = '\n'.join(elements_str)
+        result = f'Custom Summary: elements = 0x{elements_address:x}, len = {length}, cap = {capacity}, values =\n{elements_summary}'
+        logger.debug(f"Final result: {result}")
+        return result
+
+    except Exception as e:
+        logger.exception(f"Error in seq_summary: {str(e)}")
+        return f"Error in seq_summary: {str(e)}"
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        'type summary add -F shards_printer.seq_summary SHSeq')
+    debugger.HandleCommand(
+        'type summary add -F shards_printer.seq_summary SHExposedTypesInfo')
+    debugger.HandleCommand(
+        'type summary add -F shards_printer.seq_summary SHTypesInfo')


### PR DESCRIPTION
Move non-blittable type handling to _destroyVarSlow for better performance. Update Dockerfile for benchmarking environment.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
