### PR TITLE
refactor(types): Replace 'exposed' flag with 'tracked' and 'declared'

### DIFF
--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -523,8 +523,11 @@ struct SHExposedTypeInfo {
   // If the exposed variable should be available to all wires in the mesh
   SHBool global;
 
-  // If the variable is market as exposed, apps building on top will can use this feature
-  SHBool exposed;
+  // If the variable is market as tracked, apps building on top will can use this feature
+  SHBool tracked;
+
+  // If the variable is declared in this shard (not inherited from an inner shard)
+  SHBool declared;
 };
 
 typedef struct SHStringPayload {

--- a/shards/core/brancher.hpp
+++ b/shards/core/brancher.hpp
@@ -123,7 +123,7 @@ public:
 
     // Clear exposed flags, since these are copies
     for (auto &req : _mergedRequirements._innerInfo) {
-      req.exposed = false;
+      req.tracked = false;
     }
 
     // Copy shared

--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -285,6 +285,8 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
   struct ComposeData {
     // List of output types used for this wire
     std::vector<SHTypeInfo> outputTypes;
+    // name, isMutable
+    std::unordered_map<std::string_view, bool> declaredVariables;
   };
   std::shared_ptr<ComposeData> composeData;
 

--- a/shards/egui/src/egui_host.rs
+++ b/shards/egui/src/egui_host.rs
@@ -34,7 +34,8 @@ impl Default for EguiHost {
         isMutable: false,
         isProtected: true, // don't allow to be used in code/wires
         global: false,
-        exposed: false,
+        tracked: false,
+        declared: false,
       },
       ExposedInfo {
         exposedType: EGUI_UI_TYPE,
@@ -43,7 +44,8 @@ impl Default for EguiHost {
         isMutable: false,
         isProtected: true, // don't allow to be used in code/wires
         global: false,
-        exposed: false,
+        tracked: false,
+        declared: false,
       },
     ];
 

--- a/shards/egui/src/layouts/table.rs
+++ b/shards/egui/src/layouts/table.rs
@@ -274,7 +274,8 @@ impl LegacyShard for Table {
           isMutable: false,
           isProtected: false,
           global: false,
-          exposed: false,
+          tracked: false,
+          declared: true,
         };
         shared.push(index_info);
         // update shared

--- a/shards/egui/src/widgets/button.rs
+++ b/shards/egui/src/widgets/button.rs
@@ -151,6 +151,8 @@ impl Shard for Button {
         exposedType: common_type::bool,
         name: self.selected.get_name(),
         help: shccstr!("The exposed bool variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/checkbox.rs
+++ b/shards/egui/src/widgets/checkbox.rs
@@ -161,6 +161,8 @@ impl LegacyShard for Checkbox {
         exposedType: common_type::bool,
         name: self.variable.get_name(),
         help: shccstr!("The exposed bool variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/code_editor/mod.rs
+++ b/shards/egui/src/widgets/code_editor/mod.rs
@@ -166,6 +166,8 @@ impl LegacyShard for CodeEditor {
         exposedType: common_type::string,
         name: self.variable.get_name(),
         help: shccstr!("The exposed string variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/color_input.rs
+++ b/shards/egui/src/widgets/color_input.rs
@@ -142,6 +142,8 @@ impl LegacyShard for ColorInput {
         exposedType: common_type::color,
         name: self.variable.get_name(),
         help: shccstr!("The exposed color variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/combo.rs
+++ b/shards/egui/src/widgets/combo.rs
@@ -199,6 +199,8 @@ impl LegacyShard for Combo {
         exposedType: common_type::int,
         name: self.index.get_name(),
         help: shccstr!("The exposed int variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/image_button.rs
+++ b/shards/egui/src/widgets/image_button.rs
@@ -110,6 +110,8 @@ impl Shard for ImageButton {
         exposedType: common_type::bool,
         name: self.selected.get_name(),
         help: shccstr!("The exposed bool variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/listbox.rs
+++ b/shards/egui/src/widgets/listbox.rs
@@ -233,6 +233,8 @@ impl LegacyShard for ListBox {
         exposedType: common_type::int,
         name: self.index.get_name(),
         help: shccstr!("The exposed int variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/numeric_input.rs
+++ b/shards/egui/src/widgets/numeric_input.rs
@@ -174,6 +174,8 @@ macro_rules! impl_ui_input {
             exposedType: common_type::$common_type,
             name: self.variable.get_name(),
             help: shccstr!("The exposed variable"),
+            declared: true,
+            isMutable: true,
             ..ExposedInfo::default()
           };
 
@@ -386,6 +388,7 @@ macro_rules! impl_ui_n_input {
             exposedType: common_type::$common_type,
             name: self.variable.get_name(),
             help: shccstr!("The exposed variable"),
+            declared: true,
             ..ExposedInfo::default()
           };
 

--- a/shards/egui/src/widgets/numeric_slider.rs
+++ b/shards/egui/src/widgets/numeric_slider.rs
@@ -187,6 +187,8 @@ macro_rules! impl_ui_slider {
             exposedType: common_type::$common_type,
             name: self.variable.get_name(),
             help: shccstr!("The exposed variable"),
+            declared: true,
+            isMutable: true,
             ..ExposedInfo::default()
           };
 
@@ -440,6 +442,7 @@ macro_rules! impl_ui_n_slider {
             exposedType: common_type::$common_type,
             name: self.variable.get_name(),
             help: shccstr!("The exposed variable"),
+            declared: true,
             ..ExposedInfo::default()
           };
 

--- a/shards/egui/src/widgets/plots/plot.rs
+++ b/shards/egui/src/widgets/plots/plot.rs
@@ -177,7 +177,8 @@ impl LegacyShard for Plot {
       isMutable: false,
       isProtected: true, // don't allow to be used in code/wires
       global: false,
-      exposed: false,
+      tracked: false,
+      declared: false,
     };
     shared.push(ctx_info);
     // update shared

--- a/shards/egui/src/widgets/radio_button.rs
+++ b/shards/egui/src/widgets/radio_button.rs
@@ -172,6 +172,8 @@ impl LegacyShard for RadioButton {
         },
         name: self.variable.get_name(),
         help: shccstr!("The exposed variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/egui/src/widgets/text_field.rs
+++ b/shards/egui/src/widgets/text_field.rs
@@ -147,6 +147,8 @@ impl Shard for TextField {
         exposedType: common_type::string,
         name: self.variable.get_name(),
         help: shccstr!("The exposed string variable"),
+        declared: true,
+        isMutable: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/modules/candle/src/lib.rs
+++ b/shards/modules/candle/src/lib.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate lazy_static;
 
-use shards::core::{register_enum, register_shard};
+use shards::core::{register_enum, register_object_type, register_shard};
 use shards::types::{Type, FRAG_CC};
 use shards::{fourCharacterCode, ref_counted_object_type_impl};
 
-use candle_core::{DType, Device, Tensor};
+use candle_core::{DType, Device, Tensor as CandleTensor};
 
 mod model;
 mod tensor;
@@ -38,8 +38,8 @@ pub fn get_global_device() -> &'static Device {
   })
 }
 
-struct TensorWrapper(Tensor);
-ref_counted_object_type_impl!(TensorWrapper);
+struct Tensor(CandleTensor);
+ref_counted_object_type_impl!(Tensor);
 
 lazy_static! {
   pub static ref TENSOR_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"cTEN")); // last letter used as version
@@ -128,4 +128,8 @@ pub extern "C" fn shardsRegister_ml_rust(core: *mut shards::shardsc::SHCore) {
   register_shard::<tensor::TensorSliceShard>();
   register_shard::<tensor::TensorToIntsShard>();
   register_shard::<tensor::TensorToFloatsShard>();
+
+  register_object_type::<Tensor>(FRAG_CC, fourCharacterCode(*b"cTEN"));
+  register_object_type::<tokenizer::Tokenizer>(FRAG_CC, fourCharacterCode(*b"TOKn"));
+  register_object_type::<model::Model>(FRAG_CC, fourCharacterCode(*b"cMOD"));
 }

--- a/shards/modules/candle/src/model.rs
+++ b/shards/modules/candle/src/model.rs
@@ -20,11 +20,11 @@ use shards::types::{ClonedVar, Context, Type, Types, Var};
 use candle_core::Device;
 
 use crate::get_global_device;
-use crate::TensorWrapper;
+use crate::Tensor;
 use crate::TENSORS_TYPE_VEC;
 use crate::TENSOR_TYPE;
 
-enum Model {
+pub enum Model {
   Bert(BertModel),
 }
 
@@ -351,10 +351,10 @@ impl Shard for ForwardShard {
       Model::Bert(model) => {
         if tensors.len() == 2 {
           let input_ids = unsafe {
-            &mut *Var::from_ref_counted_object::<TensorWrapper>(&tensors[0], &*TENSOR_TYPE)?
+            &mut *Var::from_ref_counted_object::<Tensor>(&tensors[0], &*TENSOR_TYPE)?
           };
           let input_type_ids = unsafe {
-            &mut *Var::from_ref_counted_object::<TensorWrapper>(&tensors[1], &*TENSOR_TYPE)?
+            &mut *Var::from_ref_counted_object::<Tensor>(&tensors[1], &*TENSOR_TYPE)?
           };
           let output = model
             .forward(&input_ids.0, &input_type_ids.0)
@@ -362,7 +362,7 @@ impl Shard for ForwardShard {
               shlog_error!("Failed to forward: {}", e);
               "Failed to forward"
             })?;
-          let output = Var::new_ref_counted(TensorWrapper(output), &*TENSOR_TYPE);
+          let output = Var::new_ref_counted(Tensor(output), &*TENSOR_TYPE);
           self.outputs.0.push(&output);
         } else {
           return Err("Invalid number of tensors");

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -540,9 +540,9 @@ struct XpendTo : public XPendBase {
           throw ComposeError("AppendTo/PrependTo input type is not compatible "
                              "with the backing SHType::Seq.");
         }
-        if (cons.exposed) {
-          SHLOG_ERROR("AppendTo/PrependTo: Variable {} cannot be exposed.", _collection.variableName());
-          throw ComposeError("AppendTo/PrependTo: Variable cannot be exposed.");
+        if (cons.tracked) {
+          SHLOG_ERROR("AppendTo/PrependTo: Variable {} cannot be tracked.", _collection.variableName());
+          throw ComposeError("AppendTo/PrependTo: Variable cannot be tracked.");
         }
         // Validation Ok if here..
         return data.inputType;

--- a/shards/modules/core/wires.cpp
+++ b/shards/modules/core/wires.cpp
@@ -802,7 +802,7 @@ struct SwitchTo : public WireBase {
       dataCopy.requiredVariables = &wire->requirements;
       for (auto &req : dataCopy.shared) {
         if (!req.global)
-          req.exposed = false;
+          req.tracked = false;
       }
 
       WireBase::compose(dataCopy);

--- a/shards/rust/README.md
+++ b/shards/rust/README.md
@@ -300,6 +300,7 @@ Implement this function when a shard can receive a variable as parameter that do
         exposedType: common_type::int,
         name: self.my_param.get_name(),
         help: shccstr!("The exposed variable"),
+        declared: true,
         ..ExposedInfo::default()
       };
 

--- a/shards/rust/src/core.rs
+++ b/shards/rust/src/core.rs
@@ -15,6 +15,7 @@ use crate::types::InstanceData;
 use crate::types::Mesh;
 use crate::types::ParameterInfo;
 use crate::types::Parameters;
+use crate::types::RCObjectVar;
 use crate::types::Var;
 use crate::types::WireRef;
 use crate::types::WireState;
@@ -351,6 +352,17 @@ pub fn releaseVariable(var: &SHVar) {
     let v = var as *const SHVar as *mut SHVar;
     (*Core).releaseVariable.unwrap_unchecked()(v);
   }
+}
+
+pub fn register_object_type_internal(vendorId: i32, typeId: i32, info: SHObjectInfo) {
+  unsafe {
+    (*Core).registerObjectType.unwrap_unchecked()(vendorId, typeId, info);
+  }
+}
+
+pub fn register_object_type<T: RCObjectVar>(vendor_id: i32, type_id: i32) {
+  let info = T::get_info();
+  register_object_type_internal(vendor_id, type_id, unsafe { *info });
 }
 
 pub fn register_enum_internal(vendorId: i32, typeId: i32, info: SHEnumInfo) {

--- a/shards/rust/src/types.rs
+++ b/shards/rust/src/types.rs
@@ -781,7 +781,8 @@ impl ExposedInfo {
       isMutable: false,
       isProtected: false,
       global: false,
-      exposed: false,
+      tracked: false,
+      declared: false,
     }
   }
 
@@ -796,7 +797,8 @@ impl ExposedInfo {
       isMutable: false,
       isProtected: false,
       global: false,
-      exposed: false,
+      tracked: false,
+      declared: false,
     }
   }
 
@@ -808,7 +810,8 @@ impl ExposedInfo {
       isMutable: false,
       isProtected: false,
       global: false,
-      exposed: false,
+      tracked: false,
+      declared: false,
     }
   }
 
@@ -825,7 +828,8 @@ impl ExposedInfo {
       isMutable: false,
       isProtected: false,
       global: false,
-      exposed: false,
+      tracked: false,
+      declared: false,
     }
   }
 
@@ -842,7 +846,8 @@ impl ExposedInfo {
       isMutable: false,
       isProtected: false,
       global: false,
-      exposed: false,
+      tracked: false,
+      declared: false,
     }
   }
 }


### PR DESCRIPTION
Update SHExposedTypeInfo struct to use 'tracked' and 'declared' flags instead of 'exposed'. Modify related code to use these new flags for variable tracking and declaration. Update Rust bindings accordingly.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
