### PR TITLE
Add support for Boost containers in TTableVar implementation

### DIFF
--- a/shards/core/CMakeLists.txt
+++ b/shards/core/CMakeLists.txt
@@ -38,6 +38,9 @@ if(SHARDS_INLINE_EVERYTHING)
   target_compile_definitions(shards-core PUBLIC SHARDS_INLINE_EVERYTHING=1)
 endif()
 
+# we are building with boost containers since we build shards, we can support this
+target_compile_definitions(shards-core PUBLIC HAS_BOOST_CONTAINER=1)
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(SHARDS_DEBUG_THREAD_NAMES_DEFAULT ON)
 else()


### PR DESCRIPTION
Integrate Boost's `flat_map` and `stable_vector` containers in the `TTableVar` template to enable aligned memory allocation via `aligned_allocator` for better performance. Define `ShardsAlignedMap` type alias when `HAS_BOOST_CONTAINER` is enabled. Add conditional compilation blocks to handle map operations such as insertion, key search, deletion, and clearing using Boost containers when available. Update `CMakeLists.txt` to define `HAS_BOOST_CONTAINER=1` for `shards-core` to conditionally support Boost containers in builds.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
