### PR TITLE
Finished documenting IsAny-x shards and Input shards

### DIFF
--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -238,7 +238,7 @@ struct DefaultHelpText {
 
   static inline const SHOptionalString InputHelpAnyType = SHCCSTR("Input of any type is accepted.");
 
-  static inline const SHOptionalString InputHelpAnyButType = SHCCSTR("Input of any type is accepted. However, when comparing different types(e.g., boolean with integer), the shard will not throw an error, but will sometimes return unexpected results.");
+  static inline const SHOptionalString InputHelpAnyButType = SHCCSTR("Input of any type is accepted. For types without inherent value (e.g., None, Bool), a lexicographical comparison is used.");
 
   static inline const SHOptionalString InputHelpIgnored = SHCCSTR("The input of this shard is ignored.");
 

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -238,6 +238,8 @@ struct DefaultHelpText {
 
   static inline const SHOptionalString InputHelpAnyType = SHCCSTR("Input of any type is accepted.");
 
+  static inline const SHOptionalString InputHelpAnyButType = SHCCSTR("Input of any type is accepted. However, when comparing different types(e.g., boolean with integer), the shard will not throw an error, but will sometimes return unexpected results.");
+
   static inline const SHOptionalString InputHelpIgnored = SHCCSTR("The input of this shard is ignored.");
 
   static inline const SHOptionalString InputHelpPass =

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -93,6 +93,13 @@ struct Const {
 static shards::ParamsInfo compareParamsInfo =
     shards::ParamsInfo(shards::ParamsInfo::Param("Value", SHCCSTR("The value to check against."), CoreInfo::AnyType));
 
+static shards::ParamsInfo compareParamsInfo2 = shards::ParamsInfo(
+    shards::ParamsInfo::Param("Value",
+                              SHCCSTR("The value to check against. Note: This shard will not evaluate variables nested within "
+                                      "sequences and tables. If you need to compare them against such variables, wrap them in "
+                                      "parentheses, so that they are evaluated first. Example: Value:([your-variable]) instead of Value:your-variable."),
+                              CoreInfo::AnyType));
+
 struct BaseOpsBin {
   ParamVar _operand{shards::Var(0)};
   ExposedInfo _requiredVariables;
@@ -105,7 +112,7 @@ struct BaseOpsBin {
   SHTypesInfo outputTypes() { return CoreInfo::BoolType; }
   static SHOptionalString outputHelp() { return SHCCSTR("The result of the comparison."); }
 
-  SHParametersInfo parameters() { return SHParametersInfo(compareParamsInfo); }
+  static SHParametersInfo parameters() { return SHParametersInfo(compareParamsInfo); }
 
   SHExposedTypesInfo requiredVariables() {
     _requiredVariables.clear();
@@ -203,8 +210,9 @@ LOGIC_OP(IsLessEqual, <=, "Checks if the input is less than or equal to the oper
       return shards::Var::False;                                                          \
     }                                                                                     \
     static SHOptionalString help() { return SHCCSTR(HELP_TEXT); }                         \
-    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyButType; }     \
+    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyButType; }  \
     static SHOptionalString outputHelp() { return SHCCSTR(OUTPUT_HELP_TEXT); }            \
+    static SHParametersInfo parameters() { return SHParametersInfo(compareParamsInfo2); } \
   };                                                                                      \
   RUNTIME_CORE_SHARD_TYPE(NAME);
 
@@ -246,8 +254,9 @@ LOGIC_OP(IsLessEqual, <=, "Checks if the input is less than or equal to the oper
       return shards::Var::False;                                                             \
     }                                                                                        \
     static SHOptionalString help() { return SHCCSTR(HELP_TEXT); }                            \
-    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyButType;}        \
+    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyButType; }     \
     static SHOptionalString outputHelp() { return SHCCSTR(OUTPUT_HELP_TEXT); }               \
+    static SHParametersInfo parameters() { return SHParametersInfo(compareParamsInfo2); }    \
   };                                                                                         \
   RUNTIME_CORE_SHARD_TYPE(NAME);
 
