### PR TITLE
Add Codex submodule and implement ApplyPatch shard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -113,3 +113,6 @@
 [submodule "deps/opus"]
 	path = deps/opus
 	url = https://github.com/xiph/opus.git
+[submodule "deps/codex"]
+	path = deps/codex
+	url = https://github.com/openai/codex.git

--- a/shards/modules/codex/CMakeLists.txt
+++ b/shards/modules/codex/CMakeLists.txt
@@ -1,0 +1,9 @@
+if(NOT EMSCRIPTEN)
+  add_rust_library(NAME shards-codex
+    PROJECT_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+  add_shards_module(codex
+    RUST_TARGETS shards-codex-rust
+    REGISTER_SHARDS rust
+    EXPERIMENTAL)
+endif()

--- a/shards/modules/codex/Cargo.toml
+++ b/shards/modules/codex/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "shards-markdown"
+name = "shards-codex"
 description = ""
 license = "BSD-3-Clause"
 version = "0.1.0"
@@ -13,5 +13,4 @@ crate-type = ["rlib", "staticlib"]
 lazy_static = "1.5"
 shards = { path = "../../rust" }
 compile-time-crc32 = "0.1"
-pulldown-cmark = { version = "0.13", default-features = false }
-htmd = "0.2.1"
+codex-apply-patch = { path = "../../../deps/codex/codex-rs/apply-patch" }

--- a/shards/modules/codex/src/lib.rs
+++ b/shards/modules/codex/src/lib.rs
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
+use codex_apply_patch::apply_patch;
+
+use shards::core::register_shard;
+use shards::shard::Shard;
+use shards::shlog_error;
+use shards::types::{
+  common_type, AutoSeqVar, AutoTableVar, ClonedVar, ParamVar, ANY_TABLE_TYPES, STRINGS_TYPES,
+  STRING_TYPES,
+};
+use shards::types::{Context, ExposedTypes, InstanceData, Type, Types, Var};
+
+#[derive(shards::shard)]
+#[shard_info("Codex.ApplyPatch", "Apply an OpenAI Codex patch to files.")]
+struct ApplyPatchShard {
+  #[shard_required]
+  required: ExposedTypes,
+
+  output: AutoTableVar,
+}
+
+impl Default for ApplyPatchShard {
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      output: AutoTableVar::new(),
+    }
+  }
+}
+
+#[shards::shard_impl]
+impl Shard for ApplyPatchShard {
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
+
+  fn output_types(&mut self) -> &Types {
+    &ANY_TABLE_TYPES
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let patch: &str = input.try_into()?;
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    apply_patch(patch, &mut stdout, &mut stderr).map_err(|e| {
+      shlog_error!("Failed to apply patch: {}", e);
+      "Failed to apply patch"
+    })?;
+
+    let stdout_str = String::from_utf8_lossy(&stdout);
+    let stderr_str = String::from_utf8_lossy(&stderr);
+
+    self
+      .output
+      .0
+      .insert_fast_static("stdout", &Var::ephemeral_string(&stdout_str));
+    self
+      .output
+      .0
+      .insert_fast_static("stderr", &Var::ephemeral_string(&stderr_str));
+
+    Ok(Some(self.output.0 .0))
+  }
+}
+
+#[no_mangle]
+pub extern "C" fn shardsRegister_codex_rust(core: *mut shards::shardsc::SHCore) {
+  unsafe {
+    shards::core::Core = core;
+  }
+
+  register_shard::<ApplyPatchShard>();
+}

--- a/shards/modules/markdown/Cargo.toml
+++ b/shards/modules/markdown/Cargo.toml
@@ -15,3 +15,4 @@ shards = { path = "../../rust" }
 compile-time-crc32 = "0.1"
 pulldown-cmark = { version = "0.13", default-features = false }
 htmd = "0.2.1"
+codex-apply-patch = { path = "../../../deps/codex/codex-rs/apply-patch" }

--- a/shards/modules/markdown/src/lib.rs
+++ b/shards/modules/markdown/src/lib.rs
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
+use codex_apply_patch::apply_patch;
 use htmd::HtmlToMarkdown;
 use shards::core::register_shard;
 use shards::shard::Shard;
+use shards::shlog_error;
 use shards::types::{common_type, AutoSeqVar, ClonedVar, ParamVar, STRINGS_TYPES, STRING_TYPES};
 use shards::types::{Context, ExposedTypes, InstanceData, Type, Types, Var};
 
