### PR TITLE
feat(shards): add local epoch time shards and update variable setters

### DIFF
--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -536,8 +536,13 @@ struct XPendBase {
         if (cons.exposedType.basicType == SHType::Seq &&
             (cons.exposedType.seqTypes.len != 1 ||
              !matchTypes(data.inputType, cons.exposedType.seqTypes.elements[0], true, true, true))) {
-          throw ComposeError(fmt::format("AppendTo/PrependTo input type is not compatible (in: {}, expected: {})", data.inputType,
-                                         cons.exposedType.seqTypes.elements[0]));
+          if (cons.exposedType.seqTypes.len == 0) {
+            throw ComposeError(fmt::format("AppendTo/PrependTo input type is not compatible (in: {}, expected: {})",
+                                           data.inputType, "<unknown/empty>"));
+          } else {
+            throw ComposeError(fmt::format("AppendTo/PrependTo input type is not compatible (in: {}, expected: {})",
+                                           data.inputType, cons.exposedType.seqTypes.elements[0]));
+          }
         }
         if (cons.tracked) {
           SHLOG_ERROR("AppendTo/PrependTo: Variable {} cannot be tracked.", _collection.variableName());

--- a/shards/modules/gfx/camera.cpp
+++ b/shards/modules/gfx/camera.cpp
@@ -194,12 +194,12 @@ inline CameraInputs getCameraInputs(const InputState &inputState, ParamVar &look
     float2 slideDelta = inputState.slideGesture->delta;
     inputs.translation.x += slideDelta.x * panSpeed * 2.0f;
     inputs.translation.y += -slideDelta.y * panSpeed * 2.0f;
-    SPDLOG_INFO("Sliding {} ({})", slideDelta, inputState.slideGesture->slideOffset);
+    SPDLOG_TRACE("Sliding {} ({})", slideDelta, inputState.slideGesture->slideOffset);
   } else if (inputState.gestures.activeGesture == inputState.rotateGesture.get()) {
     float2 rotateDelta = inputState.rotateGesture->delta;
     inputs.lookRotation.y -= rotateDelta.x * lookSpeed * 2.0f;
     inputs.lookRotation.x -= rotateDelta.y * lookSpeed * 2.0f;
-    SPDLOG_INFO("Rotating {} ({})", rotateDelta, inputState.rotateGesture->slideOffset);
+    SPDLOG_TRACE("Rotating {} ({})", rotateDelta, inputState.rotateGesture->slideOffset);
   }
 
   if (inputState.zoom != 0.0f) {

--- a/shards/tests/rust.shs
+++ b/shards/tests/rust.shs
@@ -87,6 +87,7 @@
 
   1500000000 | Date.Format | Log("Date formatted")
   Assert.Is("Fri Jul 14 02:40:00 2017" true)
+  Time.EpochLocal | Date.Format | Log("Date formatted")
 })
 
 @schedule(root test)

--- a/shards/tests/rust.shs
+++ b/shards/tests/rust.shs
@@ -88,6 +88,7 @@
   1500000000 | Date.Format | Log("Date formatted")
   Assert.Is("Fri Jul 14 02:40:00 2017" true)
   Time.EpochLocal | Date.Format | Log("Date formatted")
+  Time.EpochLocalMs | Div(1000) | Date.Format | Log("Date formatted")
 })
 
 @schedule(root test)


### PR DESCRIPTION
- Add `EpochLocal` and `EpochLocalMs` shards to calculate local time since Unix epoch.
- Update `SHVar` setters to assert variable type before assignment.
- Add `maybeString` property to `SHVar` for optional string conversion.
- Add `set(index:value:)` method to `SeqVar` for setting sequence elements.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