@@ -317,6 +326,7 @@ LOGIC_ALL_SEQ_OP(
   RUNTIME_SHARD_help(NAME);              \
   RUNTIME_SHARD_inputHelp(NAME);         \
   RUNTIME_SHARD_outputHelp(NAME);        \
+  RUNTIME_SHARD_parameters(NAME);        \
   RUNTIME_SHARD_END(NAME);
 
 struct Input {

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -91,7 +91,7 @@ struct Const {
 };
 
 static shards::ParamsInfo compareParamsInfo =
-    shards::ParamsInfo(shards::ParamsInfo::Param("Value", SHCCSTR("The value to test against for equality."), CoreInfo::AnyType));
+    shards::ParamsInfo(shards::ParamsInfo::Param("Value", SHCCSTR("The value to check against."), CoreInfo::AnyType));
 
 struct BaseOpsBin {
   ParamVar _operand{shards::Var(0)};
@@ -136,26 +136,36 @@ struct BaseOpsBin {
   void cleanup(SHContext *context) { _operand.cleanup(); }
 };
 
-#define LOGIC_OP(NAME, OP)                                                         \
-  struct NAME : public BaseOpsBin {                                                \
-    FLATTEN ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) { \
-      const auto &value = _operand.get();                                          \
-      if (input OP value) {                                                        \
-        return shards::Var::True;                                                  \
-      }                                                                            \
-      return shards::Var::False;                                                   \
-    }                                                                              \
-  };                                                                               \
+#define LOGIC_OP(NAME, OP, HELP_TEXT, OUTPUT_HELP_TEXT)                               \
+  struct NAME : public BaseOpsBin {                                                   \
+    FLATTEN ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {    \
+      const auto &value = _operand.get();                                             \
+      if (input OP value) {                                                           \
+        return shards::Var::True;                                                     \
+      }                                                                               \
+      return shards::Var::False;                                                      \
+    }                                                                                 \
+    static SHOptionalString help() { return SHCCSTR(HELP_TEXT); }                     \
+    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyType; } \
+    static SHOptionalString outputHelp() { return SHCCSTR(OUTPUT_HELP_TEXT); }        \
+  };                                                                                  \
   RUNTIME_CORE_SHARD_TYPE(NAME);
 
-LOGIC_OP(Is, ==);
-LOGIC_OP(IsNot, !=);
-LOGIC_OP(IsMore, >);
-LOGIC_OP(IsLess, <);
-LOGIC_OP(IsMoreEqual, >=);
-LOGIC_OP(IsLessEqual, <=);
+// Now use the updated macro with help text for each operation
+LOGIC_OP(Is, ==, "Checks if the input is equal to the operand.",
+         "Returns true if the input is equal to the operand and false otherwise.");
+LOGIC_OP(IsNot, !=, "Checks if the input is not equal to the operand.",
+         "Returns true if the input is not equal to the operand and false otherwise.");
+LOGIC_OP(IsMore, >, "Checks if the input is greater than the operand.",
+         "Returns true if the input is greater than the operand and false otherwise.");
+LOGIC_OP(IsLess, <, "Checks if the input is less than the operand.",
+         "Returns true if the input is less than the operand and false otherwise.");
+LOGIC_OP(IsMoreEqual, >=, "Checks if the input is greater than or equal to the operand.",
+         "Returns true if the input is greater than or equal to the operand and false otherwise.");
+LOGIC_OP(IsLessEqual, <=, "Checks if the input is less than or equal to the operand.",
+         "Returns true if the input is less than or equal to the operand and false otherwise.");
 
-#define LOGIC_ANY_SEQ_OP(NAME, OP)                                                        \
+#define LOGIC_ANY_SEQ_OP(NAME, OP, HELP_TEXT, OUTPUT_HELP_TEXT)                           \
   struct NAME : public BaseOpsBin {                                                       \
     SHVar activate(SHContext *context, const SHVar &input) {                              \
       const auto &value = _operand.get();                                                 \
@@ -192,10 +202,13 @@ LOGIC_OP(IsLessEqual, <=);
       }                                                                                   \
       return shards::Var::False;                                                          \
     }                                                                                     \
+    static SHOptionalString help() { return SHCCSTR(HELP_TEXT); }                         \
+    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyButType; }     \
+    static SHOptionalString outputHelp() { return SHCCSTR(OUTPUT_HELP_TEXT); }            \
   };                                                                                      \
   RUNTIME_CORE_SHARD_TYPE(NAME);
 