@@ -108,7 +110,7 @@ impl Shard for MarkdownParseShard {
             for class in classes {
               let class = format!(".{}", class);
               let d = Var::ephemeral_string(&class);
-               self.output.0.push(&d);
+              self.output.0.push(&d);
             }
             for (name, value) in attrs {
               if let Some(value) = value {
@@ -715,6 +717,69 @@ impl Shard for MarkdownFromHTMLShard {
   }
 }
 
+#[derive(shards::shard)]
+#[shard_info("Codex.ApplyPatch", "Apply an OpenAI Codex patch to files.")]
+struct ApplyPatchShard {
+  #[shard_required]
+  required: ExposedTypes,
+
+  output: AutoSeqVar,
+}
+
+impl Default for ApplyPatchShard {
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      output: AutoSeqVar::new(),
+    }
+  }
+}
+
+#[shards::shard_impl]
+impl Shard for ApplyPatchShard {
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
+
+  fn output_types(&mut self) -> &Types {
+    &STRINGS_TYPES
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let patch: &str = input.try_into()?;
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    apply_patch(patch, &mut stdout, &mut stderr).map_err(|e| {
+      shlog_error!("Failed to apply patch: {}", e);
+      "Failed to apply patch"
+    })?;
+    self
+      .output
+      .0
+      .push(&Var::ephemeral_string(&String::from_utf8_lossy(&stdout)));
+    self
+      .output
+      .0
+      .push(&Var::ephemeral_string(&String::from_utf8_lossy(&stderr)));
+    Ok(Some(self.output.0 .0))
+  }
+}
+
 #[no_mangle]
 pub extern "C" fn shardsRegister_markdown_rust(core: *mut shards::shardsc::SHCore) {
   unsafe {
@@ -723,4 +788,5 @@ pub extern "C" fn shardsRegister_markdown_rust(core: *mut shards::shardsc::SHCor
 
   register_shard::<MarkdownParseShard>();
   register_shard::<MarkdownFromHTMLShard>();
+  register_shard::<ApplyPatchShard>();
 }

--- a/shards/modules/markdown/src/lib.rs
+++ b/shards/modules/markdown/src/lib.rs
@@ -1,12 +1,14 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2021 Fragcolor Pte. Ltd. */
 
-use codex_apply_patch::apply_patch;
 use htmd::HtmlToMarkdown;
 use shards::core::register_shard;
 use shards::shard::Shard;
 use shards::shlog_error;
-use shards::types::{common_type, AutoSeqVar, ClonedVar, ParamVar, STRINGS_TYPES, STRING_TYPES};
+use shards::types::{
+  common_type, AutoSeqVar, AutoTableVar, ClonedVar, ParamVar, ANY_TABLE_TYPES, STRINGS_TYPES,
+  STRING_TYPES,
+};
 use shards::types::{Context, ExposedTypes, InstanceData, Type, Types, Var};
 
 use pulldown_cmark::{
@@ -717,69 +719,6 @@ impl Shard for MarkdownFromHTMLShard {
   }
 }
 
-#[derive(shards::shard)]
-#[shard_info("Codex.ApplyPatch", "Apply an OpenAI Codex patch to files.")]
-struct ApplyPatchShard {
-  #[shard_required]
-  required: ExposedTypes,
-
-  output: AutoSeqVar,
-}
-
-impl Default for ApplyPatchShard {
-  fn default() -> Self {
-    Self {
-      required: ExposedTypes::new(),
-      output: AutoSeqVar::new(),
-    }
-  }
-}
-
-#[shards::shard_impl]
-impl Shard for ApplyPatchShard {
-  fn input_types(&mut self) -> &Types {
-    &STRING_TYPES
-  }
-
-  fn output_types(&mut self) -> &Types {
-    &STRINGS_TYPES
-  }
-
-  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-    self.warmup_helper(ctx)?;
-    Ok(())
-  }
-
-  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-    self.cleanup_helper(ctx)?;
-    Ok(())
-  }
-
-  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-    self.compose_helper(data)?;
-    Ok(self.output_types()[0])
-  }
-
-  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-    let patch: &str = input.try_into()?;
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    apply_patch(patch, &mut stdout, &mut stderr).map_err(|e| {
-      shlog_error!("Failed to apply patch: {}", e);
-      "Failed to apply patch"
-    })?;
-    self
-      .output
-      .0
-      .push(&Var::ephemeral_string(&String::from_utf8_lossy(&stdout)));
-    self
-      .output
-      .0
-      .push(&Var::ephemeral_string(&String::from_utf8_lossy(&stderr)));
-    Ok(Some(self.output.0 .0))
-  }
-}
-
 #[no_mangle]
 pub extern "C" fn shardsRegister_markdown_rust(core: *mut shards::shardsc::SHCore) {
   unsafe {
@@ -788,5 +727,4 @@ pub extern "C" fn shardsRegister_markdown_rust(core: *mut shards::shardsc::SHCor
 
   register_shard::<MarkdownParseShard>();
   register_shard::<MarkdownFromHTMLShard>();
-  register_shard::<ApplyPatchShard>();
 }

--- a/shards/tests/markdown.shs
+++ b/shards/tests/markdown.shs
@@ -10,3 +10,23 @@ Repeat({
 none | Http.Get("https://github.com/fragcolor-xyz/shards") | Markdown.FromHTML = md
 
 "md.md" | FS.Write(md Overwrite: true)
+
+"""
+foo
+bar
+baz
+qux
+""" = codex-test
+"codex-test.txt" | FS.Write(codex-test Overwrite: true)
+
+"""*** Begin Patch
+*** Update File: codex-test.txt
+@@
+ foo
+-bar
++BAR
+@@
+ baz
+-qux
++QUX
+*** End Patch""" | Codex.ApplyPatch | Log


### PR DESCRIPTION
- Added a new submodule for OpenAI Codex.
- Introduced ApplyPatchShard to apply patches using Codex functionality.
- Updated Cargo.toml to include codex-apply-patch dependency.
- Enhanced markdown tests to validate the new ApplyPatch functionality.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
