### PR TITLE
Add string initialization and retrieval methods in SHVar and TableVar

### DIFF
--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -1026,7 +1026,7 @@ typedef SHBool(__cdecl *SHIsEqualVar)(const struct SHVar *v1, const struct SHVar
 typedef int(__cdecl *SHCompareVar)(const struct SHVar *v1, const struct SHVar *v2);
 typedef SHBool(__cdecl *SHIsEqualType)(const struct SHTypeInfo *t1, const struct SHTypeInfo *t2);
 
-typedef struct SHTypeInfo(__cdecl *SHDeriveTypeInfo)(const struct SHVar *v, const struct SHInstanceData *data);
+typedef struct SHTypeInfo(__cdecl *SHDeriveTypeInfo)(const struct SHVar *v, const struct SHInstanceData *data, bool mutable_);
 typedef void(__cdecl *SHFreeDerivedTypeInfo)(struct SHTypeInfo *t);
 
 typedef void *(__cdecl *SHAlloc)(uint32_t size);

--- a/include/shards/shards.swift
+++ b/include/shards/shards.swift
@@ -436,6 +436,10 @@ extension SHVar: CustomStringConvertible {
         v.payload.objectValue = pointer
         self = v
     }
+    
+    func isNone() -> Bool {
+        return type == .NoValue
+    }
 }
 
 class OwnedVar {
@@ -1222,11 +1226,11 @@ class WireController {
         }
     }
 