-#define LOGIC_ALL_SEQ_OP(NAME, OP)                                                           \
+#define LOGIC_ALL_SEQ_OP(NAME, OP, HELP_TEXT, OUTPUT_HELP_TEXT)                              \
   struct NAME : public BaseOpsBin {                                                          \
     SHVar activate(SHContext *context, const SHVar &input) {                                 \
       const auto &value = _operand.get();                                                    \
@@ -232,21 +245,63 @@ LOGIC_OP(IsLessEqual, <=);
       }                                                                                      \
       return shards::Var::False;                                                             \
     }                                                                                        \
+    static SHOptionalString help() { return SHCCSTR(HELP_TEXT); }                            \
+    static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyButType;}        \
+    static SHOptionalString outputHelp() { return SHCCSTR(OUTPUT_HELP_TEXT); }               \
   };                                                                                         \
   RUNTIME_CORE_SHARD_TYPE(NAME);
 
-LOGIC_ANY_SEQ_OP(IsAny, ==);
-LOGIC_ALL_SEQ_OP(IsAll, ==);
-LOGIC_ANY_SEQ_OP(IsAnyNot, !=);
-LOGIC_ALL_SEQ_OP(IsAllNot, !=);
-LOGIC_ANY_SEQ_OP(IsAnyMore, >);
-LOGIC_ALL_SEQ_OP(IsAllMore, >);
-LOGIC_ANY_SEQ_OP(IsAnyLess, <);
-LOGIC_ALL_SEQ_OP(IsAllLess, <);
-LOGIC_ANY_SEQ_OP(IsAnyMoreEqual, >=);
-LOGIC_ALL_SEQ_OP(IsAllMoreEqual, >=);
-LOGIC_ANY_SEQ_OP(IsAnyLessEqual, <=);
-LOGIC_ALL_SEQ_OP(IsAllLessEqual, <=);
+LOGIC_ANY_SEQ_OP(IsAny, ==,
+                 "Checks if any element in the input is equal to the given value. It returns true if any element is equal and "
+                 "false otherwise.",
+                 "Returns true if any element in the input is equal to the specified value and false otherwise.");
+LOGIC_ALL_SEQ_OP(IsAll, ==,
+                 "Checks if all elements in the input are equal to the given value. It returns true if all elements are equal "
+                 "and false otherwise.",
+                 "Returns true if all elements in the input are equal to the specified value and false otherwise.");
+LOGIC_ANY_SEQ_OP(IsAnyNot, !=,
+                 "Checks if any element in the input is not equal to the given value. It returns true if any element is not "
+                 "equal and false otherwise.",
+                 "Returns true if any element in the input is not equal to the specified value and false otherwise.");
+LOGIC_ALL_SEQ_OP(IsAllNot, !=,
+                 "Checks if all elements in the input are not equal to the given value. It returns true if all elements are "
+                 "not equal and false otherwise.",
+                 "Returns true if all elements in the input are not equal to the specified value and false otherwise.");
+LOGIC_ANY_SEQ_OP(IsAnyMore, >,
+                 "Checks if any element in the input is greater than the given value. It returns true if any element is "
+                 "greater and false otherwise.",
+                 "Returns true if any element in the input is greater than the specified value and false otherwise.");
+LOGIC_ALL_SEQ_OP(IsAllMore, >,
+                 "Checks if all elements in the input are greater than the given value. It returns true if all elements are "
+                 "greater and false otherwise.",
+                 "Returns true if all elements in the input are greater than the specified value and false otherwise.");
+LOGIC_ANY_SEQ_OP(IsAnyLess, <,
+                 "Checks if any element in the input is less than the given value. It returns true if any element is less and "
+                 "false otherwise.",
+                 "Returns true if any element in the input is less than the specified value and false otherwise.");
+LOGIC_ALL_SEQ_OP(IsAllLess, <,
+                 "Checks if all elements in the input are less than the given value. It returns true if all elements are less "
+                 "and false otherwise.",
+                 "Returns true if all elements in the input are less than the specified value and false otherwise.");
+LOGIC_ANY_SEQ_OP(
+    IsAnyMoreEqual, >=,
+    "Checks if any element in the input is greater than or equal to the given value. It returns true if any element is "
+    "greater or equal and false otherwise.",
+    "Returns true if any element in the input is greater than or equal to the specified value and false otherwise.");
+LOGIC_ALL_SEQ_OP(
+    IsAllMoreEqual, >=,
+    "Checks if all elements in the input are greater than or equal to the given value. It returns true if all elements are "
+    "greater or equal and false otherwise.",
+    "Returns true if all elements in the input are greater than or equal to the specified value and false otherwise.");
+LOGIC_ANY_SEQ_OP(IsAnyLessEqual, <=,
+                 "Checks if any element in the input is less than or equal to the given value. It returns true if any element "
+                 "is less or equal and false otherwise.",
+                 "Returns true if any element in the input is less than or equal to the specified value and false otherwise.");
+LOGIC_ALL_SEQ_OP(
+    IsAllLessEqual, <=,
+    "Checks if all elements in the input are less than or equal to the given value. It returns true if all elements are less "
+    "or equal and false otherwise.",
+    "Returns true if all elements in the input are less than or equal to the specified value and false otherwise.");
 
 #define LOGIC_OP_DESC(NAME)              \
   RUNTIME_CORE_SHARD_FACTORY(NAME);      \
