### PR TITLE
Refactor network broadcast API to support include lists

### DIFF
--- a/shards/core/ops_internal.cpp
+++ b/shards/core/ops_internal.cpp
@@ -107,7 +107,7 @@ std::ostream &DocsFriendlyFormatter::format(std::ostream &os, const SHVar &var) 
   case SHType::Int16:
     os << "@i16(";
     for (auto i = 0; i < 16; i++) {
-      os << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(var.payload.int16Value[i] & 0xFF);
+      os << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned>(var.payload.int16Value[i] & 0xFF) << std::dec;
     }
     os << ")";
     break;

--- a/shards/modules/network/network.hpp
+++ b/shards/modules/network/network.hpp
@@ -96,8 +96,10 @@ private:
 };
 
 struct Server {
-  virtual void broadcast(boost::span<const uint8_t> data, const SHVar &exclude) = 0;
-  void broadcastVar(const SHVar &input, const SHVar &exclude) { broadcast(getSendWriter().varToSendBuffer(input), exclude); }
+  virtual void broadcast(boost::span<const uint8_t> data, const SHVar &nodes, bool include) = 0;
+  void broadcastVar(const SHVar &input, const SHVar &nodes, bool include) {
+    broadcast(getSendWriter().varToSendBuffer(input), nodes, include);
+  }
 };
 
 struct OnPeerConnected {

--- a/shards/modules/network/network_common.cpp
+++ b/shards/modules/network/network_common.cpp
@@ -86,7 +86,8 @@ struct Broadcast {
 
   PARAM_PARAMVAR(_server, "Server", "The server to send the input to.", {Types::ServerVar});
   PARAM_PARAMVAR(_exclude, "Exclude", "The list of Peer IDs to exclude from the broadcast.", {CoreInfo::IntVarSeqType, CoreInfo::IntSeqType, CoreInfo::NoneType});
-  PARAM_IMPL(PARAM_IMPL_FOR(_server), PARAM_IMPL_FOR(_exclude));
+  PARAM_PARAMVAR(_include, "Include", "The list of Peer IDs to include in the broadcast. If set, only these peers will receive the broadcast.", {CoreInfo::IntVarSeqType, CoreInfo::IntSeqType, CoreInfo::NoneType});
+  PARAM_IMPL(PARAM_IMPL_FOR(_server), PARAM_IMPL_FOR(_exclude), PARAM_IMPL_FOR(_include));
 
   Broadcast() {
     _server = Var("Network.Server");
@@ -106,7 +107,11 @@ struct Broadcast {
 
   SHVar activate(SHContext *context, const SHVar &input) {
     auto &server = getServer();
-    server.broadcastVar(input, _exclude.get());
+    if (_include.get().valueType != SHType::None) {
+      server.broadcastVar(input, _include.get(), true);
+    } else {
+      server.broadcastVar(input, _exclude.get(), false);
+    }
     return input;
   }
 };


### PR DESCRIPTION
Update the network broadcast functionality to optionally include specific nodes instead of only excluding nodes. Refactor implementations for KCP and WebSocket servers to handle include and exclude logic. Adjust related parameter definitions and documentation.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
