### PR TITLE
Add Disconnect shard and implement peer disconnection logic

### DIFF
--- a/shards/modules/network/network.hpp
+++ b/shards/modules/network/network.hpp
@@ -88,6 +88,7 @@ struct Peer {
   virtual void send(boost::span<const uint8_t> data) = 0;
   virtual void send_text(std::string_view data) = 0;
   virtual bool disconnected() const = 0;
+  virtual void disconnect() = 0;
   int64_t getId() { return id; }
   void sendVar(const SHVar &input) { send(getSendWriter().varToSendBuffer(input)); }
 

--- a/shards/modules/network/network_common.cpp
+++ b/shards/modules/network/network_common.cpp
@@ -249,6 +249,29 @@ struct PeerShard {
 
   SHVar activate(SHContext *shContext, const SHVar &input) { return _peer.get(); }
 };
+
+struct Disconnect {
+  static SHTypesInfo inputTypes() { return Types::Peer; }
+  static SHTypesInfo outputTypes() { return Types::Peer; }
+  static SHOptionalString help() {
+    return SHCCSTR("This shard disconnects the peer passed as input. "
+                   "Works with both KCP and WebSocket peers.");
+  }
+
+  static SHOptionalString inputHelp() { return SHCCSTR("The peer to disconnect."); }
+
+  static SHOptionalString outputHelp() { return SHCCSTR("The same peer object."); }
+
+  SHTypeInfo compose(SHInstanceData &data) {
+    return data.inputType;
+  }
+
+  SHVar activate(SHContext *shContext, const SHVar &input) {
+    auto &peer = varAsObjectChecked<Peer>(input, Types::Peer);
+    peer.disconnect();
+    return input;
+  }
+};
 }; // namespace Network
 }; // namespace shards
 
@@ -259,4 +282,5 @@ SHARDS_REGISTER_FN(network_common) {
   REGISTER_SHARD("Network.Send", Send);
   REGISTER_SHARD("Network.PeerID", PeerID);
   REGISTER_SHARD("Network.Peer", PeerShard);
+  REGISTER_SHARD("Network.Disconnect", Disconnect);
 }

--- a/shards/modules/network/network_kcp.cpp
+++ b/shards/modules/network/network_kcp.cpp
@@ -247,6 +247,11 @@ struct KCPPeer final : public Peer {
 
   bool disconnected() const override { return disconnected_; }
 
+  void disconnect() override {
+    std::scoped_lock lock(mutex);
+    disconnected_ = true;
+  }
+
   void send_text(std::string_view data) override {
     send(boost::span<const uint8_t>(reinterpret_cast<const uint8_t *>(data.data()), data.size()));
   }
@@ -890,6 +895,13 @@ struct ServerShard : public NetworkBase {
       for (auto &[end, peer] : _server._end2Peer) {
         if (now > (peer->_lastContact.load() + SHDuration(_timeoutSecs))) {
           SPDLOG_LOGGER_DEBUG(logger, "Peer {}:{} timed out", peer->endpoint->address().to_string(), peer->endpoint->port());
+          _stopWireQueue.push(peer->wire.get());
+          continue;
+        }
+        
+        // Check if peer was manually disconnected
+        if (peer->disconnected()) {
+          SPDLOG_LOGGER_DEBUG(logger, "Peer {}:{} manually disconnected", peer->endpoint->address().to_string(), peer->endpoint->port());
           _stopWireQueue.push(peer->wire.get());
           continue;
         }

--- a/shards/modules/network/network_ws.cpp
+++ b/shards/modules/network/network_ws.cpp
@@ -73,6 +73,10 @@ struct WSPeer : public Peer {
   void send(boost::span<const uint8_t> data) override { pollnet_send_binary(ctx, socket, data.data(), data.size()); }
   void send_text(std::string_view data) override { pollnet_send(ctx, socket, toSWL(data)); }
   bool disconnected() const override { return disconnected_; }
+  
+  void disconnect() override {
+    close();
+  }
 };
 struct WSHandler : public WSPeer {
   entt::connection onStopConnection;
@@ -657,6 +661,10 @@ struct WSPeer : public Peer {
   }
 
   bool disconnected() const override { return disconnected_; }
+  
+  void disconnect() override {
+    close();
+  }
 };
 
 struct WSClient {

--- a/shards/tests/network.shs
+++ b/shards/tests/network.shs
@@ -8,9 +8,13 @@
 @wire(handler {
   Log("Server's Peer Received")
   When(Is("The End") {
-    Log("Disconnecting client after receiving end sequence")
+    Log("Received end sequence")
     true > test/server-received-end
-    "" | Stop
+  })
+  When(Is("Disconnect Me") {
+    Log("Server disconnecting peer on request")
+    Network.Peer | Network.Disconnect
+    true > test/server-disconnected-peer
   })
   "Ok" | Network.Send
 } Looped: true)
@@ -48,6 +52,7 @@
       
       When({test/client-received-smaller | And | test/client-received-random1} {
         "The End" | Network.Send | Log("Sent end")
+        "Disconnect Me" | Network.Send | Log("Requesting disconnect after end")
       })
     }) = peer
     Once(Do(client-init))
@@ -63,6 +68,7 @@
   false | Set(test/client-received-smaller Global: true) | Log("Client received smaller Set")
   false | Set(test/client-received-random1 Global: true) | Log("Client received random1 Set")
   false | Set(test/server-received-end Global: true) | Log("Server received end Set")
+  false | Set(test/server-disconnected-peer Global: true) | Log("Server disconnected peer Set")
   ForRange(1 @tick-count-1 {
     Pause(0.0)
   })
@@ -71,6 +77,7 @@
   test/server-received-end | Log("server-received-end") | Assert.Is(true)
   test/client-received-smaller | Log("client-received-smaller") | Assert.Is(true)
   test/client-received-random1 | Log("client-received-random1") | Assert.Is(true)
+  test/server-disconnected-peer | Log("server-disconnected-peer") | Assert.Is(true)
 } Priority: -2)
 
 @wire(network-test-stun {


### PR DESCRIPTION
- Introduced a new Disconnect shard to handle peer disconnection, supporting both KCP and WebSocket peers.
- Implemented disconnect methods in KCPPeer and WSPeer classes to update their state upon disconnection.
- Updated network tests to validate the disconnection functionality, ensuring proper logging and state management.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
