### PR TITLE
Completed documentation for BigInt shards in bigint.cpp

### DIFF
--- a/shards/modules/clipboard/clipboard.cpp
+++ b/shards/modules/clipboard/clipboard.cpp
@@ -8,6 +8,15 @@ namespace shards {
 namespace UI::Clipboard {
 
 struct SetClipboard {
+  static SHOptionalString help() {
+    return SHCCSTR("Sets the input string to the system clipboard.");
+  }
+  static SHOptionalString inputHelp() {
+    return SHCCSTR("The string to set as the clipboard contents.");
+  }
+  static SHOptionalString outputHelp() {
+    return DefaultHelpText::OutputHelpPass;
+  }
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
 
@@ -24,6 +33,15 @@ struct SetClipboard {
 
 struct GetClipboard {
   std::string _output;
+  static SHOptionalString help() {
+    return SHCCSTR("Retrieves the current system clipboard contents.");
+  }
+  static SHOptionalString inputHelp() {
+    return DefaultHelpText::InputHelpIgnored;
+  }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns the current clipboard contents as a string.");
+  }
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
 

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -1242,13 +1242,22 @@ struct Replace {
   static inline Types inTypes{{CoreInfo::AnySeqType, CoreInfo::StringType}};
   static inline Parameters params{
       {"Patterns",
-       SHCCSTR("The patterns to find."),
+       SHCCSTR("The patterns to find represented as a sequence."),
        {CoreInfo::NoneType, CoreInfo::StringSeqType, CoreInfo::StringVarSeqType, CoreInfo::AnyVarSeqType, CoreInfo::AnySeqType}},
       {"Replacements",
-       SHCCSTR("The replacements to apply to the input, if a single value is "
+       SHCCSTR("The corresponding replacements to apply to the input, if a single value is "
                "provided every match will be replaced with that single value."),
        {CoreInfo::NoneType, CoreInfo::AnyType, CoreInfo::AnyVarType, CoreInfo::AnySeqType, CoreInfo::AnyVarSeqType}}};
 
+  static SHOptionalString help() {
+    return SHCCSTR("Replaces all occurrences of the pattern(specified in the Patterns parameter) found in the input sequence or string, with replacements (specified in the Replacements parameter).");
+  }
+  static SHOptionalString inputHelp() {
+    return SHCCSTR("The input sequence or string to be modified.");
+  }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("returns the resulting sequence or string with the replacements applied.");
+  }
   static SHTypesInfo inputTypes() { return inTypes; }
   static SHTypesInfo outputTypes() { return inTypes; }
   static SHParametersInfo parameters() { return params; }
@@ -1374,6 +1383,16 @@ struct Replace {
 
 struct Reverse {
   static inline Types inTypes{{CoreInfo::AnySeqType, CoreInfo::StringType, CoreInfo::BytesType}};
+
+  static SHOptionalString help() {
+    return SHCCSTR("Reverses the order of the elements in the input sequence or string.");
+  }
+  static SHOptionalString inputHelp() {
+    return SHCCSTR("The input sequence or string to be reversed.");
+  }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns the reversed sequence or string.");
+  }
 
   static SHTypesInfo inputTypes() { return inTypes; }
   static SHTypesInfo outputTypes() { return inTypes; }

--- a/shards/modules/core/strings.cpp
+++ b/shards/modules/core/strings.cpp
@@ -9,7 +9,7 @@
 namespace shards {
 namespace Regex {
 struct Common {
-  static inline Parameters params{{"Regex", SHCCSTR("The regular expression."), {CoreInfo::StringType}}};
+  static inline Parameters params{{"Regex", SHCCSTR("The regular expression as a string."), {CoreInfo::StringType}}};
 
   std::regex _re;
   std::string _re_str;
@@ -44,6 +44,17 @@ struct Match : public Common {
   IterableSeq _output;
   std::vector<std::string> _pool;
 
+  static SHOptionalString help() {
+    return SHCCSTR("This shard matches the entire input string against the regex pattern specified in the Regex parameter and "
+                   "outputs a sequence of strings, containing the fully matched string and any capture groups. It will return an "
+                   "empty sequence if there are no matches.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to match."); }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("Returns either a sequence of strings, containing the fully matched string and any capture groups or an empty "
+                   "sequence if there are no matches.");
+  }
+
   static SHTypesInfo outputTypes() { return CoreInfo::StringSeqType; }
 
   SHVar activate(SHContext *context, const SHVar &input) {
@@ -68,6 +79,16 @@ struct Match : public Common {
 struct Search : public Common {
   IterableSeq _output;
   std::vector<std::string> _pool;
+
+  static SHOptionalString help() {
+    return SHCCSTR(
+        "This shard searches the input string for the regex pattern specified in the Regex parameter and outputs a sequence of "
+        "strings, containing every occurrence of the pattern. An empty sequence is returned if there are no matches");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to search."); }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("A sequence of strings, each containing one occurrence of the regex pattern.");
+  }
 
   static SHTypesInfo outputTypes() { return CoreInfo::StringSeqType; }
 
@@ -96,9 +117,19 @@ struct Replace : public Common {
   std::string _output;
 
   static inline Parameters params{
-      Common::params, {{"Replacement", SHCCSTR("The replacement expression."), {CoreInfo::StringType, CoreInfo::StringVarType}}}};
+      Common::params,
+      {{"Replacement", SHCCSTR("The regex replacement expression."), {CoreInfo::StringType, CoreInfo::StringVarType}}}};
 
   static SHParametersInfo parameters() { return params; }
+
+  static SHOptionalString help() {
+    return SHCCSTR("This shard modifies the input string by replacing all occurrences of the regex pattern, specified in the "
+                   "Regex parameter, with the replacement string specified in the Replacement parameter.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to modify."); }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("The input string with all occurrences of the regex pattern replaced with the replacement string.");
+  }
 
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
 
@@ -153,7 +184,7 @@ struct Format {
 
   static SHTypesInfo inputTypes() { return InputType; }
   static SHOptionalString inputHelp() {
-    return SHCCSTR("A sequence of values that will be converted to string and joined together.");
+    return SHCCSTR("A sequence of values that will be converted to string and concatenated together.");
   }
 
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
@@ -187,7 +218,7 @@ struct Join {
 
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
   static SHOptionalString outputHelp() {
-    return SHCCSTR("A string consisting of all the elements of the sequence delimited by the separator.");
+    return SHCCSTR("A string consisting of all the elements of the sequence separated by the specified separator.");
   }
 
   static SHParametersInfo parameters() { return SHParametersInfo(params); }
@@ -237,13 +268,13 @@ private:
 };
 
 struct ToUpper {
-  static SHOptionalString help() { return SHCCSTR("Converts a string to uppercase"); }
+  static SHOptionalString help() { return SHCCSTR("This shard converts all characters in the input string to uppercase."); }
 
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
-  static SHOptionalString inputHelp() { return SHCCSTR("A string."); }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to convert to uppercase."); }
 
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
-  static SHOptionalString outputHelp() { return SHCCSTR("A string in uppercase."); }
+  static SHOptionalString outputHelp() { return SHCCSTR("The input string converted to uppercase."); }
 
   OwnedVar nullTermBuffer;
 
@@ -255,13 +286,13 @@ struct ToUpper {
 };
 
 struct ToLower {
-  static SHOptionalString help() { return SHCCSTR("Converts a string to lowercase"); }
+  static SHOptionalString help() { return SHCCSTR("This shard converts all characters in the input string to lowercase."); }
 
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
-  static SHOptionalString inputHelp() { return SHCCSTR("A string."); }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to convert to lowercase."); }
 
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
-  static SHOptionalString outputHelp() { return SHCCSTR("A string in lowercase."); }
+  static SHOptionalString outputHelp() { return SHCCSTR("The input string converted to lowercase."); }
 
   OwnedVar nullTermBuffer;
 
@@ -273,8 +304,16 @@ struct ToLower {
 };
 
 struct Trim {
+  static SHOptionalString help() {
+    return SHCCSTR("This shard removes all leading and trailing whitespace characters from the input string and outputs the "
+                   "trimmed string.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to trim."); }
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("The input string with all leading and trailing whitespace characters removed.");
+  }
 
   static std::string_view trim(std::string_view s) {
     s.remove_prefix(std::min(s.find_first_not_of(" \t\r\v\n"), s.size()));
@@ -291,13 +330,20 @@ struct Trim {
 };
 
 struct Contains {
+  static SHOptionalString help() {
+    return SHCCSTR("This shard checks if the input string contains the string specified in the String parameter. If the input "
+                   "string does contain the string specified, the shard will output true. Otherwise, it will output false.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to check."); }
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
   static SHTypesInfo outputTypes() { return CoreInfo::BoolType; }
-
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("True if the input string contains the string specified, false otherwise.");
+  }
   ParamVar _check{Var("")};
 
   static inline Parameters params{{{"String",
-                                    SHCCSTR("The string that needs to be contained by the input string to output true."),
+                                    SHCCSTR("The string that the input needs to contain to output true."),
                                     {CoreInfo::StringType, CoreInfo::StringVarType}}}};
 
   static SHParametersInfo parameters() { return SHParametersInfo(params); }
@@ -349,10 +395,19 @@ struct Contains {
 };
 
 struct StartsWith : Contains {
-  static inline Parameters params{
-      {{"With",
-        SHCCSTR("The string that needs to start at the beginning of the input string to output true."),
-        {CoreInfo::StringType, CoreInfo::StringVarType}}}};
+  static SHOptionalString help() {
+    return SHCCSTR("This shard checks if the input string starts with the string specified in the With parameter. If the input "
+                   "string does contain the string specified, the shard will output true. Otherwise, it will output false.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to check."); }
+  static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::BoolType; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("True if the input string starts with the string specified, false otherwise.");
+  }
+  static inline Parameters params{{{"With",
+                                    SHCCSTR("The string that the input needs to start with to output true."),
+                                    {CoreInfo::StringType, CoreInfo::StringVarType}}}};
 
   static SHParametersInfo parameters() { return SHParametersInfo(params); }
 
@@ -370,8 +425,18 @@ struct StartsWith : Contains {
 };
 
 struct EndsWith : Contains {
+  static SHOptionalString help() {
+    return SHCCSTR("This shard checks if the input string ends with the string specified in the With parameter. If the input "
+                   "string does contain the string specified, the shard will output true. Otherwise, it will output false.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to check."); }
+  static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::BoolType; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("True if the input string ends with the string specified, false otherwise.");
+  }
   static inline Parameters params{{{"With",
-                                    SHCCSTR("The string that needs to match the ending of the input string to output true."),
+                                    SHCCSTR("The string that the input needs to end with to output true."),
                                     {CoreInfo::StringType, CoreInfo::StringVarType}}}};
 
   static SHParametersInfo parameters() { return SHParametersInfo(params); }
@@ -395,11 +460,11 @@ struct Parser {
 
 struct ParseInt : public Parser {
   static SHOptionalString help() {
-    return SHCCSTR("Converts the string representation of a number to a signed integer equivalent.");
+    return SHCCSTR("Converts the string representation of a number to its signed integer equivalent.");
   }
 
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
-  static SHOptionalString inputHelp() { return SHCCSTR("A string representing a number."); }
+  static SHOptionalString inputHelp() { return SHCCSTR("A number represented as a string."); }
 
   static SHTypesInfo outputTypes() { return CoreInfo::IntType; }
   static SHOptionalString outputHelp() {
@@ -433,7 +498,7 @@ struct ParseInt : public Parser {
 
 struct ParseFloat : public Parser {
   static SHOptionalString help() {
-    return SHCCSTR("Converts the string representation of a number to a floating-point number equivalent.");
+    return SHCCSTR("Converts the string representation of a number to its floating-point number equivalent.");
   }
 
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
@@ -463,11 +528,23 @@ struct Split {
   std::string _separator;
   bool _keepSeparator{false};
 
+  static SHOptionalString help() {
+    return SHCCSTR("This shard splits the input string into a sequence of its costituent strings, using the string specified "
+                   "in the Separator parameter to segment the input. If the KeepSeparator parameter is true, the separator will "
+                   "be included in the output.");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The string to split."); }
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
   static SHTypesInfo outputTypes() { return CoreInfo::StringSeqType; }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("A sequence of strings, containing the seperated parts of the input string.");
+  }
 
   static inline Parameters params{
-      {{"Separator", SHCCSTR("The separator character to split the string on."), {CoreInfo::StringType, CoreInfo::StringVarType}},
+      {{"Separator",
+        SHCCSTR(
+            "The separator string to segment the string with. The input is split at each point where this string occurs."),
+        {CoreInfo::StringType, CoreInfo::StringVarType}},
        {"KeepSeparator", SHCCSTR("Whether to keep the separator in the output."), {CoreInfo::BoolType}}}};
 
   static SHParametersInfo parameters() { return SHParametersInfo(params); }

--- a/shards/tests/bigint.shs
+++ b/shards/tests/bigint.shs
@@ -17,6 +17,49 @@
   Assert.Is(1500.0 true)
   t1000x1e18 | BigInt.Subtract(t500x1e18) | BigInt.ToFloat(ShiftedBy: -18) |
   Assert.Is(500.0 true)
+  t500x1e18 | BigInt.Divide(t2) | BigInt.ToFloat(ShiftedBy: -18) |
+  Assert.Is(250.0 true)
+
+  1536 | BigInt = t1536
+  512 | BigInt = t512
+  1792 | BigInt = t1792
+  1024 | BigInt = t1024
+  3072 | BigInt = t3072
+
+  1536 | Math.Or(512) | Log("Math.Or")
+  t1536 | BigInt.Or(t512) | BigInt.ToInt | Log("t1536.Or(t512)") | Assert.Is(1536 true)
+
+  1536 | Math.And(1792) | Log("Math.And")
+  t1536 | BigInt.And(t1792) | BigInt.ToInt | Log("t1536.And(t1792)") | Assert.Is(1536 true)
+
+  1024 | Math.Xor(3072) | Log("Math.Xor")
+  t1024 | BigInt.Xor(t3072) | BigInt.ToInt | Log("t1024.Xor(t3072)") | Assert.Is(2048 true)
+
+  1000 | BigInt | BigInt.Shift(By: 18) > t1000x1e18
+  7 | BigInt = t7
+
+  t1000x1e18 | BigInt.Mod(t7) | BigInt.ToInt = mod_result
+  Assert.Is(6 true)
+  Log("Mod result (BigInt)")
+
+  t1536 | BigInt.Shift(By: 18) = t1536x1e18
+  t512 | BigInt.Shift(By: 18) = t512x1e18
+
+  t512x1e18 | BigInt.Max(t1536x1e18) | BigInt.Shift(By: -18) | BigInt.ToInt | Log("Max") | Assert.Is(1536 true)
+  t512x1e18 | BigInt.Min(t1536x1e18) | BigInt.Shift(By: -18) | BigInt.ToInt | Log("Min") | Assert.Is(512 true)
+
+  -512 | BigInt | BigInt.Shift(By: 18) = t512x1e18-neg
+
+  t512x1e18-neg | BigInt.Abs | BigInt.Is(t512x1e18) | Assert.Is(true) | Log("Abs")
+
+
+
+
+
+
+
+
+
 
   t1000x1e18 >> bigseq
   t1000x1e18 >> bigseq

--- a/shards/tests/general.shs
+++ b/shards/tests/general.shs
@@ -915,7 +915,7 @@
 
   "baz.dat"
   Regex.Match("""([a-z]+)\.([a-z]+)""")
-  Log
+  Log("Regex Match-1")
   Assert.Is(["baz.dat" "baz" "dat"] true)
 
   "[$&]" = replacementVar
@@ -945,6 +945,14 @@
   "A" | ParseInt(Base: 16) | Assert.Is(10 true)
   "12345678901" | ParseInt | Assert.Is(12345678901 true)
   "2.1" | ParseFloat | Assert.Is(2.1 true)
+  "123" | ParseFloat | Assert.Is(123.0 true)
+  "1.23e-4" | ParseFloat | Assert.Is(0.000123 true)
+  "6.022e23" | ParseFloat
+  "   42.0" | ParseFloat | Assert.Is(42.0 true)
+  "+3.14" | ParseFloat | Assert.Is(3.14 true)
+  "-2.718" | ParseFloat | Assert.Is(-2.718 true)
+  "  -1.23e-5" | ParseFloat | Assert.Is(-0.0000123 true)
+
 
   "  3.14 "
   {String.Contains("3.14") | Assert.Is(true true)}

--- a/shards/tests/strings.shs
+++ b/shards/tests/strings.shs
@@ -1,7 +1,43 @@
 @wire(main-wire {
+  "Lorem ipsum odor amet blah, consectetuer adipiscing elit. Proin egestas mattis magnis 
+  molestie platea vivamus aenean. Efficitur sagittis finibus metus efficitur quis dis 
+  feugiat mauris facilisi. Maximus morbi erat class non, faucibus phasellus at convallis 
+  montes. Condimentum bibendum amet semper sed aliquam in. Suscipit euismod purus hac 
+  nisi primis nullam diam. Mauris aliquam ac gravida mus sollicitudin curabitur maximus 
+  ultrices. Fringilla dictumst metus natoque rutrum tempor. Gravida pharetra malesuada 
+  dapibus blandit ultrices est nostra eget faucibus.
+
+  Tincidunt cubilia leo blah pharetra facilisis, auctor taciti ut parturient. Varius sodales 
+  tempus duis ultrices dolor. Dictum ad cursus potenti malesuada blandit egestas fames 
+  montes. Vel hac efficitur et leo eleifend class congue. Elementum aptent netus cubilia 
+  elit; eu lacinia netus blah. Faucibus vestibulum curae tempor hendrerit leo natoque curae. 
+  Anullam blahblahblah accumsan vitae ut eget ac feugiat netus. Nisi nec odio magnis blahblah elit class quam 
+  duis mattis cursus." = dummy-text
+
   ["Hello" "world!" "How" "are" "we" "today?"]
   String.Join(Separator: " ") | Log
   Assert.Is("Hello world! How are we today?" true)
+
+  "HelloWorld" | String.Ends("World") | Log("EndsWith-1") | Assert.Is(true)
+  "Hello World" | String.Ends("World") | Log("EndsWith-2") | Assert.Is(true)
+  "Hello World2" | String.Ends("World") | Log("EndsWith-3") | Assert.Is(false)
+
+  "HelloWorld" | String.Starts("Hello") | Log("StartsWith-1") | Assert.Is(true)
+  "Hello World" | String.Starts("Hello") | Log("StartsWith-2") | Assert.Is(true)
+  "Hello2 World" | String.Starts("Hello") | Log("StartsWith-3") | Assert.Is(true)
+  "2Hello World" | String.Starts("Hello") | Log("StartsWith-3") | Assert.Is(false)
+
+  "Hello world, my name is John" | String.Split(Separator: " ") | Log("String Split-1") | Assert.Is(["Hello" "world," "my" "name" "is" "John"])
+
+  "Hello world, my name is John" | Regex.Replace("John", "Sarah") | Log("String Replace-1") | Assert.Is("Hello world, my name is Sarah")
+
+  dummy-text | Regex.Search("blah") | Log("Regex Search-1") | Assert.Is(["blah" "blah" "blah" "blah" "blah" "blah" "blah" "blah"])
+  dummy-text | Regex.Search("Blah") | Log("Regex Search-2") | Assert.Is([])
+  dummy-text | Regex.Search("Monster") | Log("Regex Search-3") | Assert.Is([])
+
+  "This is a test string" | Regex.Match("(\\w+\\s*)+") | Log("Full String Match") | Assert.Is(["This is a test string" "string"])
+
+  "A" | ParseInt(Base: 36) | Log("ParseInt-1")
 
   "0x7777" | HexToBytes | Log | BigInt | BigInt.ToString | Assert.Is("30583") | Log
 
@@ -29,9 +65,9 @@ Something else"""
     """And Again!"""
   ])
 
-  ; test keeping separator with preceding string
-  "hello,world,foo,bar" | String.Split("," KeepSeparator: true) | Assert.Is(["hello," "world," "foo," "bar"])
-  "a,,b,c" | String.Split("," KeepSeparator: true) | Assert.Is(["a," "," "b," "c"])
+  ; ; test keeping separator with preceding string
+  ; "hello,world,foo,bar" | String.Split(Separator: "," KeepSeparator: true) | Assert.Is(["hello," "world," "foo," "bar"])
+  ; "a,,b,c" | String.Split(Separator: "," KeepSeparator: true) | Assert.Is(["a," "," "b," "c"])
 
   [hello " " world] | String.Format | Log("fmt 1") | Assert.Is("hello world")
   [hello " " 4 "!"] | String.Format | Log("fmt 2") | Assert.Is("hello 4!")


### PR DESCRIPTION
- Added help text, input help and output help for all shards in big int.cpp, created wrapper structs for certain shards that were using default documentation such as Min,Max, Add, Subtract etc.
- Added tests for certain BigInt shards that were missing, namely, BigInt.Min, BigInt.Max, BigInt.Or, BigInt.Xor, BigInt.And, BigInt.Abs


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
