### PR TITLE
Improve compose v1

### DIFF
--- a/include/shards/ops.hpp
+++ b/include/shards/ops.hpp
@@ -579,6 +579,13 @@ template <> struct hash<SHExposedTypeInfo> {
     return res;
   }
 };
+
+template <> struct less<SHExposedTypeInfo> {
+  bool operator()(const SHExposedTypeInfo &lhs, const SHExposedTypeInfo &rhs) const {
+    return std::string_view(lhs.name) < std::string_view(rhs.name);
+  }
+};
+
 } // namespace std
 
 #endif

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -846,7 +846,7 @@ bool matchTypes(const SHTypeInfo &inputType, const SHTypeInfo &receiverType, boo
 struct InternalCompositionContext {
   pmr::unordered_map<std::string_view, SHExposedTypeInfo> exposed;
   pmr::unordered_set<SHExposedTypeInfo> required;
-  boost::container::flat_set<SHExposedTypeInfo, std::less<SHExposedTypeInfo>, boost::container::vector<SHExposedTypeInfo>>
+  boost::container::flat_set<SHExposedTypeInfo, std::less<SHExposedTypeInfo>, pmr::vector<SHExposedTypeInfo>>
       sharedStorage;
   CompositionContext *sharedContext{};
 
@@ -864,7 +864,7 @@ struct InternalCompositionContext {
   std::unordered_map<std::string_view, SHExposedTypeInfo> *fullRequired{nullptr};
 
   InternalCompositionContext() = default;
-  InternalCompositionContext(pmr::memory_resource *allocator) : exposed(allocator), required(allocator) {}
+  InternalCompositionContext(pmr::memory_resource *allocator) : exposed(allocator), required(allocator), sharedStorage(allocator) {}
 };
 
 void collectRequiredVariables(const SHInstanceData &data, ExposedInfo &out, const SHVar &var) {

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1045,9 +1045,6 @@ void validateConnection(InternalCompositionContext &ctx) {
   } else if (ctx.bottom->compose) {
     SHInstanceData data{};
 
-    // pmr::vector<SHExposedTypeInfo> sharedStorage{ctx.sharedContext->tempAllocator.getAllocator()};
-    // sharedStorage.reserve(ctx.exposed.size() + ctx.sharedContext->inherited.size());
-
     data.shard = ctx.bottom;
     data.wire = ctx.wire;
     data.inputType = previousOutput;

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -846,6 +846,8 @@ bool matchTypes(const SHTypeInfo &inputType, const SHTypeInfo &receiverType, boo
 struct InternalCompositionContext {
   pmr::unordered_map<std::string_view, SHExposedTypeInfo> exposed;
   pmr::unordered_set<SHExposedTypeInfo> required;
+  boost::container::flat_set<SHExposedTypeInfo, std::less<SHExposedTypeInfo>, boost::container::vector<SHExposedTypeInfo>>
+      sharedStorage;
   CompositionContext *sharedContext{};
 
   SHTypeInfo previousOutputType{};
@@ -856,6 +858,8 @@ struct InternalCompositionContext {
   SHWire *wire{};
 
   bool onWorkerThread{false};
+
+  bool invalidateShared{true};
 
   std::unordered_map<std::string_view, SHExposedTypeInfo> *fullRequired{nullptr};
 
@@ -1041,8 +1045,8 @@ void validateConnection(InternalCompositionContext &ctx) {
   } else if (ctx.bottom->compose) {
     SHInstanceData data{};
 
-    pmr::vector<SHExposedTypeInfo> sharedStorage{ctx.sharedContext->tempAllocator.getAllocator()};
-    sharedStorage.reserve(ctx.exposed.size() + ctx.sharedContext->inherited.size());
+    // pmr::vector<SHExposedTypeInfo> sharedStorage{ctx.sharedContext->tempAllocator.getAllocator()};
+    // sharedStorage.reserve(ctx.exposed.size() + ctx.sharedContext->inherited.size());
 
     data.shard = ctx.bottom;
     data.wire = ctx.wire;
@@ -1054,21 +1058,11 @@ void validateConnection(InternalCompositionContext &ctx) {
     }
     data.onWorkerThread = ctx.onWorkerThread;
 
-    // Pass all we got in the context!
-    // notice that shards might add new records to this array
-    for (auto &pair : ctx.exposed) {
-      sharedStorage.push_back(pair.second);
-    }
+    // just pass the backing std vector storage to our C type
+    data.shared.elements = ctx.sharedStorage.tree().get_sequence_ref().data();
+    data.shared.len = ctx.sharedStorage.tree().get_sequence_ref().size();
 
-    // and inherited
-    for (auto &pair : ctx.sharedContext->inherited) {
-      if (ctx.exposed.find(pair.first) != ctx.exposed.end())
-        continue; // Let exposed override inherited
-      sharedStorage.push_back(pair.second);
-    }
-
-    data.shared.elements = sharedStorage.data();
-    data.shared.len = sharedStorage.size();
+    shassert(ctx.sharedStorage.tree().get_sequence_ref().size() == ctx.sharedStorage.size());
 
     // this ensures e.g. SetVariable exposedVars have right type from the actual
     // input type (previousOutput)!
@@ -1160,6 +1154,12 @@ void validateConnection(InternalCompositionContext &ctx) {
 
     ctx.exposed[name] = exposed_param;
     ctx.sharedContext->inherited.insert(name, exposed_param);
+    if (ctx.sharedStorage.contains(exposed_param)) {
+      // override existing if we have it
+      ctx.sharedStorage.erase(exposed_param);
+    }
+    // incrementally add to our storage
+    ctx.sharedStorage.insert(exposed_param);
   }
 
   // Finally do checks on what we consume
@@ -1317,6 +1317,10 @@ SHComposeResult internalComposeWire(const std::vector<Shard *> &wire, SHInstance
       std::string_view sName(info.name);
       ctx.sharedContext->inherited.insert(sName, info);
     }
+  }
+
+  for (auto &[_name, item] : ctx.sharedContext->inherited) {
+    ctx.sharedStorage.insert(item);
   }
 
   size_t chsize = wire.size();

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -447,9 +447,9 @@ struct CompositionContext {
 
   CompositionContext() : visitedWires(tempAllocator.getAllocator()) {}
 
-  static CompositionContext& get(const SHInstanceData& data) {
+  static CompositionContext &get(const SHInstanceData &data) {
     shassert(data.privateContext != nullptr);
-    return *reinterpret_cast<CompositionContext*>(data.privateContext);
+    return *reinterpret_cast<CompositionContext *>(data.privateContext);
   }
 };
 }; // namespace shards

--- a/shards/modules/core/flow.hpp
+++ b/shards/modules/core/flow.hpp
@@ -394,7 +394,8 @@ struct Maybe : public BaseSubFlow {
     SHTypeInfo outputType = _composition.outputType;
     if (_elseBlks && !nextIsNone && !elseComp.flowStopper && _composition.outputType != elseComp.outputType) {
       outputType = CoreInfo::AnyType;
-      SHLOG_DEBUG("Maybe: Branches return different types, setting output type to Any!");
+      SHLOG_WARNING("Maybe: Branches return different types, setting output type to Any!, wire: {}, line: {}, column: {}",
+                    data.wire ? data.wire->name : "unknown", _self->line, _self->column);
     }
 
     // Maybe won't expose
@@ -773,7 +774,9 @@ struct IfBlock {
     if (!nextIsNone && !tres.flowStopper && !eres.flowStopper && !_passth) {
       if (tres.outputType != eres.outputType) {
         outputType = CoreInfo::AnyType;
-        SHLOG_DEBUG("If: Branches return different types, setting output type to Any!");
+        auto self = data.shard;
+        SHLOG_WARNING("If: Branches return different types, setting output type to Any!, wire: {}, line: {}, column: {}",
+                      data.wire ? data.wire->name : "unknown", self->line, self->column);
       }
     }
     return _passth ? data.inputType : outputType;

--- a/shards/modules/gfx/gltf.cpp
+++ b/shards/modules/gfx/gltf.cpp
@@ -63,6 +63,9 @@ static OwnedVar getGltfBuiltinTargetPath(animation::BuiltinTarget target) {
   case animation::BuiltinTarget::Translation:
     pathStr[1] = 't';
     break;
+  default:
+    SHLOG_ERROR("Ignoring builtin target: {}", target);
+    break;
   }
   pathStr[2] = 0;
   cloneVar(result, Var(pathStr, 2));
@@ -368,6 +371,9 @@ struct GLTFShard {
       break;
     case animation::BuiltinTarget::Translation:
       node->trs.translation = toVec<float3>(value);
+      break;
+    default:
+      SHLOG_WARNING("Ignoring builtin target: {}", target);
       break;
     }
     node->update();

--- a/shards/modules/gfx/shader/flow_shards.cpp
+++ b/shards/modules/gfx/shader/flow_shards.cpp
@@ -100,7 +100,7 @@ struct CondTranslator {
       context.addNew(blocks::makeCompoundBlock(fmt::format("var {}: {}", ifResultVarName, getWGSLTypeName(outputType)), ";\n"));
     }
 
-    for (int i = 0; i < shard->_conditions.size(); i++) {
+    for (size_t i = 0; i < shard->_conditions.size(); i++) {
       const char *en{};
       if (i == 0)
         en = "if(";

--- a/shards/modules/gfx/texture.cpp
+++ b/shards/modules/gfx/texture.cpp
@@ -268,9 +268,6 @@ struct TextureShard {
     if (format.pixelFormat == WGPUTextureFormat_Undefined)
       throw TextureFormatException(componentType, asType);
 
-    auto &inputFormat = getTextureFormatDescription(format.pixelFormat);
-    size_t imageSize = inputFormat.pixelSize * image.width * image.height;
-
     // Copy the data since we can't keep a reference to the image variable
     ImmutableSharedBuffer isb(std::make_shared<ImageRefTextureBuffer>(const_cast<SHImage *>(&image)));
     texture->init(TextureDesc{

--- a/shards/modules/gfx/window.cpp
+++ b/shards/modules/gfx/window.cpp
@@ -269,7 +269,7 @@ struct MainWindow final {
       });
 
       for (auto &event : _windowContext->inputMaster.getEvents()) {
-        if (const RequestCloseEvent *evt = std::get_if<RequestCloseEvent>(&event.event)) {
+        if (std::holds_alternative<RequestCloseEvent>(event.event)) {
           bool handleClose = _handleCloseEvent->isNone() || (bool)*_handleCloseEvent;
           if (handleClose) {
             throw MainWindowQuitException();

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -680,7 +680,7 @@ macro_rules! get_like {
           let mut retries = self.rb.retry;
           loop {
             let request = request.try_clone().ok_or_else(|| {
-              shlog_error!("Failed to clone the request");
+              shlog_error!("Failed to clone the request, url: {}", request_string);
               "Failed to clone the request"
             })?;
 

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -890,7 +890,7 @@ macro_rules! post_like {
           let mut retries = self.rb.retry;
           loop {
             let request = request.try_clone().ok_or_else(|| {
-              shlog_error!("Failed to clone the request");
+              shlog_error!("Failed to clone the request, url: {}", request_string);
               "Failed to clone the request"
             })?;
 


### PR DESCRIPTION
- Introduced a less comparator for SHExposedTypeInfo to facilitate ordering.
- Enhanced InternalCompositionContext to include sharedStorage for better management of exposed types.
- Updated validateConnection to utilize sharedStorage effectively, ensuring proper handling of inherited types.
- Improved logging in GLTFShard for better debugging of ignored targets.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
