### PR TITLE
refactor(core): enhance cancel_abort logic with return value and retr…

### DIFF
--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -3253,9 +3253,14 @@ SHVar shards_deserialize_var(const SHVar *bytes_buffer_var) {
   return leaking_tmp;
 }
 
-void shards_cancel_abort(SHContext *context) {
+SHBool shards_cancel_abort(SHContext *context) {
+  if (context->shouldStop()) {
+    // ok this flow should stop already... so we can just return false
+    return false;
+  }
   context->resetErrorStack();
   context->continueFlow();
+  return true;
 }
 }
 

--- a/shards/modules/core/wires.hpp
+++ b/shards/modules/core/wires.hpp
@@ -126,7 +126,9 @@ struct BaseRunner : public WireBase {
 
   SHTypeInfo compose(const SHInstanceData &data) {
     resolveWire();
-    assert(wire && "wire should be set at this point");
+    if (!wire) {
+      throw std::runtime_error("wire should be set at this point");
+    }
     // Start/Resume need to capture all it needs, so we need deeper informations
     // this is triggered by populating requiredVariables variable
     auto dataCopy = data;
@@ -218,7 +220,9 @@ struct BaseRunner : public WireBase {
 
   void warmup(SHContext *ctx) {
     if (capturing) {
-      assert(wire && "wire should be set at this point");
+      if (!wire) {
+        throw std::runtime_error("wire should be set at this point");
+      }
 
       for (auto &v : _vars) {
         SHLOG_TRACE("BaseRunner: warming up variable: {}, wire: {}", v.variableName(), wire->name);

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -587,10 +587,13 @@ macro_rules! get_like {
             if retries == 0 {
               return Err("Request failed");
             } else {
-              shards::core::cancel_abort(context);
-              shlog_debug!("Retrying request, {} tries left", retries);
-              shards::core::suspend(context, self.rb.backoff as f64); // use backoff instead of hardcoded 1.0
-              retries -= 1;
+              if shards::core::cancel_abort(context) {
+                shlog_debug!("Retrying request, {} tries left", retries);
+                shards::core::suspend(context, self.rb.backoff as f64); // use backoff instead of hardcoded 1.0
+                retries -= 1;
+              } else {
+                return Err("Cannot retry request, wire might have been aborted");
+              }
             }
           }
         }
@@ -793,10 +796,13 @@ macro_rules! post_like {
             if retries == 0 {
               return Err("Request failed");
             } else {
-              shards::core::cancel_abort(context);
-              shlog_debug!("Retrying request, {} tries left", retries);
-              shards::core::suspend(context, self.rb.backoff as f64); // use backoff instead of hardcoded 1.0
-              retries -= 1;
+              if shards::core::cancel_abort(context) {
+                shlog_debug!("Retrying request, {} tries left", retries);
+                shards::core::suspend(context, self.rb.backoff as f64); // use backoff instead of hardcoded 1.0
+                retries -= 1;
+              } else {
+                return Err("Cannot retry request, wire might have been aborted");
+              }
             }
           }
         }

--- a/shards/rust/src/core.rs
+++ b/shards/rust/src/core.rs
@@ -194,17 +194,15 @@ pub fn abortWire(context: &SHContext, message: &str) {
   }
 }
 
-// void shards_cancel_abort(SHContext *context)
+// SHBool shards_cancel_abort(SHContext *context)
 // Not exposed in the C API, but used internally
 extern "C" {
-  fn shards_cancel_abort(context: *mut SHContext);
+  fn shards_cancel_abort(context: *mut SHContext) -> SHBool;
 }
 
 #[inline(always)]
-pub fn cancel_abort(context: &SHContext) {
-  unsafe {
-    shards_cancel_abort(context as *const SHContext as *mut SHContext);
-  }
+pub fn cancel_abort(context: &SHContext) -> bool {
+  unsafe { shards_cancel_abort(context as *const SHContext as *mut SHContext) }
 }
 
 #[inline(always)]


### PR DESCRIPTION
…y handling

The commit modifies the `shards_cancel_abort` function to return a boolean indicating whether the abort was successfully canceled. This change is propagated to the Rust bindings and used in HTTP request retry logic to handle cases where the wire might have been aborted, preventing unnecessary retries.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