-    func addExternal(name: String, owned: OwnedVar) {
+    func addExternal(name: String, owned: inout OwnedVar) {
         addExternalVar(name: name, varPtr: owned.ptr())
     }
 
-    func addExternal(name: String, sequence: SeqVar) {
+    func addExternal(name: String, sequence: inout SeqVar) {
         addExternalVar(name: name, varPtr: sequence.ptr())
     }
 
@@ -1236,6 +1240,10 @@ class WireController {
 
     func isRunning() -> Bool {
         G.Core.pointee.isWireRunning(nativeRef)
+    }
+    
+    func setPriority(_ priority: Int) {
+        G.Core.pointee.setWirePriority(nativeRef, Int32(priority))
     }
 
     var nativeRef = SHWireRef(bitPattern: 0)

--- a/include/shards/shards.swift
+++ b/include/shards/shards.swift
@@ -367,6 +367,16 @@ extension SHVar: CustomStringConvertible {
         }
         self = v
     }
+    
+    init(string: StaticString) {
+        var v = SHVar()
+        v.payload.stringValue = string.withUTF8Buffer { buffer in
+            unsafeBitCast(buffer.baseAddress, to: UnsafePointer<CChar>.self)
+        }
+        v.payload.stringLen = UInt32(string.utf8CodeUnitCount)
+        v.payload.stringCapacity = 0
+        self = v
+    }
 
     public var string: String {
         assert(type == .String, "String variable expected!")
@@ -509,6 +519,10 @@ class TableVar {
     func get(key: SHVar) -> SHVar {
         let vPtr = containerVar.payload.tableValue.api.pointee.tableAt(containerVar.payload.tableValue, key)
         return vPtr!.pointee
+    }
+    
+    func get(key: StaticString) -> SHVar {
+        return get(key: SHVar(string: key))
     }
 
     func clear() {

--- a/include/shards/shards.swift
+++ b/include/shards/shards.swift
@@ -370,6 +370,7 @@ extension SHVar: CustomStringConvertible {
     
     init(string: StaticString) {
         var v = SHVar()
+        v.valueType = String
         v.payload.stringValue = string.withUTF8Buffer { buffer in
             unsafeBitCast(buffer.baseAddress, to: UnsafePointer<CChar>.self)
         }

--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -182,8 +182,8 @@ struct TypeInfo {
   TypeInfo() {}
 
   TypeInfo(const SHVar &var, const SHInstanceData &data, std::vector<SHExposedTypeInfo> *expInfo = nullptr,
-           bool resolveContextVariables = true) {
-    _info = deriveTypeInfo(var, data, expInfo, resolveContextVariables);
+           bool resolveContextVariables = true, bool mutable_ = false) {
+    _info = deriveTypeInfo(var, data, expInfo, resolveContextVariables, mutable_);
   }
 
   TypeInfo(const SHTypeInfo &info) { _info = cloneTypeInfo(info); }

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1124,7 +1124,9 @@ SHComposeResult internalComposeWire(const std::vector<Shard *> &wire, SHInstance
     for (const auto &[key, pVar] : ctx.wire->getExternalVariables()) {
       const SHExternalVariable &extVar = pVar;
       const SHVar &var = *extVar.var;
-      shassert((var.flags & SHVAR_FLAGS_EXTERNAL) != 0);
+      if ((var.flags & SHVAR_FLAGS_EXTERNAL) == 0) {
+        throw std::runtime_error(fmt::format("Variable '{}' must have SHVAR_FLAGS_EXTERNAL flag set", key.payload.stringValue));
+      }
 
       const SHTypeInfo *type{};
       if (extVar.type) {

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1133,7 +1133,7 @@ SHComposeResult internalComposeWire(const std::vector<Shard *> &wire, SHInstance
         type = extVar.type;
       } else {
         static TypeCache typeCache;
-        type = &typeCache.insertUnique(TypeInfo(var, data));
+        type = &typeCache.insertUnique(TypeInfo(var, data, nullptr, true, true));
       }
 
       SHExposedTypeInfo expInfo{key.payload.stringValue, {}, *type, true /* mutable */};
@@ -3077,8 +3077,8 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
 
   result->isEqualType = [](const SHTypeInfo *t1, const SHTypeInfo *t2) -> SHBool { return *t1 == *t2; };
 
-  result->deriveTypeInfo = [](const SHVar *v, const struct SHInstanceData *data) -> SHTypeInfo {
-    return deriveTypeInfo(*v, *data);
+  result->deriveTypeInfo = [](const SHVar *v, const struct SHInstanceData *dat, bool mutable_) -> SHTypeInfo {
+    return deriveTypeInfo(*v, *dat, nullptr, true, mutable_);
   };
 
   result->freeDerivedTypeInfo = [](SHTypeInfo *t) { freeDerivedInfo(*t); };

--- a/shards/core/type_info.cpp
+++ b/shards/core/type_info.cpp
@@ -112,6 +112,10 @@ SHTypeInfo deriveTypeInfo(const SHVar &value, const SHInstanceData &data, std::v
       }
     }
     varType.fixedSize = value.payload.seqValue.len;
+    // if the len is 0 we should make it a [Any] seq!
+    if (value.payload.seqValue.len == 0) {
+      shards::arrayPush(varType.seqTypes, SHTypeInfo{SHType::Any});
+    }
     break;
   }
   case SHType::Table: {

--- a/shards/core/type_info.cpp
+++ b/shards/core/type_info.cpp
@@ -83,7 +83,7 @@ SHTypeInfo cloneTypeInfo(const SHTypeInfo &other) {
 }
 
 SHTypeInfo deriveTypeInfo(const SHVar &value, const SHInstanceData &data, std::vector<SHExposedTypeInfo> *expInfo,
-                          bool resolveContextVariables) {
+                          bool resolveContextVariables, bool mutable_) {
   ZoneScopedN("deriveTypeInfo");
 
   SHTypeInfo varType{};
@@ -113,7 +113,7 @@ SHTypeInfo deriveTypeInfo(const SHVar &value, const SHInstanceData &data, std::v
     }
     varType.fixedSize = value.payload.seqValue.len;
     // if the len is 0 we should make it a [Any] seq!
-    if (value.payload.seqValue.len == 0) {
+    if (mutable_ && value.payload.seqValue.len == 0) {
       shards::arrayPush(varType.seqTypes, SHTypeInfo{SHType::Any});
     }
     break;

--- a/shards/core/type_info.hpp
+++ b/shards/core/type_info.hpp
@@ -9,7 +9,7 @@ void freeTypeInfo(SHTypeInfo info);
 SHTypeInfo cloneTypeInfo(const SHTypeInfo &other);
 inline void freeDerivedInfo(SHTypeInfo info) { freeTypeInfo(info); }
 SHTypeInfo deriveTypeInfo(const SHVar &value, const SHInstanceData &data, std::vector<SHExposedTypeInfo> *expInfo = nullptr,
-                          bool resolveContextVariables = true);
+                          bool resolveContextVariables = true, bool mutable_ = false);
 } // namespace shards
 
 #endif /* E46E13C8_B6C4_45A0_92E1_48F26F3C80BC */

--- a/shards/rust/src/core.rs
+++ b/shards/rust/src/core.rs
@@ -308,8 +308,10 @@ pub fn writeCachedString1(id: u32, string: &'static str) -> SHOptionalString {
   }
 }
 
-pub fn deriveType(var: &Var, data: &InstanceData) -> DerivedType {
-  let t = unsafe { (*Core).deriveTypeInfo.unwrap_unchecked()(var as *const _, data as *const _) };
+pub fn deriveType(var: &Var, data: &InstanceData, mutable_: bool) -> DerivedType {
+  let t = unsafe {
+    (*Core).deriveTypeInfo.unwrap_unchecked()(var as *const _, data as *const _, mutable_)
+  };
   DerivedType(t)
 }
 

--- a/shards/rust/src/util.rs
+++ b/shards/rust/src/util.rs
@@ -35,6 +35,7 @@ pub fn get_param_var_type(
     Ok(TypeOrDerived::Derived(deriveType(
       &var.get_param(),
       instance_data,
+      false,
     )))
   }
 }


### PR DESCRIPTION
- Introduced a new initializer in SHVar to create instances from StaticString.
- Added a convenience method in TableVar to retrieve SHVar using StaticString keys.
- Updated type_info.cpp to handle empty sequences by pushing a default type of [Any] when the length is zero.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
