### PR TITLE
Add core shards documentation generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ shards/tests/testResized2.jpg
 shards/tests/data/whisper-config.json
 shards/tests/data/whisper-tokenizer.json
 .edgetalk.coding.md
+ai/data-gen/shards-reference.md

--- a/ai/data-gen/gen-core-shards.shs
+++ b/ai/data-gen/gen-core-shards.shs
@@ -1,0 +1,252 @@
+@template(resolve-type-id [type-id] {
+  type-id | Match([
+    2 ; Enum
+    {
+      "Enum"
+    }
+    59 ; ShardRef
+    {
+      "Shard"
+    }
+    54 ; ContextVar
+    {
+      "Variable"
+    }
+    56 ; Seq
+    {
+      "Sequence"
+    }
+    57 ; Table
+    {
+      "Table"
+    }
+    60 ; Object
+    {
+      "Object"
+    }
+    none
+    {
+      ""
+    }
+  ] Passthrough: false)
+})
+
+@template(format-type-field [type-field] {
+  type-field | ExpectTable = tt
+  @resolve-type-id((tt:type)) = tn
+  If(IsNot("") {
+      ["`" (tt:name) " (" tn ")`"] | String.Format
+    } {
+      ["`" (tt:name) "`"] | String.Format
+    }
+  )
+})
+
+; Initialize markdown document
+"# Shards reference\n\n" >= markdown-doc
+
+Shards.Enumerate("core") = shards
+{Count(shards) | Log("Total Shards")}
+ForEach({
+  If({
+      String.Starts(With: "_") | Or ; private shards
+      String.Ends(With: "!") | Or ; those are unsafe shards
+      Is("Comment") | Or ; might just create confusion
+      Is("Reduce") | Or ; this is an alias of Fold
+      Is("WriteFile") | Or ; avoid fs ops files for now
+      Is("ReadFile") ; avoid fs ops for now
+    } {
+      Log("Skipping shard")
+    } {
+      Log("Parsing shard")
+      
+      "" >= shard-doc-md
+      ; Add shard name as a header
+      ["## " $0 "\n\n"] | String.Format | AppendTo(shard-doc-md)
+      
+      $0
+      Shards.Help
+      
+      ; Add general help 
+      {Take("help") | When(IsNot("") {
+          = i
+          [i "\n\n"] | String.Format | AppendTo(shard-doc-md)
+        })
+      }
+      
+      ; Add input and output information
+      {Take("inputHelp") | When(IsNot("") {
+          = i
+          ["### Input\n\n" i "\n\n"] | String.Format | AppendTo(shard-doc-md)
+        })
+      }
+      
+      {Take("outputHelp") | When(IsNot("") {
+          = i
+          ["### Output\n\n" i "\n\n"] | String.Format | AppendTo(shard-doc-md)
+        })
+      }
+      
+      ; Add input types if available
+      {Take("inputTypes") | ExpectSeq | When(IsNot([]) {
+          {"### Input Types\n\n" | AppendTo(shard-doc-md)}
+          ForEach({
+            "- " | AppendTo(shard-doc-md)
+            @format-type-field($0) | AppendTo(shard-doc-md)
+            "\n" | AppendTo(shard-doc-md)
+          })
+          "\n" | AppendTo(shard-doc-md)
+        })
+      }
+      
+      ; Add output types if available
+      {Take("outputTypes") | ExpectSeq | When(IsNot([]) {
+          {"### Output Types\n\n" | AppendTo(shard-doc-md)}
+          ForEach({
+            "- " | AppendTo(shard-doc-md)
+            @format-type-field($0) | AppendTo(shard-doc-md)
+            "\n" | AppendTo(shard-doc-md)
+          })
+          "\n" | AppendTo(shard-doc-md)
+        })
+      }
+      
+      ; Add parameters if available
+      {Take("parameters") | ExpectSeq = parameters}
+      parameters | When(IsNot([]) {
+        {"### Parameters\n\n" | AppendTo(shard-doc-md)}
+        ForEach({
+          ExpectTable
+          {Take("name") = param-name}
+          {Take("help") = param-help}
+          {Take("default") | ToString = param-default}
+          {Take("types") = param-types}
+          
+          ; Format parameter name and help
+          ["#### " param-name "\n\n"] | String.Format | AppendTo(shard-doc-md)
+          
+          ; Add parameter help if available
+          param-help | When(IsNotNone {
+            = i
+            [i "\n\n"] | String.Format | AppendTo(shard-doc-md)
+          })
+          
+          ; Add default value if available
+          param-default | When(IsNotNone {
+            = i
+            ["**Default value**: `" i "`\n\n"] | String.Format | AppendTo(shard-doc-md)
+          })
+          
+          ; Add parameter types if available
+          param-types | When(IsNotNone {
+            ExpectSeq | When(IsNot([]) {
+              {"**Types**:\n\n" | AppendTo(shard-doc-md)}
+              ForEach({
+                "- " | AppendTo(shard-doc-md)
+                @format-type-field($0) | AppendTo(shard-doc-md)
+                "\n" | AppendTo(shard-doc-md)
+              })
+              "\n" | AppendTo(shard-doc-md)
+            })
+          })
+        })
+      })
+      
+      ; Append this shard's documentation to the main markdown
+      shard-doc-md | AppendTo(markdown-doc)
+    }
+  )
+})
+
+; Write enums too
+"# Enums reference\n\n" | AppendTo(markdown-doc)
+
+Shards.EnumTypes | ForEach({
+  Shards.EnumTypeHelp
+  ExpectTable
+  {Take("name") = enum-name}
+  {Take("help") = enum-help}
+  {Take("labels") | ExpectSeq = labels}
+  {Take("descriptions") | ExpectSeq = descs}
+  
+  enum-name | When({
+      IsAny(
+        [
+          "LogLevel"
+          "WaitUntil"
+          "Type"
+          "RunWireMode"
+          "Mean"
+          "BranchFailure"
+        ]
+      )
+    } {
+      ["## " enum-name "\n\n"] | String.Format | AppendTo(markdown-doc)
+      
+      enum-help | When(IsNotNone {
+        = i
+        [i "\n\n"] | String.Format | AppendTo(markdown-doc)
+      })
+      
+      Zip([labels descs] Keys: ["l" "d"]) | ForEach({
+        $0:l = label
+        $0:d = desc
+        
+        ["### " enum-name "::" label "\n\n"] | String.Format | AppendTo(markdown-doc)
+        desc | When(IsNotNone {
+          = i
+          [i "\n\n"] | String.Format | AppendTo(markdown-doc)
+        })
+      })
+    }
+  )
+})
+
+; Write objects too
+"# Object types reference\n\n" | AppendTo(markdown-doc)
+
+Shards.ObjectTypes | ForEach({
+  Shards.ObjectTypeHelp
+  ExpectTable
+  {Take("name") = object-name}
+  {Take("isThreadSafe") = is-thread-safe}
+  
+  object-name | When({
+      IsAny([
+        "Mesh"
+      ])
+    } {
+      ["## " object-name "\n\n"] | String.Format | AppendTo(markdown-doc)
+      
+      is-thread-safe | When(IsNotNone {
+        = i
+        ["**Thread safe**: " i "\n\n"] | String.Format | AppendTo(markdown-doc)
+      })
+    }
+  )
+})
+
+; Write to shards-reference.md
+"shards-reference.md" | FS.Write(markdown-doc Overwrite: true)
+"" > markdown-doc
+
+; ; Write example code
+; @env("SHARDS_EXAMPLES_ROOT") | If(Is("") {
+;     Get(ext/shards-examples-root Default: "../../../shards/shards/tests/")
+;   } {
+;     Pass
+;   }
+; ) >= examples-root
+
+; "# Shards Example Code\n\n" | AppendTo(markdown-doc)
+; examples-root | FS.Iterate(false) | ForEach({
+;   FS.Extension | When(Is(".shs") {
+;     ["## " ($0 | FS.Filename) "\n\n"] | String.Format | AppendTo(markdown-doc)
+;     "```shards\n" | AppendTo(markdown-doc)
+;     $0 | FS.Read | AppendTo(markdown-doc)
+;     "\n```\n" | AppendTo(markdown-doc)
+;   })
+; })
+
+; ; Write markdown to file
+; "shards-examples.md" | FS.Write(markdown-doc Overwrite: true)

