### PR TITLE
Add logging and ensure child wires are stopped properly

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -49,9 +49,9 @@ jobs:
           cmake --build build_ios --target shards-cpp-union
           cmake --build build_ios --target shards-core
           cmake --build build_ios --target shards-lib
-      - name: Build visionOS
-        run: |
-          cmake -Bbuild_visionos -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=visionOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=xros
-          cmake --build build_visionos --target shards-cpp-union
-          cmake --build build_visionos --target shards-core
-          cmake --build build_visionos --target shards-lib
+      # - name: Build visionOS
+      #   run: |
+      #     cmake -Bbuild_visionos -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=visionOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=xros
+      #     cmake --build build_visionos --target shards-cpp-union
+      #     cmake --build build_visionos --target shards-core
+      #     cmake --build build_visionos --target shards-lib

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -46,10 +46,12 @@ jobs:
       - name: Build iOS
         run: |
           cmake -Bbuild_ios -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=iphoneos
-          cmake --build build_ios --target cargo-shards-rust-union-rust
+          cmake --build build_ios --target shards-cpp-union
+          cmake --build build_ios --target shards-core
           cmake --build build_ios --target shards-lib
-      # - name: Build visionOS
-      #   run: |
-      #     cmake -Bbuild_visionos -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=visionOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=xros
-      #     cmake --build build_visionos --target shards-lib
-      #     cmake --build build_visionos --target cargo-shards-rust-union-rust
+      - name: Build visionOS
+        run: |
+          cmake -Bbuild_visionos -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=visionOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=xros
+          cmake --build build_visionos --target shards-cpp-union
+          cmake --build build_visionos --target shards-core
+          cmake --build build_visionos --target shards-lib

--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -465,8 +465,11 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
     }
   }
 
+  // Used in mesh when deciding if we should tick this wire or not
   bool paused{false};
 
+  // So far used only in activateStepMode, because that mode directly ticks the wire resuming the coroutine
+  // But indirectly used in SwitchTo, where we assign the actual child wire to tick
   SHWire *tickingWire() {
     SHWire *wire = this;
     while (wire->childWire) {

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -702,11 +702,13 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
   void clear() {
     auto it = _scheduled.begin();
     while (it != _scheduled.end()) {
+      SHLOG_TRACE("Mesh {} stopping scheduled wire {}", label, (*it)->name);
       shards::stop((*it).get());
       ++it;
     }
     auto it2 = _pendingSchedule.begin();
     while (it2 != _pendingSchedule.end()) {
+      SHLOG_TRACE("Mesh {} stopping pending wire {}", label, (*it2)->name);
       shards::stop((*it2).get());
       ++it2;
     }

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -657,6 +657,8 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
         observer.before_tick(wire);
         shards::tick(wire->tickingWire(), now);
 
+        // Notice that we are not checking tickingWire here, but wire itself
+        // as childWire yield back to parent wire when they end, moreover they are not in the scheduled set
         if (unlikely(!shards::isRunning(wire))) {
           if (wire->finishedError.size() > 0) {
             _errors.emplace_back(wire->finishedError);
@@ -874,6 +876,13 @@ private:
 
 namespace shards {
 inline bool stop(SHWire *wire, SHVar *result, SHContext *currentContext) {
+  // but avoid stopping if detached and scheduled
+  if (wire->childWire) {
+    // stop the child wire if any
+    shards::stop(wire->childWire);
+    wire->childWire = nullptr;
+  }
+
   if (wire->state == SHWire::State::Stopped) {
     // Clone the results if we need them
     if (result)

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -1221,7 +1221,7 @@ struct Set : public SetUpdateBase {
     const SHExposedTypeInfo *existingExposedType = setBaseCompose(data, true, false, false);
 
     bool global = _global;
-    if (existingExposedType->global) {
+    if (existingExposedType && existingExposedType->global) {
       global = true;
     }
 

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -1220,13 +1220,18 @@ struct Set : public SetUpdateBase {
 
     const SHExposedTypeInfo *existingExposedType = setBaseCompose(data, true, false, false);
 
+    bool global = _global;
+    if (existingExposedType->global) {
+      global = true;
+    }
+
     // bake exposed types
     if (_isTable) {
       // we are a table!
       _tableTypeInfo = updateTableType(_tableType, !_key.isVariable() ? &(SHVar &)_key : &Var::Empty, data.inputType,
                                        existingExposedType ? &existingExposedType->exposedType : nullptr);
 
-      if (_global) {
+      if (global) {
         _exposedInfo =
             ExposedInfo(ExposedInfo::GlobalVariable(_name.c_str(), SHCCSTR("The exposed table."), _tableTypeInfo, true));
       } else {
@@ -1236,7 +1241,7 @@ struct Set : public SetUpdateBase {
       const_cast<Shard *>(data.shard)->inlineShardId = InlineShard::CoreSetUpdateTable;
     } else {
       // just a variable!
-      if (_global) {
+      if (global) {
         _exposedInfo = ExposedInfo(
             ExposedInfo::GlobalVariable(_name.c_str(), SHCCSTR("The exposed variable."), SHTypeInfo(data.inputType), true));
       } else {

--- a/shards/modules/core/wires.hpp
+++ b/shards/modules/core/wires.hpp
@@ -190,12 +190,6 @@ struct BaseRunner : public WireBase {
           wire->cleanup();
         }
       } else if (!wire->detached) {
-        // but avoid stopping if detached and scheduled
-        if (wire->childWire) {
-          // stop the child wire if any
-          shards::stop(wire->childWire);
-          wire->childWire = nullptr;
-        }
         shards::stop(wire.get());
       }
     }

--- a/shards/modules/core/wires.hpp
+++ b/shards/modules/core/wires.hpp
@@ -191,6 +191,11 @@ struct BaseRunner : public WireBase {
         }
       } else if (!wire->detached) {
         // but avoid stopping if detached and scheduled
+        if (wire->childWire) {
+          // stop the child wire if any
+          shards::stop(wire->childWire);
+          wire->childWire = nullptr;
+        }
         shards::stop(wire.get());
       }
     }


### PR DESCRIPTION
- Add trace logs in SHMesh to log the stopping of scheduled and pending wires for better debugging.
- Ensure child wires in BaseRunner are stopped and set to nullptr to avoid potential issues with dangling references.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
