### PR TITLE
Refactor variable reference management in brancher classes

### DIFF
--- a/shards/core/brancher.hpp
+++ b/shards/core/brancher.hpp
@@ -150,6 +150,7 @@ public:
         SHLOG_TRACE("Branch: referencing required variable: {}", name);
         auto vp = referenceVariable(context, name);
         mesh->addRef(toSWL(name), vp);
+        refs.push_back(vp);
       }
     }
   }
@@ -162,8 +163,11 @@ public:
   }
 
   void cleanup(SHContext *context = nullptr) {
-    mesh->releaseAllRefs();
     mesh->terminate();
+    for (auto ref : refs) {
+      shards::releaseVariable(ref);
+    }
+    refs.clear();
     mesh->parent = nullptr;
   }
 
@@ -211,6 +215,8 @@ private:
 
     wire->composeResult = composeWire(wire.get(), dataCopy);
   }
+
+  std::vector<SHVar *> refs;
 };
 } // namespace shards
 

--- a/shards/core/capturing_brancher.hpp
+++ b/shards/core/capturing_brancher.hpp
@@ -81,10 +81,11 @@ public:
 
   auto requiredVariables() { return brancher.requiredVariables(); }
 
-  void compose(const SHInstanceData &data, const ExposedInfo &shared = ExposedInfo{}, const IgnoredVariables &ignored = {}, bool shareObjectVariables = false) {
+  void compose(const SHInstanceData &data, const ExposedInfo &shared = ExposedInfo{}, const IgnoredVariables &ignored = {},
+               bool shareObjectVariables = false) {
     _variablesApplied = false;
     ExposedInfo sharedNonMutable{data.shared};
-    for(auto& data : sharedNonMutable._innerInfo) {
+    for (auto &data : sharedNonMutable._innerInfo) {
       // Make all captured variables non-mutable as it doesn't make sense to mutate them
       // they would get overwritten every time the capturing brancher updates it's variables
       data.isMutable = false;
@@ -106,7 +107,7 @@ public:
     }
   }
 
-  void applyCapturedVariablesSwap(CapturedVariables& _variables) {
+  void applyCapturedVariablesSwap(CapturedVariables &_variables) {
     std::swap(variableState, _variables);
 
     if (!_variablesApplied) {
@@ -134,8 +135,12 @@ public:
   }
 
   void cleanup() {
-    brancher.mesh->releaseAllRefs();
     brancher.mesh->terminate();
+    for (auto &storage : variableStorage) {
+      if (storage.second.refcount > 1) {
+        SHLOG_ERROR("Variable {} still has a refcount of {}", storage.first, storage.second.refcount);
+      }
+    }
     variableStorage.clear();
     variableState.clear();
   }

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -701,6 +701,11 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
       shards::stop((*it).get());
       ++it;
     }
+    auto it2 = _pendingSchedule.begin();
+    while (it2 != _pendingSchedule.end()) {
+      shards::stop((*it2).get());
+      ++it2;
+    }
 
     // release all wires
     _scheduled.clear();

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -815,13 +815,6 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
     }
   }
 
-  void releaseAllRefs() {
-    for (auto ref : refs) {
-      shards::releaseVariable(ref.second);
-    }
-    refs.clear();
-  }
-
   bool hasRef(const SHStringWithLen name) {
     auto key = shards::OwnedVar::Foreign(name);
     return refs.count(key) > 0;


### PR DESCRIPTION
Improve variable reference handling in `brancher` and `capturing_brancher` by introducing scoped reference tracking with `refs`. Remove `releaseAllRefs` and replace with explicit cleanup logic. Ensure proper refcount checks and clear storage during cleanup. Simplify and standardize captured variable application and handling.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