--- a/ai/data-gen/gen-core-shards.shs
+++ b/ai/data-gen/gen-core-shards.shs
@@ -43,7 +43,7 @@
 })
 
 ; Initialize markdown document
-"# Shards reference\n\n" >= markdown-doc
+"# Shards Reference\n\n" >= markdown-doc
 
 Shards.Enumerate("core") = shards
 {Count(shards) | Log("Total Shards")}
@@ -62,94 +62,107 @@ ForEach({
       
       "" >= shard-doc-md
       ; Add shard name as a header
-      ["## " $0 "\n\n"] | String.Format | AppendTo(shard-doc-md)
+      ["# " $0 "\n"] | String.Format | AppendTo(shard-doc-md)
       
       $0
-      Shards.Help
+      Shards.Help = docs
       
       ; Add general help 
-      {Take("help") | When(IsNot("") {
-          = i
-          [i "\n\n"] | String.Format | AppendTo(shard-doc-md)
-        })
-      }
+      docs:help | When(IsNot("") {
+        = i
+        [i "\n\n"] | String.Format | AppendTo(shard-doc-md)
+      })
       
-      ; Add input and output information
-      {Take("inputHelp") | When(IsNot("") {
-          = i
-          ["### Input\n\n" i "\n\n"] | String.Format | AppendTo(shard-doc-md)
-        })
-      }
+      ; Prepare I/O Types section
+      "I/O Types: " >= io-types-section
       
-      {Take("outputHelp") | When(IsNot("") {
-          = i
-          ["### Output\n\n" i "\n\n"] | String.Format | AppendTo(shard-doc-md)
-        })
-      }
+      ; Get input types
+      docs:inputTypes | ExpectSeq = input-types
       
-      ; Add input types if available
-      {Take("inputTypes") | ExpectSeq | When(IsNot([]) {
-          {"### Input Types\n\n" | AppendTo(shard-doc-md)}
-          ForEach({
-            "- " | AppendTo(shard-doc-md)
-            @format-type-field($0) | AppendTo(shard-doc-md)
-            "\n" | AppendTo(shard-doc-md)
+      ; Format input types
+      "" >= formatted-input-types
+      input-types | When(IsNot([]) {
+        ForEach({
+          $0 | ExpectTable = tt
+          @resolve-type-id((tt:type)) = tn
+          tt:name | When(IsNot("") {
+            [(tt:name) "/"] | String.Format | AppendTo(io-types-section)
           })
-          "\n" | AppendTo(shard-doc-md)
         })
-      }
+      })
       
-      ; Add output types if available
-      {Take("outputTypes") | ExpectSeq | When(IsNot([]) {
-          {"### Output Types\n\n" | AppendTo(shard-doc-md)}
-          ForEach({
-            "- " | AppendTo(shard-doc-md)
-            @format-type-field($0) | AppendTo(shard-doc-md)
-            "\n" | AppendTo(shard-doc-md)
+      io-types-section | When(String.Ends(With: "/") {
+        io-types-section | Slice(To: -1) > io-types-section
+      })
+      
+      ; Add arrow
+      " → " | AppendTo(io-types-section)
+      
+      ; Get output types
+      docs:outputTypes | ExpectSeq = output-types
+      
+      ; Format output types
+      output-types | When(IsNot([]) {
+        ForEach({
+          $0 | ExpectTable = tt
+          @resolve-type-id((tt:type)) = tn
+          tt:name | When(IsNot("") {
+            [(tt:name) "/"] | String.Format | AppendTo(io-types-section)
           })
-          "\n" | AppendTo(shard-doc-md)
         })
-      }
+      })
+      
+      io-types-section | When(String.Ends(With: "/") {
+        io-types-section | Slice(To: -1) > io-types-section
+      })
+      
+      ; Add the I/O Types section to the documentation
+      [io-types-section "\n\n"] | String.Format | AppendTo(shard-doc-md)
       
       ; Add parameters if available
-      {Take("parameters") | ExpectSeq = parameters}
+      docs:parameters | ExpectSeq = parameters
       parameters | When(IsNot([]) {
-        {"### Parameters\n\n" | AppendTo(shard-doc-md)}
+        {"Parameters:\n" | AppendTo(shard-doc-md)}
         ForEach({
           ExpectTable
           {Take("name") = param-name}
           {Take("help") = param-help}
-          {Take("default") | ToString = param-default}
+          {Take("default") | If(IsString {
+              ExpectString = string-value
+              ["\"" string-value "\""] | String.Join
+            } ToString) = param-default
+          }
           {Take("types") = param-types}
           
-          ; Format parameter name and help
-          ["#### " param-name "\n\n"] | String.Format | AppendTo(shard-doc-md)
+          ; Start with parameter name
+          ["- " param-name ": "] | String.Format | AppendTo(shard-doc-md)
           
-          ; Add parameter help if available
-          param-help | When(IsNotNone {
-            = i
-            [i "\n\n"] | String.Format | AppendTo(shard-doc-md)
+          ; Format parameter types in a compact way
+          param-types | When(IsNotNone {
+            ExpectSeq | When(IsNot([]) {
+              ForEach({
+                $0 | ExpectTable = tt
+                @resolve-type-id((tt:type)) = tn
+                tt:name | When(IsNot("") {
+                  [(tt:name) "/"] | String.Format | AppendTo(shard-doc-md)
+                })
+              })
+            })
+          })
+
+          shard-doc-md | When(String.Ends(With: "/") {
+            shard-doc-md | Slice(To: -1) > shard-doc-md
           })
           
           ; Add default value if available
           param-default | When(IsNotNone {
             = i
-            ["**Default value**: `" i "`\n\n"] | String.Format | AppendTo(shard-doc-md)
+            [" (default: " i ")"] | String.Format | AppendTo(shard-doc-md)
           })
           
-          ; Add parameter types if available
-          param-types | When(IsNotNone {
-            ExpectSeq | When(IsNot([]) {
-              {"**Types**:\n\n" | AppendTo(shard-doc-md)}
-              ForEach({
-                "- " | AppendTo(shard-doc-md)
-                @format-type-field($0) | AppendTo(shard-doc-md)
-                "\n" | AppendTo(shard-doc-md)
-              })
-              "\n" | AppendTo(shard-doc-md)
-            })
-          })
+          "\n" | AppendTo(shard-doc-md)
         })
+        "\n" | AppendTo(shard-doc-md)
       })
       
       ; Append this shard's documentation to the main markdown
@@ -181,9 +194,9 @@ Shards.EnumTypes | ForEach({
         ]
       )
     } {
-      ["## " enum-name "\n\n"] | String.Format | AppendTo(markdown-doc)
+      ["# " enum-name "\n\n"] | String.Format | AppendTo(markdown-doc)
       
-      enum-help | When(IsNotNone {
+      enum-help | When({IsNotNone | And | IsNot("")} {
         = i
         [i "\n\n"] | String.Format | AppendTo(markdown-doc)
       })
@@ -193,7 +206,7 @@ Shards.EnumTypes | ForEach({
         $0:d = desc
         
         ["### " enum-name "::" label "\n\n"] | String.Format | AppendTo(markdown-doc)
-        desc | When(IsNotNone {
+        desc | When({IsNotNone | And | IsNot("")} {
           = i
           [i "\n\n"] | String.Format | AppendTo(markdown-doc)
         })
@@ -216,7 +229,7 @@ Shards.ObjectTypes | ForEach({
         "Mesh"
       ])
     } {
-      ["## " object-name "\n\n"] | String.Format | AppendTo(markdown-doc)
+      ["# " object-name "\n\n"] | String.Format | AppendTo(markdown-doc)
       
       is-thread-safe | When(IsNotNone {
         = i

--- a/ai/data-gen/gen-core-shards.shs
+++ b/ai/data-gen/gen-core-shards.shs
@@ -74,7 +74,7 @@ ForEach({
       })
       
       ; Prepare I/O Types section
-      "I/O Types: " >= io-types-section
+      "I/O Types " >= io-types-section
       
       ; Get input types
       docs:inputTypes | ExpectSeq = input-types
@@ -122,20 +122,20 @@ ForEach({
       ; Add parameters if available
       docs:parameters | ExpectSeq = parameters
       parameters | When(IsNot([]) {
-        {"Parameters:\n" | AppendTo(shard-doc-md)}
+        {"Parameters\n" | AppendTo(shard-doc-md)}
         ForEach({
           ExpectTable
           {Take("name") = param-name}
           {Take("help") = param-help}
-          {Take("default") | If(IsString {
-              ExpectString = string-value
-              ["\"" string-value "\""] | String.Join
-            } ToString) = param-default
-          }
+          ; {Take("default") | If(IsString {
+          ;     ExpectString = string-value
+          ;     ["\"" string-value "\""] | String.Join
+          ;   } ToString) = param-default
+          ; }
           {Take("types") = param-types}
           
           ; Start with parameter name
-          ["- " param-name ": "] | String.Format | AppendTo(shard-doc-md)
+          [param-name " "] | String.Format | AppendTo(shard-doc-md)
           
           ; Format parameter types in a compact way
           param-types | When(IsNotNone {
@@ -154,11 +154,11 @@ ForEach({
             shard-doc-md | Slice(To: -1) > shard-doc-md
           })
           
-          ; Add default value if available
-          param-default | When(IsNotNone {
-            = i
-            [" (default: " i ")"] | String.Format | AppendTo(shard-doc-md)
-          })
+          ; ; Add default value if available
+          ; param-default | When(IsNotNone {
+          ;   = i
+          ;   [" (default: " i ")"] | String.Format | AppendTo(shard-doc-md)
+          ; })
           
           "\n" | AppendTo(shard-doc-md)
         })

--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -772,6 +772,9 @@ struct Shard {
   // internal use only, to optionally identify the shard
   uint64_t id;
 
+  // Optional compile time defined category
+  SHString category;
+
   // \-- The interface to fill --/
 
   SHNameProc name;             // Returns the name of the shard, do not free the string,

--- a/include/shards/shardwrapper.hpp
+++ b/include/shards/shardwrapper.hpp
@@ -46,6 +46,12 @@ template <class T> struct ShardWrapper {
   static __cdecl Shard *create() {
     Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) ShardWrapper<T>());
 
+#ifdef SHARDS_THIS_MODULE_ID
+#define SHARD_MODULE_STRINGIFY_HELPER(x) #x
+#define SHARD_MODULE_STRINGIFY(x) SHARD_MODULE_STRINGIFY_HELPER(x)
+    result->category = SHString(SHARD_MODULE_STRINGIFY(SHARDS_THIS_MODULE_ID));
+#endif
+
     // name
     if constexpr (has_name<T>::value) {
       result->name = static_cast<SHNameProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.name(); });

--- a/shards/lang/src/eval.rs
+++ b/shards/lang/src/eval.rs
@@ -698,11 +698,11 @@ fn extract_make_ints_shard<const WIDTH: usize>(
   }
 
   let shard = match WIDTH {
-    2 => AutoShardRef::create("MakeInt2", Some(line_info.into())),
-    3 => AutoShardRef::create("MakeInt3", Some(line_info.into())),
-    4 => AutoShardRef::create("MakeInt4", Some(line_info.into())),
-    8 => AutoShardRef::create("MakeInt8", Some(line_info.into())),
-    16 => AutoShardRef::create("MakeInt16", Some(line_info.into())),
+    2 => AutoShardRef::create("_MakeInt2", Some(line_info.into())),
+    3 => AutoShardRef::create("_MakeInt3", Some(line_info.into())),
+    4 => AutoShardRef::create("_MakeInt4", Some(line_info.into())),
+    8 => AutoShardRef::create("_MakeInt8", Some(line_info.into())),
+    16 => AutoShardRef::create("_MakeInt16", Some(line_info.into())),
     _ => {
       return Err(
         (
@@ -730,7 +730,7 @@ fn extract_make_ints_shard<const WIDTH: usize>(
       .map_err(|err| {
         (
           format!(
-            "Error setting parameter for MakeInt{}, error: {}",
+            "Error setting parameter for _MakeInt{}, error: {}",
             WIDTH, err
           ),
           line_info,
@@ -916,9 +916,9 @@ fn extract_make_floats_shard<const WIDTH: usize>(
   }
 
   let shard = match WIDTH {
-    2 => AutoShardRef::create("MakeFloat2", Some(line_info.into())),
-    3 => AutoShardRef::create("MakeFloat3", Some(line_info.into())),
-    4 => AutoShardRef::create("MakeFloat4", Some(line_info.into())),
+    2 => AutoShardRef::create("_MakeFloat2", Some(line_info.into())),
+    3 => AutoShardRef::create("_MakeFloat3", Some(line_info.into())),
+    4 => AutoShardRef::create("_MakeFloat4", Some(line_info.into())),
     _ => {
       return Err(
         (
@@ -946,7 +946,7 @@ fn extract_make_floats_shard<const WIDTH: usize>(
       .map_err(|err| {
         (
           format!(
-            "Error setting parameter for MakeFloat{}, error: {}",
+            "Error setting parameter for _MakeFloat{}, error: {}",
             WIDTH, err
           ),
           line_info,
@@ -1053,7 +1053,7 @@ fn extract_make_colors_shard(
     )
   }
 
-  let shard = AutoShardRef::create("MakeColor", Some(line_info.into())).unwrap(); // qed, this shard must exist!
+  let shard = AutoShardRef::create("_MakeColor", Some(line_info.into())).unwrap(); // qed, this shard must exist!
 
   for i in 0..len {
     let var = match &params[i].value {
@@ -1069,7 +1069,7 @@ fn extract_make_colors_shard(
       .set_parameter(i as i32, *var.as_ref()) // Type conversion should be handled by the shard!
       .map_err(|err| {
         (
-          format!("Error setting parameter for MakeColor, error: {}", err),
+          format!("Error setting parameter for _MakeColor, error: {}", err),
           line_info,
         )
           .into()
@@ -3327,7 +3327,7 @@ fn eval_pipeline(
                       blocks: vec![Block {
                         content: BlockContent::Shard(Function {
                           name: Identifier {
-                            name: "MakeTrait".into(),
+                            name: "_MakeTrait".into(),
                             namespaces: vec![],
                             custom_state: CustomStateContainer::new(),
                           },

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -1278,20 +1278,20 @@ SHARDS_REGISTER_FN(casting) {
   REGISTER_SHARD("ToFloat3", ToNumber<SHType::Float3>);
   REGISTER_SHARD("ToFloat4", ToNumber<SHType::Float4>);
 
-  REGISTER_SHARD("MakeInt2", MakeVector<SHType::Int2>);
-  REGISTER_SHARD("MakeInt3", MakeVector<SHType::Int3>);
-  REGISTER_SHARD("MakeInt4", MakeVector<SHType::Int4>);
-  REGISTER_SHARD("MakeInt8", MakeVector<SHType::Int8>);
-  REGISTER_SHARD("MakeInt16", MakeVector<SHType::Int16>);
-  REGISTER_SHARD("MakeColor", MakeVector<SHType::Color>);
-  REGISTER_SHARD("MakeFloat2", MakeVector<SHType::Float2>);
-  REGISTER_SHARD("MakeFloat3", MakeVector<SHType::Float3>);
-  REGISTER_SHARD("MakeFloat4", MakeVector<SHType::Float4>);
+  REGISTER_SHARD("_MakeInt2", MakeVector<SHType::Int2>);
+  REGISTER_SHARD("_MakeInt3", MakeVector<SHType::Int3>);
+  REGISTER_SHARD("_MakeInt4", MakeVector<SHType::Int4>);
+  REGISTER_SHARD("_MakeInt8", MakeVector<SHType::Int8>);
+  REGISTER_SHARD("_MakeInt16", MakeVector<SHType::Int16>);
+  REGISTER_SHARD("_MakeColor", MakeVector<SHType::Color>);
+  REGISTER_SHARD("_MakeFloat2", MakeVector<SHType::Float2>);
+  REGISTER_SHARD("_MakeFloat3", MakeVector<SHType::Float3>);
+  REGISTER_SHARD("_MakeFloat4", MakeVector<SHType::Float4>);
 
   REGISTER_SHARD("ToString", ToString);
   REGISTER_SHARD("ToHex", ToHex);
   REGISTER_SHARD("ToAny", ToAny);
-  REGISTER_SHARD("VarAddr", VarAddr);
+  REGISTER_SHARD("VarAddr!", VarAddr);
   REGISTER_SHARD("BitSwap32", BitSwap32);
   REGISTER_SHARD("BitSwap64", BitSwap64);
 
@@ -1434,6 +1434,6 @@ SHARDS_REGISTER_FN(casting) {
   REGISTER_SHARD("FromBase64", FromBase64);
   REGISTER_SHARD("HexToBytes", HexToBytes);
 
-  REGISTER_SHARD("VarPtr", VarPtr);
+  REGISTER_SHARD("VarPtr!", VarPtr);
 }
 }; // namespace shards

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -1857,12 +1857,40 @@ struct GetShards {
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
   static SHTypesInfo outputTypes() { return CoreInfo::StringSeqType; }
 
+  PARAM_VAR(_category, "Category", "The optional category of the shards to get.", {CoreInfo::NoneType, CoreInfo::StringType});
+  PARAM_IMPL(PARAM_IMPL_FOR(_category));
+
+  PARAM_REQUIRED_VARIABLES()
+  SHTypeInfo composeV2(SHInstanceData &data) {
+    PARAM_COMPOSE_REQUIRED_VARIABLES(data);
+    return CoreInfo::StringSeqType;
+  }
+
+  void warmup(SHContext *context) { PARAM_WARMUP(context); }
+
+  void cleanup(SHContext *context) {
+    PARAM_CLEANUP(context);
+    _output = {};
+  }
+
   SeqVar _output{};
 
   SHVar activate(SHContext *context, const SHVar &input) {
+    _output.clear();
+
     for (auto [name, _] : shards::GetGlobals().ShardsRegister) {
-      _output.emplace_back(Var(name));
+      if (_category.valueType != SHType::None) {
+        auto cat = SHSTRVIEW(_category);
+        // sadly we need to create it to check the category but whatever
+        auto shard = createShard(name);
+        if (shard->category && std::string_view(shard->category) == cat) {
+          _output.emplace_back(Var(name));
+        }
+      } else {
+        _output.emplace_back(Var(name));
+      }
     }
+
     return _output;
   }
 };
@@ -3293,7 +3321,7 @@ SHARDS_REGISTER_FN(core) {
 
   using ExitShard = LambdaShard<exitProgramActivation, CoreInfo::IntType, CoreInfo::NoneType>;
   REGISTER_SHARD("Pass", PassShard);
-  REGISTER_SHARD("Exit", ExitShard);
+  REGISTER_SHARD("Exit!", ExitShard);
 
   REGISTER_SHARD("Hash", HasherShard);
 

--- a/shards/modules/core/trait.cpp
+++ b/shards/modules/core/trait.cpp
@@ -123,6 +123,6 @@ struct TraitId {
 } // namespace shards
 
 SHARDS_REGISTER_FN(trait) {
-  REGISTER_SHARD("MakeTrait", shards::MakeTrait);
+  REGISTER_SHARD("_MakeTrait", shards::MakeTrait);
   REGISTER_SHARD("TraitId", shards::TraitId);
 }

--- a/shards/modules/gfx/shader/math_shards.cpp
+++ b/shards/modules/gfx/shader/math_shards.cpp
@@ -248,15 +248,15 @@ void registerMathShards() {
   REGISTER_EXTERNAL_SHADER_SHARD_T1(ToNumberTranslator, "ToFloat3", ToNumber<SHType::Float3>);
   REGISTER_EXTERNAL_SHADER_SHARD_T1(ToNumberTranslator, "ToFloat4", ToNumber<SHType::Float4>);
 
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeInt2", MakeVector<SHType::Int2>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeInt3", MakeVector<SHType::Int3>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeInt4", MakeVector<SHType::Int4>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeInt8", MakeVector<SHType::Int8>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeInt16", MakeVector<SHType::Int16>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeColor", MakeVector<SHType::Color>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeFloat2", MakeVector<SHType::Float2>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeFloat3", MakeVector<SHType::Float3>);
-  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "MakeFloat4", MakeVector<SHType::Float4>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeInt2", MakeVector<SHType::Int2>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeInt3", MakeVector<SHType::Int3>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeInt4", MakeVector<SHType::Int4>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeInt8", MakeVector<SHType::Int8>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeInt16", MakeVector<SHType::Int16>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeColor", MakeVector<SHType::Color>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeFloat2", MakeVector<SHType::Float2>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeFloat3", MakeVector<SHType::Float3>);
+  REGISTER_EXTERNAL_SHADER_SHARD_T1(MakeVectorTranslator, "_MakeFloat4", MakeVector<SHType::Float4>);
 }
 
 } // namespace gfx::shader

--- a/shards/rust/src/shard.rs
+++ b/shards/rust/src/shard.rs
@@ -563,6 +563,7 @@ pub fn create<T: Default + LegacyShard>() -> LegacyShardWrapper<T> {
       } else {
         None
       },
+      category: core::ptr::null(),
     },
     shard: T::default(),
     name: None,
@@ -909,6 +910,7 @@ pub fn create2<T: Default + Shard + ShardGenerated + ShardGeneratedOverloads>() 
       } else {
         None
       },
+      category: core::ptr::null(),
     },
     shard: T::default(),
     name: None,

--- a/shards/tests/gfx-buffer.shs
+++ b/shards/tests/gfx-buffer.shs
@@ -18,12 +18,12 @@
 
 @wire(gfx {
   Animation.Timer >= time
-
+  
   false >= looped-trigger
   Animation.Timer(Duration: 0.2 Looped: true Action: {
     true > looped-trigger
   }) = lt-timer
-
+  
   GFX.Buffer(@buffer-type AddressSpace: BufferAddressSpace::StorageRW) >= buf
   {
     "global_int": 100
@@ -32,18 +32,18 @@
     flags: (lt-timer | If(IsLess(0.1) {1} {0}))
     values: [1.0 2.0 3.0 4.0 5.0 0.0 99.0]
   } | GFX.WriteBuffer(buf)
-
+  
   Once({
     GFX.BuiltinMesh(Type: BuiltinMeshType::Cube) >= mesh
   })
   @f3(0 0 0) | Math.Translation >= transform-0
-
+  
   ; The first pass that just renders the spinning cube
   GFX.BuiltinFeature(BuiltinFeatureId::Transform) >> features
   GFX.BuiltinFeature(BuiltinFeatureId::BaseColor) >> features
   GFX.DrawQueue >= queue
   GFX.DrawablePass(Features: features Queue: queue) >> render-steps1
-
+  
   GFX.Feature(BlockParams: {
     "buffer": {
       AddressSpace: BufferAddressSpace::StorageRW
@@ -51,7 +51,7 @@
       BindGroup: BindGroupId::Draw
     }
   }) >> fx-features
-
+  
   ; The effect pass that modifies the rendered cube image
   ; It also uses the depth buffer from the rendered cube
   GFX.EffectPass(
@@ -65,7 +65,7 @@
       Shader.ReadInput("texCoord0") >= uv
       uv | Take(0) >= u
       uv | Take(1) >= v
-
+      
       Shader.RefBuffer("buffer") = b
       Shader.Literal([
         "let b = " b ";"
@@ -77,33 +77,33 @@
         v " = " v " + f32(jy) * 0.00005;"
         "}"
       ])
-
+      
       ; Manipulate coordinates
       v | Math.Multiply(300.0) | Math.Cos | Math.Multiply(0.001) | Math.Add(u) > u
-      MakeFloat2(u v) | Math.Multiply(3.0) | Math.Mod(@f2(1.0 1.0)) > uv
-
+      @f2(u v) | Math.Multiply(3.0) | Math.Mod(@f2(1.0 1.0)) > uv
+      
       ; Sample the previous pass color output
       uv | Shader.SampleTextureCoord("color") | ToFloat4 >= color
-
+      
       ; Sample the previous pass depth output
       ; Linearize and scale the result to display it, since depth is stored as normalized 1/z
       uv | Shader.SampleTextureCoord("depth") | Take([0])
       Shader.LinearizeDepth | Math.Subtract(1.5) | Math.Divide(5.0) >= depth
-
+      
       ; Write output to "color"
-      MakeFloat4(depth depth 1.0 1.0) | Math.Multiply(color)
+      @f4(depth depth 1.0 1.0) | Math.Multiply(color)
       Shader.WriteOutput("color")
       ; End shader
     }
   ) >> render-steps1
-
+  
   {Position: @f3(0 0 4) Target: @f3(0 0 0)} | Math.LookAt >= view-transform
   GFX.View(View: view-transform) >= view
-
+  
   view-transform | FreeCamera > view-transform
-
+  
   @spin-transform(time @f3(0.0 0 0)) > transform-0
-
+  
   transform-0 | GFX.Drawable(Mesh: mesh Params: {BaseColor: @f4(1 1 1 1)}) | GFX.Draw(Queue: queue)
   GFX.Render(Steps: render-steps1 View: view)
 } Looped: true)
@@ -130,7 +130,7 @@
         BindGroup: BindGroupId::View
       }
     }) >> fx-features
-
+    
     GFX.EffectPass(
       Features: fx-features
       EntryPoint: {
@@ -138,13 +138,13 @@
         Shader.Literal([
           "let b = " b ";"
         ])
-
+        
         @f4(0.0) | Shader.WriteOutput("color")
       }
     ) >> render-steps
     GFX.View = view
     GFX.Render(Steps: render-steps View: view)
-
+    
   })
 } Looped: true LStack: 4194304)
 
@@ -160,7 +160,7 @@
     Once({
       GFX.Buffer(@v-buffer-type) = buf
       {color: @f4(1.0 0.0 0.5 1.0)} | GFX.WriteBuffer(buf)
-
+      
       GFX.Feature(BlockParams: {
           "buffer_v": {
             AddressSpace: BufferAddressSpace::Uniform
@@ -173,18 +173,18 @@
         }
       ) >> fx-features
     })
-
+    
     GFX.EffectPass(
       Features: fx-features
       EntryPoint: {
         Shader.RefBuffer("buffer_v") = b
         @f4(0.0) >= color
-
+        
         Shader.Literal([
           "let b = " b ";"
           color " = (*b).color;" ;
         ])
-
+        
         color | Shader.WriteOutput("color")
       }
     ) >> render-steps
@@ -204,7 +204,7 @@
   GFX.Renderer(wnd IgnoreCompilationErrors: true Contents: {
     Once({
       GFX.Buffer(@v-readback-buffer-type AddressSpace: BufferAddressSpace::StorageRW) = buf
-
+      
       GFX.Feature(BlockParams: {
           "buffer_v": {
             AddressSpace: BufferAddressSpace::StorageRW
@@ -217,29 +217,29 @@
         }
       ) >> fx-features
     })
-
+    
     GFX.EffectPass(
       Features: fx-features
       EntryPoint: {
         Shader.RefBuffer("buffer_v") = b
         @f4(0.0) >= color
-
+        
         Shader.Literal([
           "let b = " b ";"
           "(*b).color = vec4<f32>(1.0, 0.2, 0.4, 1.0);"
           color " = (*b).color;"
         ])
-
+        
         color | Shader.WriteOutput("color")
       }
     ) >> render-steps
-
+    
     {color: @f4(0.0)} >= tmp-var
     When({GFX.ReadBuffer(buf tmp-var)} {
       ["Read buffer result" tmp-var] | String.Format | Log
       tmp-var | Take("color") | Assert.Is(@f4(1 0.2 0.4 1))
     })
-
+    
     GFX.View = view
     GFX.Render(Steps: render-steps View: view)
   })

--- a/shards/tests/gfx-effect.shs
+++ b/shards/tests/gfx-effect.shs
@@ -36,7 +36,7 @@
 
         ; Manipulate coordinates
         v | Math.Multiply(300.0) | Math.Cos | Math.Multiply(0.001) | Math.Add(u) > u
-        MakeFloat2(u v) | Math.Multiply(2.0) | Math.Mod(@f2(1.0 1.0)) > uv
+        @f2(u v) | Math.Multiply(2.0) | Math.Mod(@f2(1.0 1.0)) > uv
 
         ; Sample the previous pass color output
         uv | Shader.SampleTextureCoord("color") | ToFloat4 >= color
@@ -47,7 +47,7 @@
         Shader.LinearizeDepth | Math.Subtract(6.0) | Math.Divide(4.0) >= depth
 
         ; Write output to "color"
-        MakeFloat4(depth depth 1.0 1.0) | Math.Multiply(color)
+        @f4(depth depth 1.0 1.0) | Math.Multiply(color)
         Shader.WriteOutput("color")
         ; End shader
       }

--- a/shards/tests/struct.shs
+++ b/shards/tests/struct.shs
@@ -154,4 +154,4 @@
 1024 | BytesBuffer = buffer
 Count(buffer) | Assert.Is(1024 true)
 
-"Hello world" | VarPtr | PtrToString | Assert.Is("Hello world" true)
+"Hello world" | VarPtr! | PtrToString | Assert.Is("Hello world" true)


### PR DESCRIPTION
- Introduced a new script `gen-core-shards.shs` to automate the generation of markdown documentation for core shards, enums, and object types.
- Enhanced the `Shard` structure by adding an optional `category` field for better organization.
- Updated shard registration to include a category for better identification.
- Refactored shard names in the `eval.rs` and `casting.cpp` files to prefix with an underscore for consistency.
- Adjusted tests to reflect changes in shard naming conventions.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