@@ -259,6 +314,9 @@ LOGIC_ALL_SEQ_OP(IsAllLessEqual, <=);
   RUNTIME_SHARD_getParam(NAME);          \
   RUNTIME_SHARD_activate(NAME);          \
   RUNTIME_SHARD_requiredVariables(NAME); \
+  RUNTIME_SHARD_help(NAME);              \
+  RUNTIME_SHARD_inputHelp(NAME);         \
+  RUNTIME_SHARD_outputHelp(NAME);        \
   RUNTIME_SHARD_END(NAME);
 
 struct Input {

--- a/shards/modules/inputs/inputs.cpp
+++ b/shards/modules/inputs/inputs.cpp
@@ -37,6 +37,18 @@ enum ModifierKey {
 };
 DECL_ENUM_INFO(ModifierKey, ModifierKey, 'mdIf');
 
+struct InputsDefaultHelpText {
+  static inline const SHOptionalString InputsMouseKey =
+      SHCCSTR("Input of any type is accepted. The input is passed as input to the code specified in the Action parameter.");
+
+  static inline constexpr const char *InputConsume =
+      "If set to true, this event will be consumed. Meaning, if there was a previous shard with \"Consume\" set to true, all "
+      "subsequent calls of the same shard with the same key specified will not activate.";
+
+  static inline constexpr const char *InputConsumeIgnored = "If true, skips events already consumed by previous shards. If "
+                                                            "false, processes all events regardless of their consumed state.";
+};
+
 struct Types {
   static inline Type ModifierKeys = Type::SeqOf(ModifierKeyEnumInfo::Type);
 };
@@ -177,7 +189,18 @@ struct Base {
 
 struct MousePixelPos : public Base {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHTypesInfo outputTypes() { return CoreInfo::Int2Type; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns the pixel position of the cursor represented as a vector with 2 int elements.");
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns the current pixel position of the cursor within the input region, represented as an int2 "
+                   "vector. The first element represents the x position of the cursor, and the second element represents the y "
+                   "position of the cursor. The coordinates are in pixel space, with (0,0) being the top-left corner of the "
+                   "input region and (input-region-pixel-width, input-region-pixel-height) being the bottom-right corner.");
+  }
 
   PARAM_REQUIRED_VARIABLES();
   SHTypeInfo compose(const SHInstanceData &data) {
@@ -196,7 +219,17 @@ struct MousePixelPos : public Base {
 
 struct MouseDelta : public Base {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHTypesInfo outputTypes() { return CoreInfo::Float2Type; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns how much the mouse has moved since the last frame, represented as a vector with 2 float elements.");
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns how much the mouse has moved since the last frame as a float2 vector. The first "
+                   "element represents the horizontal movement (a positive value indicates movement to the right), and the "
+                   "second element represents the vertical movement (a positive value indicates movement downwards).");
+  }
 
   PARAM_REQUIRED_VARIABLES();
   SHTypeInfo compose(const SHInstanceData &data) {
@@ -221,6 +254,18 @@ struct MousePos : public Base {
   int _height;
 
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns the position of the cursor represented as a vector with 2 float elements.");
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns the current logical position of the cursor within the input region, represented as a "
+                   "float2 vector. The first element represents the x position of the cursor, and the second element represents "
+                   "the y position of the cursor. The coordinates are in the same space as the input region's size, with (0,0) "
+                   "being the top-left corner and (input-region-width,input-region-height) being the bottom-right corner.");
+  }
+
   static SHTypesInfo outputTypes() { return CoreInfo::Float2Type; }
 
   PARAM_REQUIRED_VARIABLES();
@@ -238,7 +283,16 @@ struct MousePos : public Base {
 
 struct InputRegionSize : public Base {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHTypesInfo outputTypes() { return CoreInfo::Float2Type; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns the size of the input region represented as a vector with two float elements.");
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns the size of the input region represented as a float2 vector. The first element represents "
+                   "the width of the region, and the second element represents the height of the region.");
+  }
 
   PARAM_REQUIRED_VARIABLES();
   SHTypeInfo compose(const SHInstanceData &data) {
@@ -255,7 +309,16 @@ struct InputRegionSize : public Base {
 
 struct InputRegionPixelSize : public Base {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHTypesInfo outputTypes() { return CoreInfo::Int2Type; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns the pixel size of the input region represented as a vector with two int elements.");
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns the pixel size of the input region represented as an int2 vector. The first element "
+                   "represents the width of the region, and the second element represents the height of the region.");
+  }
 
   PARAM_REQUIRED_VARIABLES();
   SHTypeInfo compose(const SHInstanceData &data) {
@@ -375,7 +438,26 @@ struct Mouse : public Base {
 template <bool Pressed> struct MouseUpDown : public Base {
   static SHTypesInfo inputTypes() { return shards::CoreInfo::AnyType; }
   static SHTypesInfo outputTypes() { return shards::CoreInfo::AnyType; }
-  static SHOptionalString help() { return SHCCSTR(""); }
+
+  static SHOptionalString inputHelp() { return InputsDefaultHelpText::InputsMouseKey; }
+
+  static SHOptionalString outputHelp() { return DefaultHelpText::OutputHelpPass; }
+
+  static SHOptionalString help() {
+    if constexpr (Pressed == true) {
+      return SHCCSTR(
+          "Checks if the appropriate mouse button is pressed down. If it is pressed down, the shard executes the code "
+          "specified in the respective parameter on the frame the button is pressed down. (If the Right Mouse button was "
+          "pressed down, the code specified in the Right parameter will be executed.)");
+    } else if constexpr (Pressed == false) {
+      return SHCCSTR("Checks if the appropriate mouse button is released. If it is released, the shard executes the code "
+                     "specified in the respective parameter on the frame the button is released.(If the Right Mouse button was "
+                     "released, the code specified in the Right parameter will be executed.)");
+
+    } else {
+      return SHCCSTR("Checks if the appropriate mouse button event happened.");
+    }
+  }
 
   PARAM(ShardsVar, _leftButton, "Left", "The action to perform when the left mouse button is pressed down.",
         {CoreInfo::ShardsOrNone});
@@ -383,19 +465,26 @@ template <bool Pressed> struct MouseUpDown : public Base {
         {CoreInfo::ShardsOrNone});
   PARAM(ShardsVar, _middleButton, "Middle", "The action to perform when the middle mouse button is pressed down.",
         {CoreInfo::ShardsOrNone});
-  PARAM_VAR(_consume, "Consume", "Consume events.", {CoreInfo::NoneType, CoreInfo::BoolType});
-  PARAM_VAR(_ignoreConsumed, "IgnoreConsumed", "Ignore consumed events.", {CoreInfo::NoneType, CoreInfo::BoolType});
+  PARAM_VAR(_consume, "Consume", InputsDefaultHelpText::InputConsume, {CoreInfo::BoolType});
+  PARAM_VAR(_skipConsumed, "SkipConsumed", InputsDefaultHelpText::InputConsumeIgnored, {CoreInfo::BoolType});
   PARAM_IMPL(PARAM_IMPL_FOR(_leftButton), PARAM_IMPL_FOR(_rightButton), PARAM_IMPL_FOR(_middleButton), PARAM_IMPL_FOR(_consume),
-             PARAM_IMPL_FOR(_ignoreConsumed));
+             PARAM_IMPL_FOR(_skipConsumed));
 
-  bool ignoreConsumed{};
-  bool consume{};
+  bool ignoreConsumed{true};
+  bool consume{true};
+
+public:
+  MouseUpDown() {
+    // Set default values for _consume and _skipConsumed
+    *_consume = Var(true);
+    *_skipConsumed = Var(true);
+  }
 
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
     baseWarmup(context);
-    ignoreConsumed = _ignoreConsumed->isNone() ? true : (bool)*_ignoreConsumed;
-    consume = _consume->isNone() ? true : (bool)*_consume;
+    ignoreConsumed = (bool)*_skipConsumed;
+    consume = (bool)*_consume;
   }
 
   void cleanup(SHContext *context) {
@@ -462,22 +551,55 @@ template <bool Pressed> struct MouseUpDown : public Base {
 
 template <bool Pressed> struct KeyUpDown : public Base {
 
+  SHTypesInfo inputTypes() { return shards::CoreInfo::AnyType; }
+  static SHOptionalString inputHelp() { return InputsDefaultHelpText::InputsMouseKey; }
+  SHTypesInfo outputTypes() { return shards::CoreInfo::AnyType; }
+  static SHOptionalString outputHelp() { return DefaultHelpText::OutputHelpPass; }
+
+  static SHOptionalString help() {
+    if constexpr (Pressed == true) {
+      return SHCCSTR("This shard checks if the key specified is pressed down. If the key is pressed down, the shard executes the "
+                     "code specified in the Action parameter on the "
+                     "frame the key is pressed down. If the Repeat parameter is set to true, the code specified in the Action "
+                     "parameter will be repeated every frame the key is held down instead.");
+    } else if constexpr (Pressed == false) {
+      return SHCCSTR("This shard checks if the key specified is released. If the key is released, the shard executes the code "
+                     "specified in the Action parameter on the "
+                     "frame the key is released.");
+    } else {
+      return SHCCSTR("Checks if a key event happened.");
+    }
+  }
+
+  static inline constexpr const char *RepeatHelp =
+      Pressed ? "If set to true, the event specified in the Action parameter will be repeated if the key is held down. "
+                "Otherwise, the event will be executed only on the frame the key is pressed down."
+              : "This parameter is ignored for Inputs.KeyUp.";
+
   PARAM_VAR(_key, "Key", "The key to check.", {{CoreInfo::StringType}});
-  PARAM(ShardsVar, _shards, "Action", "The Shards to run if a key event happened.", {CoreInfo::ShardsOrNone});
-  PARAM_VAR(_repeat, "Repeat", "If the key event should be repeated.", {{CoreInfo::NoneType, CoreInfo::BoolType}});
-  PARAM_VAR(_modifiers, "Modifiers", "Modifier keys to check.", {CoreInfo::NoneType, Types::ModifierKeys});
-  PARAM_VAR(_consume, "Consume", "Consume events.", {CoreInfo::NoneType, CoreInfo::BoolType});
-  PARAM_VAR(_ignoreConsumed, "IgnoreConsumed", "Ignore consumed events.", {CoreInfo::NoneType, CoreInfo::BoolType});
+  PARAM(ShardsVar, _shards, "Action", "The code to run if the key event happened.", {CoreInfo::ShardsOrNone});
+  PARAM_VAR(_repeat, "Repeat", RepeatHelp, {CoreInfo::BoolType});
+  PARAM_VAR(_modifiers, "Modifiers",
+            "Modifier keys to check for such as \"leftctrl\", \"leftshift\", \"leftalt\", \"rightctrl\", \"rightshift\", "
+            "\"rightalt\", etc.",
+            {CoreInfo::NoneType, Types::ModifierKeys});
+  PARAM_VAR(_consume, "Consume", InputsDefaultHelpText::InputConsume, {CoreInfo::BoolType});
+  PARAM_VAR(_skipConsumed, "SkipConsumed", InputsDefaultHelpText::InputConsumeIgnored, {CoreInfo::BoolType});
   PARAM_IMPL(PARAM_IMPL_FOR(_key), PARAM_IMPL_FOR(_shards), PARAM_IMPL_FOR(_repeat), PARAM_IMPL_FOR(_modifiers),
-             PARAM_IMPL_FOR(_consume), PARAM_IMPL_FOR(_ignoreConsumed));
+             PARAM_IMPL_FOR(_consume), PARAM_IMPL_FOR(_skipConsumed));
 
   SDL_Keymod _modifierMask;
   SDL_Keycode _keyCode;
-  bool ignoreConsumed{};
-  bool consume{};
+  bool ignoreConsumed{true};
+  bool consume{true};
 
 public:
-  KeyUpDown() { _repeat = Var(false); }
+  KeyUpDown() {
+    _repeat = Var(false);
+    // Set default values for _consume and _skipConsumed
+    *_consume = Var(true);
+    *_skipConsumed = Var(true);
+  }
 
   void cleanup(SHContext *context) {
     _shards.cleanup(context);
@@ -489,8 +611,8 @@ public:
     baseWarmup(context);
     _modifierMask = convertModifierKeys(*_modifiers);
     _keyCode = keyStringToKeyCode(std::string(SHSTRVIEW(_key)));
-    ignoreConsumed = _ignoreConsumed->isNone() ? true : (bool)*_ignoreConsumed;
-    consume = _consume->isNone() ? true : (bool)*_consume;
+    ignoreConsumed = (bool)*_skipConsumed;
+    consume = (bool)*_consume;
   }
 
   PARAM_REQUIRED_VARIABLES();
@@ -532,9 +654,21 @@ public:
 
 struct MatchModifier : public Base {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHTypesInfo outputTypes() { return CoreInfo::BoolType; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR(
+        "Returns a boolean value: true if any of the specified modifier keys are currently pressed down and false otherwise.");
+  }
 
-  PARAM_VAR(_modifiers, "Modifiers", "Modifier keys to check.", {CoreInfo::NoneType, Types::ModifierKeys});
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns true if any of the modifier keys in the sequence provided in the Modifier parameter are "
+                   "currently pressed down, and false otherwise.");
+  }
+
+  PARAM_VAR(_modifiers, "Modifiers",
+            "Sequence of Modifier keys to check for such as Modifier::Shift, Modifier::Alt, Modifier::Primary and "
+            "Modifier::Secondary.", {CoreInfo::NoneType, Types::ModifierKeys});
   PARAM_IMPL(PARAM_IMPL_FOR(_modifiers));
 
   SDL_Keymod _modifierMask;
@@ -565,13 +699,21 @@ struct MatchModifier : public Base {
 
 struct IsKeyDown : public Base {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHTypesInfo outputTypes() { return CoreInfo::BoolType; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns a boolean value indicating whether the specified key is currently pressed down.");
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard returns true if the key specified is currently pressed down, and false otherwise.");
+  }
 
   SDL_Keycode _keyCode;
   std::string _keyName;
 
   static inline Parameters _params = {
-      {"Key", SHCCSTR("The name of the key to check."), {{CoreInfo::StringType}}},
+      {"Key", SHCCSTR("The key to check."), {{CoreInfo::StringType}}},
   };
 
   static SHParametersInfo parameters() { return _params; }
@@ -616,7 +758,22 @@ struct IsKeyDown : public Base {
 struct HandleURL : public Base {
   std::string _url;
 
-  PARAM(ShardsVar, _action, "Action", "The Shards to run if a text/file drop event happened.", {CoreInfo::ShardsOrNone});
+  static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpPass; }
+
+  SHTypesInfo outputTypes() { return shards::CoreInfo::AnyType; }
+  static SHOptionalString outputHelp() { return DefaultHelpText::OutputHelpPass; }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard listens to file drop events and URL events. When files are dropped onto the application or URLs "
+                   "events are received, "
+                   "this shard executes the specified Action for each file dropped or URL event received. The file path or URL "
+                   "is then passed as a string to "
+                   "the Action.");
+  }
+
+  PARAM(ShardsVar, _action, "Action", "Code to execute when a file drop event or URL event is received.",
+        {CoreInfo::ShardsOrNone});
   PARAM_IMPL(PARAM_IMPL_FOR(_action));
 
   void cleanup(SHContext *context) {
@@ -747,7 +904,7 @@ SHARDS_REGISTER_FN(inputs) {
   REGISTER_SHARD("Inputs.Mouse", Mouse);
   REGISTER_SHARD("Inputs.IsKeyDown", IsKeyDown);
   REGISTER_SHARD("Inputs.HandleURL", HandleURL);
-  REGISTER_SHARD("Inputs.DiscardTempFiles", DiscardTempFiles);
+  REGISTER_SHARD("_Inputs.DiscardTempFiles", DiscardTempFiles); // Ignored for docs
 
   using MouseDown = MouseUpDown<true>;
   using MouseUp = MouseUpDown<false>;

--- a/shards/tests/isAny-x-test.shs
+++ b/shards/tests/isAny-x-test.shs
@@ -1,0 +1,210 @@
+@wire(spawn{
+  Msg("Hello")
+} Looped: false)
+
+
+
+@wire(main-wire {
+  Audio.ReadFile("./data/Ode_to_Joy.ogg" From: 1.0 To: 2.0) = audio
+  LoadImage("../../assets/ShardsLogo.png") = image
+  image | ToString = img-string
+  [1] | IntsToBytes = bytes
+
+  [5 @i2(5) @i3(5) @i4(5) @i8(5) @i16(5) 5.0 @f2(5.0) @f3(5.0) @f4(5.0) @color(255) spawn {table:1} [1 2 3 4 5] [1.0 2.0 3.0 4.0 5.0] audio true image bytes "Hello" none] = input-seq
+  
+  input-seq
+  TryMany(
+    Wire: {IsAny(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true false false false false false false false false false false false false true false false false false false false false])
+  Log("IsAnyResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAny(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false true false false false false false false false true false false false false false false])
+  Log("IsAnyResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAll(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true false false false false false false false false false false false false false false false false false false false false])
+  Log("IsAllResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAll(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false true false false false false false false false false false false false false false false])
+  Log("IsAllResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllNot(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false true true true true true true true true true true true true false true true true true true true true])
+  Log("IsAllNotResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllNot(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true false true true true true true true true false true true true true true true])
+  Log("IsAllNotResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyNot(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false true true true true true true true true true true true true true true true true true true true true])
+  Log("IsAnyNotResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyNot(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true false true true true true true true true true true true true true true true])
+  Log("IsAnyNotResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyLess(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false false false false false false false false true false false true false false false true])
+  Log("IsAnyLessResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyLess(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true false false false false false false false true true false true false false false true])
+  Log("IsAnyLessResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllLess(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false false false false false false false false false false false true false false false true])
+  Log("IsAllLessResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllLess(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true false false false false false false false true false false true false false false true])
+  Log("IsAllLessResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyMore(1)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true true true true true true true true true true true false true true true false])
+  Log("IsAnyMoreResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyMore(1.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false true true true true true true true false true true false true true true false])
+  Log("IsAnyMoreResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllMore(1)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true true true true true true true true false true true false true true true false])
+  Log("IsAllMoreResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllMore(1.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false true true true true true true true false false true false true true true false])
+  Log("IsAllMoreResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyLessEqual(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true false false false false false false false false false false false false true false false true false false false true])
+  Log("IsAnyLessEqualResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyLessEqual(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true true false false false false false false true true false true false false false true])
+  Log("IsAnyLessEqualResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllLessEqual(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true false false false false false false false false false false false false true false false true false false false true])
+  Log("IsAllLessEqualResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllLessEqual(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true true false false false false false false true true false true false false false true])
+  Log("IsAllLessEqualResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyMoreEqual(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true true true true true true true true true true true false true true true false])
+  Log("IsAnyMoreEqualResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAnyMoreEqual(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false true true true true true true true false true true false true true true false])
+  Log("IsAnyMoreEqualResult-2")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllMoreEqual(5)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([true true true true true true true true true true true true true false true true false true true true false])
+  Log("IsAllMoreEqualResult-1")
+
+  input-seq
+  TryMany(
+    Wire: {IsAllMoreEqual(5.0)}
+    Policy: WaitUntil::SomeSuccess
+  )
+  Assert.Is([false false false false false false true true true true true true true false false true false true true true false])
+  Log("IsAllMoreEqualResult-2")
+} Looped: false)
+
+@mesh(root)
+@schedule(root main-wire)
+@run(root) | Assert.Is(true)


### PR DESCRIPTION
- Added input help, output help and help texts for Input shards
- Added input help, output help and help texts for IsAny, IsAll , IsAllEqual etc.shards
- Added test script for IsAny-x shards
- changed IgnoreConsumed parameter on some Input shard to SkipConsumed for better clarity
- Removed None types from Consume and SkipConsumed parameters and ensured they had the appropriate default values


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
