### PR TITLE
Refactor(Push): rip out the old junk, wire in composeV2 with private …

### DIFF
--- a/docs/generate.edn
+++ b/docs/generate.edn
@@ -104,10 +104,10 @@
      .parameters
      (ForEach
       (-> (ExpectTable)
-          (| (Take "name") >= .p_name)
+          (| (Take "name") (ExpectString) >= .p_name)
           (| (Take "types") >= (ExpectSeq) .p_types)
-          (| (Take "help") >= .p_help)
-          (| (Take "default") >= .p_default)
+          (| (Take "help") (ExpectString) >= .p_help)
+          (| (Take "default") (ExpectString) >= .p_default)
           (| (Take "optional") (ExpectBool) >= .p_optional)
           "| `" >> .o .p_name >> .o
           .p_optional (If (Is true)
@@ -163,7 +163,8 @@
 
                "=== \"Code\"\r\n\r\n" >> .o
                "    ```clj linenums=\"1\"\r\n" >> .o
-               "    --8<-- \"" >> .o .sample-script-fn (getFilename shardsSamplePath "" true) >> .o "\"\r\n" >> .o
+               "    --8<-- \"" >> .o 
+               .sample-script-fn (getFilename shardsSamplePath "" true) >> .o "\"\r\n" >> .o
                "    ```\r\n\r\n" >> .o
 
                "=== \"Output\"\r\n\r\n" >> .o

--- a/docs/generate.edn
+++ b/docs/generate.edn
@@ -218,8 +218,8 @@
      .values
      (ForEach
       (-> (ExpectTable)
-          (| (Take "label") >= .label)
-          (| (Take "description") >= .description)
+          (| (Take "label") (ExpectString) >= .label)
+          (| (Take "description") (ExpectString) >= .description)
           "| `" >> .o .label >> .o
           "` | " >> .o .description >> .o
           " |\r\n" >> .o))))

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -2311,7 +2311,7 @@ RUNTIME_SHARD_inputHelp(Push);
 RUNTIME_SHARD_outputTypes(Push);
 RUNTIME_SHARD_outputHelp(Push);
 RUNTIME_SHARD_parameters(Push);
-RUNTIME_SHARD_compose(Push);
+RUNTIME_SHARD_composeV2(Push);
 RUNTIME_SHARD_exposedVariables(Push);
 RUNTIME_SHARD_setParam(Push);
 RUNTIME_SHARD_getParam(Push);


### PR DESCRIPTION
…context mastery

Overhaul the Push shard to ride on composeV2’s superior framework. Lock down private contexts with rock-solid handling. Ditch the clunky shared variable loops—go direct with pointer lookups for raw speed. Tighten up type checks, nail better error handling, and throw in seamless implicit init for tables and sequences. Make it sharp, make it fast, make it bulletproof.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
