### PR TITLE
Tables refactor

### DIFF
--- a/docs/samples/shards/General/Erase/Erase.shs
+++ b/docs/samples/shards/General/Erase/Erase.shs
@@ -1,36 +1,40 @@
 ; erase single element from sequence
 [100 200 300 400] >= seq1
 Erase([1] Name: seq1)
-Log("output")                          ; => output: [100 200 300 400]      
-seq1 | Log("seq1")                     ; => seq1: [100, 300, 400]
+Log("output") ; => output: [100 200 300 400]      
+seq1 | Log("seq1") ; => seq1: [100, 300, 400]
 
 ; erase multiple elements from sequence
 [100 200 300 400] >= seq2
 Erase([2 0] Name: seq2)
-seq2 | Log                             ; => [200, 400]
+seq2 | Log ; => [200, 400]
 
 ; erase single key-value pair from table        
-{k1: 10 k2: 20 k3: 30} >= tab1
+{k1: 10 k2: 20 k3: 30}
+ExpectTable ; to make it a dynamic table
+>= tab1
 Erase("k2" Name: tab1)
-tab1 | Log                             ; => {k3: 30, k1: 10}
+tab1 | Log ; => {k3: 30, k1: 10}
 
 ; erase multiple key-value pairs from table
-{k1: 100 k2: 200 k3: 300} >= tab2
+{k1: 100 k2: 200 k3: 300}
+ExpectTable ; to make it a dynamic table
+>= tab2
 Erase(["k3" "k1"] Name: tab2)
-tab2 | Log                             ; => {k2: 200}
+tab2 | Log ; => {k2: 200}
 
 ; erase from same-name local and global sequences
-[1 2 3] >= seq                         ; create local sequence
-[1 2 3] | Set(seq Global: true)        ; create global sequence
-Erase([2 0] Name: seq)                 ; erase from local sequence
-Get(seq) | Log                         ; => [2]
-Erase([1] Name: seq Global: true)      ; erase from global sequence
-Get(seq Global: true) | Log            ; => [1, 3]
+[1 2 3] >= seq ; create local sequence
+[1 2 3] | Set(seq Global: true) ; create global sequence
+Erase([2 0] Name: seq) ; erase from local sequence
+Get(seq) | Log ; => [2]
+Erase([1] Name: seq Global: true) ; erase from global sequence
+Get(seq Global: true) | Log ; => [1, 3]
 
 ; erase from same-name local and global tables
-{k1: 1 k2: 2 k3: 3} >= tab             ; create local table   
-{k1: 1 k2: 2 k3: 3} | Set(tab Global: true)  ; create global table   
-Erase(["k3" "k1"] Name: tab)           ; erase from local table
-Get(tab) | Log                         ; => {k2: 2}
-Erase(["k2"] Name: tab Global: true)   ; erase from global table
-Get(tab Global: true) | Log            ; => {k3: 3 k1: 1}
+{k1: 1 k2: 2 k3: 3} | ExpectTable >= tab ; create local table   
+{k1: 1 k2: 2 k3: 3} | ExpectTable | Set(tab Global: true) ; create global table   
+Erase(["k3" "k1"] Name: tab) ; erase from local table
+Get(tab) | Log ; => {k2: 2}
+Erase(["k2"] Name: tab Global: true) ; erase from global table
+Get(tab Global: true) | Log ; => {k3: 3 k1: 1}

--- a/include/shards/math_ops.hpp
+++ b/include/shards/math_ops.hpp
@@ -213,60 +213,61 @@ constexpr bool hasDispatchType(DispatchType a, DispatchType b) { return (uint8_t
       "dispatchType<{}>({})", magic_enum::enum_flags_name(static_cast<DispatchType>(dispatchType)), magic_enum::enum_name(type)));
 }
 
-template <DispatchType DispatchType, typename T, typename... TArgs> void dispatchType(SHType type, T v, TArgs &&...args) {
+template <DispatchType DispatchType, typename T, typename... TArgs>
+void dispatchType(SHType type, bool *failed, T v, TArgs &&...args) {
   switch (type) {
   case SHType::Int:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Int>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Int>(std::forward<TArgs>(args)...);
     break;
   case SHType::Int2:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Int2>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Int2>(std::forward<TArgs>(args)...);
     break;
   case SHType::Int3:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Int3>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Int3>(std::forward<TArgs>(args)...);
     break;
   case SHType::Int4:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Int4>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Int4>(std::forward<TArgs>(args)...);
     break;
   case SHType::Int8:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Int8>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Int8>(std::forward<TArgs>(args)...);
     break;
   case SHType::Int16:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Int16>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Int16>(std::forward<TArgs>(args)...);
     break;
   case SHType::Color:
     if constexpr (hasDispatchType(DispatchType, DispatchType::IntTypes))
-      return v.template apply<SHType::Color>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Color>(std::forward<TArgs>(args)...);
     break;
   case SHType::Float:
     if constexpr (hasDispatchType(DispatchType, DispatchType::FloatTypes))
-      return v.template apply<SHType::Float>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Float>(std::forward<TArgs>(args)...);
     break;
   case SHType::Float2:
     if constexpr (hasDispatchType(DispatchType, DispatchType::FloatTypes))
-      return v.template apply<SHType::Float2>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Float2>(std::forward<TArgs>(args)...);
     break;
   case SHType::Float3:
     if constexpr (hasDispatchType(DispatchType, DispatchType::FloatTypes))
-      return v.template apply<SHType::Float3>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Float3>(std::forward<TArgs>(args)...);
     break;
   case SHType::Float4:
     if constexpr (hasDispatchType(DispatchType, DispatchType::FloatTypes))
-      return v.template apply<SHType::Float4>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Float4>(std::forward<TArgs>(args)...);
     break;
   case SHType::Bool:
     if constexpr (hasDispatchType(DispatchType, DispatchType::BoolTypes))
-      return v.template apply<SHType::Bool>(std::forward<TArgs>(args)...);
+      v.template apply<SHType::Bool>(std::forward<TArgs>(args)...);
     break;
   default:
+    *failed = true;
     break;
   }
-  throwDispatchError(type, static_cast<int>(DispatchType));
 }
 
 struct ModOp final {

--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -95,6 +95,8 @@ SH_ARRAY_DECL(SHPayloadArray, struct SHVarPayload);
 struct SHVar;
 SH_ARRAY_DECL(SHSeq, struct SHVar);
 
+SH_ARRAY_DECL(SHTableIndices, uint32_t);
+
 struct SHTableImpl;
 
 struct SHTableInterface;
@@ -314,6 +316,11 @@ typedef struct SHTableTypeInfo {
   // > 0 it is assumed that tableTypes contains a sequence with the possible
   // types in the table
   SHTypesInfo types;
+  // Fixed struct table, this is used to mark a table as a fixed struct table, this allows a lot of optimizations, basically
+  // turning a table into a struct
+  SHBool fixedStructTable;
+  // These are the indices of the keys in the table, this is used to optimize the table access
+  SHTableIndices indices;
 } SHTableTypeInfo;
 
 typedef struct SHExtendedObjectTypeInfo SHExtendedObjectTypeInfo;
@@ -392,8 +399,6 @@ struct SHTypeInfo {
   // inside the seqTypes or so)
   // Should not be considered when hashing this type
   SHBool recursiveSelf;
-  // Fixed struct table, this is used to mark a table as a fixed struct table, this allows a lot of optimizations, basically turning a table into a struct
-  SHBool fixedStructTable;
 };
 
 typedef struct SHTraitVariable {

--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -392,6 +392,8 @@ struct SHTypeInfo {
   // inside the seqTypes or so)
   // Should not be considered when hashing this type
   SHBool recursiveSelf;
+  // Fixed struct table, this is used to mark a table as a fixed struct table, this allows a lot of optimizations, basically turning a table into a struct
+  SHBool fixedStructTable;
 };
 
 typedef struct SHTraitVariable {
@@ -625,9 +627,10 @@ struct SHVarPayload {
 #define SHVAR_FLAGS_ABORT (1 << 5) // 6
 // this marks a weak object reference
 #define SHVAR_FLAGS_WEAK_OBJECT (1 << 6) // 7
+// this marks a variable as a fixed struct table, this allows a lot of optimizations, basically turning a table into a struct
+#define SHVAR_FLAGS_FIXED_STRUCT_TABLE (1 << 7) // 8
 
 // Additional flags available
-// #define SHVAR_FLAGS_RESERVED_0 (1 << 7) // 8
 // #define SHVAR_FLAGS_RESERVED_1 (1 << 8) // 9
 // #define SHVAR_FLAGS_RESERVED_2 (1 << 9) // 10
 // #define SHVAR_FLAGS_RESERVED_3 (1 << 10) // 11

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -183,8 +183,8 @@ struct Type {
 
   template <size_t N> static Type TableOf(SHTypesInfo types, const std::array<SHVar, N> &keys) {
     Type res;
-    if(N > 0 && N != types.len) {
-      throw std::logic_error("TableOf: keys and types length mismatch");  
+    if (N > 0 && N != types.len) {
+      throw std::logic_error("TableOf: keys and types length mismatch");
     }
     auto &k = const_cast<std::array<SHVar, N> &>(keys);
     res._type = {SHType::Table, {.table = {.keys = {&k[0], uint32_t(k.size()), 0}, .types = types}}};
@@ -936,6 +936,16 @@ struct Var : public SHVar {
   explicit Var(SHImage *img) : SHVar() {
     valueType = SHType::Image;
     payload.imageValue = img;
+  }
+
+  explicit Var(SHTrait *trait) : SHVar() {
+    valueType = SHType::Trait;
+    payload.traitValue = trait;
+  }
+
+  explicit Var(SHTypeInfo *type) : SHVar() {
+    valueType = SHType::Type;
+    payload.typeValue = type;
   }
 
   explicit constexpr Var(int64_t src) : SHVar() {

--- a/shards/core/type_info.cpp
+++ b/shards/core/type_info.cpp
@@ -32,6 +32,8 @@ void freeTypeInfo(SHTypeInfo info) {
     }
     shards::arrayFree(info.table.types);
     shards::arrayFree(info.table.keys);
+    shards::arrayFree(info.table.indices);
+    info.table.fixedStructTable = false;
   } break;
   default:
     break;
@@ -73,6 +75,9 @@ SHTypeInfo cloneTypeInfo(const SHTypeInfo &other) {
       auto idx = varType.table.keys.len;
       shards::arrayResize(varType.table.keys, idx + 1);
       cloneVar(varType.table.keys.elements[idx], other.table.keys.elements[i]);
+    }
+    for (uint32_t i = 0; i < other.table.indices.len; i++) {
+      shards::arrayPush(varType.table.indices, other.table.indices.elements[i]);
     }
     break;
   }

--- a/shards/modules/anim/anim.cpp
+++ b/shards/modules/anim/anim.cpp
@@ -180,7 +180,10 @@ struct TimerShard {
 };
 
 struct PlayShard {
-  static SHOptionalString help() { return SHCCSTR("Evaluates and interpolates the animation of the glTF model specified in the Animation parameter. The output of this shard is applied to the glTF model to play animations."); }
+  static SHOptionalString help() {
+    return SHCCSTR("Evaluates and interpolates the animation of the glTF model specified in the Animation parameter. The output "
+                   "of this shard is applied to the glTF model to play animations.");
+  }
 
   static inline shards::Types OutputTypes{{Type::SeqOf(ShardsTypes::ValueTable)}};
 
@@ -246,8 +249,13 @@ struct PlayShard {
       } else {
         // Generic lerp
         outputValue.valueType = va.valueType;
-        Math::dispatchType<Math::DispatchType::NumberTypes>(va.valueType, Math::ApplyLerp{}, outputValue.payload, va.payload,
-                                                            vb.payload, double(phase));
+        bool failed = false;
+        Math::dispatchType<Math::DispatchType::NumberTypes>(va.valueType, &failed, Math::ApplyLerp{}, outputValue.payload,
+                                                            va.payload, vb.payload, double(phase));
+        if (failed) {
+          throw ActivationError(fmt::format("Invalid types for ApplyLerp: {} and {}", magic_enum::enum_name(va.valueType),
+                                            magic_enum::enum_name(vb.valueType)));
+        }
       }
     } else {
       outputValue = va;
@@ -299,7 +307,10 @@ struct DurationShard {
 struct InterpolateShard {
   static inline shards::Types FloatTypes{CoreInfo::FloatType, CoreInfo::Float2Type, CoreInfo::Float3Type, CoreInfo::Float4Type};
 
-  static SHOptionalString help() { return SHCCSTR("Whenever the input value is changed, this shard will interpolate between the old value and the new value over the duration of the animation and output the result."); }
+  static SHOptionalString help() {
+    return SHCCSTR("Whenever the input value is changed, this shard will interpolate between the old value and the new value "
+                   "over the duration of the animation and output the result.");
+  }
   static SHTypesInfo inputTypes() { return FloatTypes; }
   static SHTypesInfo outputTypes() { return FloatTypes; }
   static SHOptionalString inputHelp() { return SHCCSTR("The value to interpolate."); }
@@ -345,8 +356,13 @@ struct InterpolateShard {
     } else {
       // Generic lerp
       _lastOutput.valueType = _a.valueType;
-      Math::dispatchType<Math::DispatchType::FloatTypes>(_a.valueType, Math::ApplyLerp{}, _lastOutput.payload, _a.payload,
-                                                         _b.payload, double(phase));
+      bool failed = false;
+      Math::dispatchType<Math::DispatchType::FloatTypes>(_a.valueType, &failed, Math::ApplyLerp{}, _lastOutput.payload,
+                                                         _a.payload, _b.payload, double(phase));
+      if (failed) {
+        throw ActivationError(fmt::format("Invalid types for ApplyLerp: {} and {}", magic_enum::enum_name(_a.valueType),
+                                          magic_enum::enum_name(_b.valueType)));
+      }
     }
   }
 

--- a/shards/modules/assert/assert.cpp
+++ b/shards/modules/assert/assert.cpp
@@ -370,8 +370,8 @@ SHARDS_REGISTER_FN(assert) {
   REGISTER_SHARD("Assert.IsVariable", IsVariable);
   REGISTER_SHARD("Assert.IsNot", IsNot);
   REGISTER_SHARD("Assert.IsAlmost", IsAlmost);
-  REGISTER_SHARD("Assert.Compose", Compose<true>);
-  REGISTER_SHARD("Assert.NoCompose", Compose<false>);
+  REGISTER_SHARD("Assert.ComposeSuccess", Compose<true>);
+  REGISTER_SHARD("Assert.ComposeFailure", Compose<false>);
   REGISTER_SHARD("Debug.Break", Break);
   REGISTER_SHARD("_Callgrind.Start", CallgrindStart);
   REGISTER_SHARD("_Callgrind.Stop", CallgrindStop);

--- a/shards/modules/bigint/bigint.cpp
+++ b/shards/modules/bigint/bigint.cpp
@@ -17,8 +17,7 @@
 using namespace boost::multiprecision;
 
 struct BigIntDefaultHelpText {
-  static inline const SHOptionalString BigIntInputOutput =
-      SHCCSTR("Big integer represented as bytes.");
+  static inline const SHOptionalString BigIntInputOutput = SHCCSTR("Big integer represented as bytes.");
 };
 
 namespace shards {
@@ -40,8 +39,6 @@ inline cpp_int from_var_payload(const SHVarPayload &payload) {
 }
 
 inline cpp_int from_var(const SHVar &op) { return from_var_payload(op.payload); }
-
-
 
 struct ToBigInt {
   std::vector<uint8_t> _buffer;
@@ -114,7 +111,7 @@ template <typename TOp> struct BigIntBinaryOperation {
     return opType;
   }
 
-  void operateDirect(SHVar &outputVar, const SHVar &a, const SHVar &b) {
+  void operateDirect(SHVar &outputVar, const SHVar &a, const SHVar &b, bool *failed) {
     cpp_int bia = from_var(a);
     cpp_int bib = from_var(b);
 
@@ -125,7 +122,8 @@ template <typename TOp> struct BigIntBinaryOperation {
     outputVar.flags = SHVAR_FLAGS_FOREIGN; // prevent double frees!
   }
 
-  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b) {
+  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
+    // fine to ignore failed, as we don't inline optimize this and throwing is fine here
     throw std::logic_error("invalid broadcast on bigint types");
   }
 
@@ -236,8 +234,9 @@ struct AddOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::AddOp>
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The big integer to add to the input as bytes."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The big integer to add to the input as bytes."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -249,8 +248,9 @@ struct SubtractOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::S
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The big integer to subtract from the input as bytes."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The big integer to subtract from the input as bytes."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -262,8 +262,9 @@ struct MultiplyOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::M
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The big integer to multiply the big integer input with."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The big integer to multiply the big integer input with."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -275,8 +276,9 @@ struct DivideOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::Div
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The big integer to divide the big integer input with."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The big integer to divide the big integer input with."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -295,8 +297,9 @@ struct XorOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::XorOp>
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The second big integer to perform the XOR operation with."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The second big integer to perform the XOR operation with."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -315,8 +318,9 @@ struct AndOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::AndOp>
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The second big integer to perform the AND operation with."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The second big integer to perform the AND operation with."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -335,8 +339,9 @@ struct OrOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::OrOp>> 
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The second big integer to perform the OR operation with."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The second big integer to perform the OR operation with."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -348,8 +353,9 @@ struct ModOp : public BigInt::BinaryOperation<BigIntBinaryOperation<Math::ModOp>
   }
 
   SHParametersInfo parameters() {
-    static Parameters params{
-        {"Operand", SHCCSTR("The big integer to compute the modulus with respect to."), {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
+    static Parameters params{{"Operand",
+                              SHCCSTR("The big integer to compute the modulus with respect to."),
+                              {CoreInfo::BytesVarType, CoreInfo::BytesVarSeqType}}};
     return params;
   }
 };
@@ -378,18 +384,24 @@ using Mod = ModOp;
     }                                                                          \
   }
 
-BIGINT_LOGIC_OP(Is, ==, "This shard checks if the input big integer is equal to the operand.",
-                "Outputs true if the input big integer is equal to the big integer specified in the Operand parameter and false otherwise.");
+BIGINT_LOGIC_OP(
+    Is, ==, "This shard checks if the input big integer is equal to the operand.",
+    "Outputs true if the input big integer is equal to the big integer specified in the Operand parameter and false otherwise.");
 BIGINT_LOGIC_OP(IsNot, !=, "This shard checks if the input big integer is not equal to the operand.",
-                "Outputs true if the input big integer is not equal to the big integer specified in the Operand parameter and false otherwise.");
+                "Outputs true if the input big integer is not equal to the big integer specified in the Operand parameter and "
+                "false otherwise.");
 BIGINT_LOGIC_OP(IsMore, >, "This shard checks if the input big integer is greater than the operand.",
-                "Outputs true if the input big integer is greater than the big integer specified in the Operand parameter and false otherwise.");
-BIGINT_LOGIC_OP(IsLess, <, "This shard checks if the input big integer is less than the operand.",
-                "Outputs true if the input big integer is less than the big integer specified in the Operand parameter and false otherwise.");
+                "Outputs true if the input big integer is greater than the big integer specified in the Operand parameter and "
+                "false otherwise.");
+BIGINT_LOGIC_OP(
+    IsLess, <, "This shard checks if the input big integer is less than the operand.",
+    "Outputs true if the input big integer is less than the big integer specified in the Operand parameter and false otherwise.");
 BIGINT_LOGIC_OP(IsMoreEqual, >=, "This shard checks if the input big integer is greater than or equal to the operand.",
-                "Outputs true if the input big integer is greater than or equal to the big integer specified in the Operand parameter and false otherwise.");
+                "Outputs true if the input big integer is greater than or equal to the big integer specified in the Operand "
+                "parameter and false otherwise.");
 BIGINT_LOGIC_OP(IsLessEqual, <=, "This shard checks if the input big integer is less than or equal to the operand.",
-                "Outputs true if the input big integer is less than or equal to the big integer specified in the Operand parameter and false otherwise.");
+                "Outputs true if the input big integer is less than or equal to the big integer specified in the Operand "
+                "parameter and false otherwise.");
 
 struct MinOp final {
   template <typename T> T apply(const T &a, const T &b) { return std::min(a, b); }
@@ -427,27 +439,27 @@ struct Max : public BigInt::BinaryOperation<BigIntBinaryOperation<MaxOp>> {
   }
 };
 
-#define BIGINT_REG_BINARY_OP(__NAME__, __OP__)                                                                                 \
-  struct __NAME__ : public RegOperandBase {                                                                                    \
-    static SHOptionalString help() {                                                                                           \
-      return SHCCSTR("This shard raises the input big integer to the power of the exponent specified in " \
-                     "the  Operand parameter.");                                                                               \
-    }                                                                                                                          \
-    SHParametersInfo parameters() {                                                                                            \
-      static Parameters params{                                                                                                \
-          {"Operand",                                                                                                          \
-           SHCCSTR("The power to which the input big integer will be raised. This must be a non-negative integer."),           \
-           {CoreInfo::IntType, CoreInfo::IntVarType}}};                                                                        \
-      return params;                                                                                                           \
-    }                                                                                                                          \
-    SHVar activate(SHContext *context, const SHVar &input) {                                                                   \
-      cpp_int bia = from_var(input);                                                                                           \
-      auto op = getOperand();                                                                                                  \
-      if (op.valueType != SHType::Int)                                                                                         \
-        throw ActivationError("Pow operand should be an Int");                                                                 \
-      cpp_int bres = __OP__(bia, op.payload.intValue);                                                                         \
-      return to_var(bres, _buffer);                                                                                            \
-    }                                                                                                                          \
+#define BIGINT_REG_BINARY_OP(__NAME__, __OP__)                                                                       \
+  struct __NAME__ : public RegOperandBase {                                                                          \
+    static SHOptionalString help() {                                                                                 \
+      return SHCCSTR("This shard raises the input big integer to the power of the exponent specified in "            \
+                     "the  Operand parameter.");                                                                     \
+    }                                                                                                                \
+    SHParametersInfo parameters() {                                                                                  \
+      static Parameters params{                                                                                      \
+          {"Operand",                                                                                                \
+           SHCCSTR("The power to which the input big integer will be raised. This must be a non-negative integer."), \
+           {CoreInfo::IntType, CoreInfo::IntVarType}}};                                                              \
+      return params;                                                                                                 \
+    }                                                                                                                \
+    SHVar activate(SHContext *context, const SHVar &input) {                                                         \
+      cpp_int bia = from_var(input);                                                                                 \
+      auto op = getOperand();                                                                                        \
+      if (op.valueType != SHType::Int)                                                                               \
+        throw ActivationError("Pow operand should be an Int");                                                       \
+      cpp_int bres = __OP__(bia, op.payload.intValue);                                                               \
+      return to_var(bres, _buffer);                                                                                  \
+    }                                                                                                                \
   }
 
 BIGINT_REG_BINARY_OP(Pow, pow);
@@ -702,7 +714,9 @@ struct Abs {
   static SHOptionalString inputHelp() { return BigIntDefaultHelpText::BigIntInputOutput; }
 
   static SHTypesInfo outputTypes() { return CoreInfo::BytesType; }
-  static SHOptionalString outputHelp() { return SHCCSTR("The resulting big integer with an absolute value, represented as bytes."); }
+  static SHOptionalString outputHelp() {
+    return SHCCSTR("The resulting big integer with an absolute value, represented as bytes.");
+  }
 
   SHVar activate(SHContext *context, const SHVar &input) {
     cpp_int bi = from_var(input);

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -1279,13 +1279,26 @@ struct Erase : SeqUser {
           fmt::format("Erase: Expected a SHType::Seq or SHType::Table, got {}, variable: {}", info->exposedType, _name));
     }
 
+    if (!info->isMutable) {
+      throw ComposeError(fmt::format("Erase: Variable {} is not mutable.", _name));
+    }
+
     auto isTable = info->exposedType.basicType == SHType::Table;
 
     // Figure if we output a sequence or not
     if (isTable) {
+      // cannot erase from a fixed struct table
       if (info->exposedType.table.fixedStructTable) {
         throw ComposeError(fmt::format("Erase: Cannot erase from a fixed struct table, variable: {}", _name));
       }
+
+      // we also need to check if there are any non dynamic keys, in that case we forbid erasing
+      for (uint32_t i = 0; i < info->exposedType.table.keys.len; i++) {
+        if (info->exposedType.table.keys.elements[i].valueType != SHType::None) {
+          throw ComposeError(fmt::format("Erase: Cannot erase from a table with non dynamic keys, variable: {}", _name));
+        }
+      }
+
       valid = true;
     } else if (_indices->valueType == SHType::Seq) {
       if (_indices->payload.seqValue.len > 0 && _indices->payload.seqValue.elements[0].valueType == SHType::Int) {

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -1283,6 +1283,9 @@ struct Erase : SeqUser {
 
     // Figure if we output a sequence or not
     if (isTable) {
+      if (info->exposedType.table.fixedStructTable) {
+        throw ComposeError(fmt::format("Erase: Cannot erase from a fixed struct table, variable: {}", _name));
+      }
       valid = true;
     } else if (_indices->valueType == SHType::Seq) {
       if (_indices->payload.seqValue.len > 0 && _indices->payload.seqValue.elements[0].valueType == SHType::Int) {

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <optional>
 #include <sstream>
+#include <numeric>
 
 using namespace std::chrono_literals;
 

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2947,8 +2947,16 @@ struct Clear : SeqUser {
     }
 
     if (info->exposedType.basicType == SHType::Table) {
+      // cannot clear a fixed struct table
       if (info->exposedType.table.fixedStructTable) {
         throw ComposeError(fmt::format("Clear: Cannot clear a fixed struct table, variable: {}", _name));
+      }
+
+      // also cannot clear tables with non dynamic keys
+      for (uint32_t i = 0; i < info->exposedType.table.keys.len; i++) {
+        if (info->exposedType.table.keys.elements[i].valueType != SHType::None) {
+          throw ComposeError(fmt::format("Clear: Cannot clear a table with non dynamic keys, variable: {}", _name));
+        }
       }
     }
 
@@ -3443,8 +3451,7 @@ struct Take {
           OVERRIDE_ACTIVATE(data, activateTable);
         }
 
-        if (data.inputType.table.keys.len > 0 && _indices.valueType != SHType::ContextVar &&
-            data.inputType.table.fixedStructTable) {
+        if (data.inputType.table.keys.len > 0 && _indices.valueType != SHType::ContextVar) {
           // we can fully reconstruct a type in this case
           if (data.inputType.table.keys.len != data.inputType.table.types.len) {
             SHLOG_ERROR("Table input type: {}", data.inputType);

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2690,6 +2690,11 @@ struct TableDecl : public VariableBase {
     // we do this by iterating over the keys and setting the default values
     for (uint32_t i = 0; i < tableInfo.keys.len; i++) {
       auto key = shards::OwnedVar::Foreign(tableInfo.keys.elements[i]);
+      if (key.valueType == SHType::None) {
+        // skip in this case, we don't want to fill default values for dynamic keys
+        continue;
+      }
+
       auto &type = tableInfo.types.elements[i];
 
       auto &value = table[key];
@@ -2713,9 +2718,6 @@ struct TableDecl : public VariableBase {
       case SHType::Color:
       case SHType::EndOfBlittableTypes:
       case SHType::Bytes:
-      case SHType::String:
-      case SHType::Path:
-      case SHType::ContextVar:
       case SHType::Audio:
       case SHType::Seq:
       case SHType::Object: {
@@ -2724,6 +2726,11 @@ struct TableDecl : public VariableBase {
         break;
       }
       // following types cannot just be memset'd
+      case SHType::String:
+      case SHType::Path:
+      case SHType::ContextVar:
+        value = shards::Var("");
+        break;
       case SHType::Table: {
         value.valueType = SHType::Table;
         value.payload.tableValue.api = &GetGlobals().TableInterface;
@@ -2937,6 +2944,12 @@ struct Clear : SeqUser {
 
     if (!info->isMutable) {
       throw ComposeError(fmt::format("Variable {} is not mutable.", _name));
+    }
+
+    if (info->exposedType.basicType == SHType::Table) {
+      if (info->exposedType.table.fixedStructTable) {
+        throw ComposeError(fmt::format("Clear: Cannot clear a fixed struct table, variable: {}", _name));
+      }
     }
 
     return data.inputType;
@@ -3430,7 +3443,8 @@ struct Take {
           OVERRIDE_ACTIVATE(data, activateTable);
         }
 
-        if (data.inputType.table.keys.len > 0 && _indices.valueType != SHType::ContextVar) {
+        if (data.inputType.table.keys.len > 0 && _indices.valueType != SHType::ContextVar &&
+            data.inputType.table.fixedStructTable) {
           // we can fully reconstruct a type in this case
           if (data.inputType.table.keys.len != data.inputType.table.types.len) {
             SHLOG_ERROR("Table input type: {}", data.inputType);

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2571,6 +2571,7 @@ struct TableDecl : public VariableBase {
       if (!_key.isVariable()) {
         shards::arrayPush(_tableInfo.table.keys, *_key);
       }
+
       if (_global) {
         _exposedInfo =
             ExposedInfo(ExposedInfo::GlobalVariable(_name.c_str(), SHCCSTR("The exposed table."), SHTypeInfo(_tableInfo), true));
@@ -2614,6 +2615,25 @@ struct TableDecl : public VariableBase {
     }
 
     if (!_isTable) {
+      // Check if we have all keys as fixed values in the type description, if so we can mark the table as a fixed struct table
+      // Btw this can work only in this case, not for nested tables, reason being KISS principle
+      // anyway you can declare nested tables within this table itself!
+      // Type: @type({"x": {"y": another-type}})
+      if (!_typeDesc->isNone()) {
+        bool hasNone = false;
+        for (uint32_t i = 0; i < _tableInfo.table.keys.len; i++) {
+          auto &key = _tableInfo.table.keys.elements[i];
+          if (key.valueType == SHType::None) {
+            hasNone = true;
+            break;
+          }
+        }
+        if (!hasNone) {
+          // Ok we can mark the table as a fixed struct table
+          _weakType.fixedStructTable = true;
+        }
+      }
+
       if (_global) {
         _exposedInfo = ExposedInfo(ExposedInfo::GlobalVariable(_name.c_str(), SHCCSTR("The exposed table."), _weakType, true));
       } else {

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2540,11 +2540,13 @@ struct TableDecl : public VariableBase {
   OwnedVar _typeDesc{};
   SHTypeInfo _weakType{};
   bool _clear = true;
+  bool _canClear = false;
 
   static inline Parameters tableParams{
       setterParams,
       {{"Clear",
-        SHCCSTR("If we should clear this sequence at every wire iteration; works only if this is the first push; default: true."),
+        SHCCSTR("If we should clear this table at every wire iteration; works ONLY if it's a dynamic table (no keys or only "
+                "`none` key); default: true."),
         {CoreInfo::BoolType}},
        {"Type", SHCCSTR("The table type to forward declare."), {CoreInfo::NoneType, CoreInfo::TypeType}}},
   };
@@ -2679,6 +2681,21 @@ struct TableDecl : public VariableBase {
       throw ComposeError("Table - Type must be a table.");
     }
 
+    if (_weakType.table.fixedStructTable) {
+      _canClear = false;
+    } else if (_typeDesc.valueType == SHType::None) {
+      _canClear = true;
+    } else {
+      // ensure there is only a none key
+      _canClear = true;
+      for (uint32_t i = 0; i < _weakType.table.keys.len; i++) {
+        if (_weakType.table.keys.elements[i].valueType != SHType::None) {
+          _canClear = false;
+          break;
+        }
+      }
+    }
+
     // Ensure declared
     _exposedInfo._innerInfo.elements[0].declared = true;
 
@@ -2781,7 +2798,7 @@ struct TableDecl : public VariableBase {
       }
     }
 
-    if (_clear && !_weakType.table.fixedStructTable) {
+    if (_canClear && _clear) {
       TableVar &table = asTable(*_cell);
       table.clear();
     }

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -1311,6 +1311,10 @@ struct Set : public SetUpdateBase {
 
     // bake exposed types
     if (_isTable) {
+      if (_tableType.table.fixedStructTable) {
+        throw ComposeError(fmt::format("Set, variable \"{}\" is a fixed struct table, cannot be used with Set", _name));
+      }
+
       // we are a table!
       _tableTypeInfo = updateTableType(_tableType, !_key.isVariable() ? &(SHVar &)_key : &Var::Empty, data.inputType,
                                        existingExposedType ? &existingExposedType->exposedType : nullptr);

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -1311,8 +1311,9 @@ struct Set : public SetUpdateBase {
 
     // bake exposed types
     if (_isTable) {
-      if (_tableType.table.fixedStructTable) {
-        throw ComposeError(fmt::format("Set, variable \"{}\" is a fixed struct table, cannot be used with Set", _name));
+      if (existingExposedType && existingExposedType->exposedType.table.fixedStructTable) {
+        throw ComposeError(fmt::format(
+            "Set, variable \"{}\" is a fixed struct table, cannot be used with Set, please use Update instead", _name));
       }
 
       // we are a table!

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2665,6 +2665,7 @@ struct TableDecl : public VariableBase {
       if (!_typeDesc->isNone()) {
         // currently we copy types deeply all the time.. in the future we should optimize this, when we do that this here likely
         // needs to change slightly, for now we just set the flag on the shallow type
+        // TODO, TODO, actually use those derived indices!
         _weakType.table.fixedStructTable = deriveTableIndices(_weakType.table);
       }
 

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2963,17 +2963,37 @@ struct Clear : SeqUser {
       throw ComposeError(fmt::format("Variable {} is not mutable.", _name));
     }
 
-    if (info->exposedType.basicType == SHType::Table) {
-      // cannot clear a fixed struct table
-      if (info->exposedType.table.fixedStructTable) {
-        throw ComposeError(fmt::format("Clear: Cannot clear a fixed struct table, variable: {}", _name));
-      }
-
-      // also cannot clear tables with non dynamic keys
-      for (uint32_t i = 0; i < info->exposedType.table.keys.len; i++) {
-        if (info->exposedType.table.keys.elements[i].valueType != SHType::None) {
-          throw ComposeError(fmt::format("Clear: Cannot clear a table with non dynamic keys, variable: {}", _name));
+    if (_key.isNone()) {
+      if (info->exposedType.basicType == SHType::Table) {
+        // cannot clear a fixed struct table
+        if (info->exposedType.table.fixedStructTable) {
+          throw ComposeError(fmt::format("Clear: Cannot clear a fixed struct table, variable: {}", _name));
         }
+
+        // also cannot clear tables with non dynamic keys
+        for (uint32_t i = 0; i < info->exposedType.table.keys.len; i++) {
+          if (info->exposedType.table.keys.elements[i].valueType != SHType::None) {
+            throw ComposeError(fmt::format("Clear: Cannot clear a table with non dynamic keys, variable: {}", _name));
+          }
+        }
+      }
+    } else {
+      bool fail = true;
+      if (info->exposedType.table.keys.len == info->exposedType.table.types.len) {
+        for (uint32_t i = 0; i < info->exposedType.table.keys.len; i++) {
+          auto &key = info->exposedType.table.keys.elements[i];
+          auto &type = info->exposedType.table.types.elements[i];
+          if (_key == key) {
+            if (type.basicType == SHType::Seq) {
+              fail = false; // fine to clear a sequence
+              break;
+            }
+          }
+        }
+      }
+      if (fail) {
+        throw ComposeError(fmt::format(
+            "Clear: Cannot clear a table with a known key that is not a sequence or a variable key, variable: {}", _name));
       }
     }
 

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2475,6 +2475,7 @@ struct TableDecl : public VariableBase {
           table->valueType = SHType::Table;
           table->payload.tableValue.api = &GetGlobals().TableInterface;
           table->payload.tableValue.opaque = new SHMap();
+          fillDefaultValues(asTable(*table), _weakType.table);
         }
       } else {
         return; // we will check during activate
@@ -2484,6 +2485,7 @@ struct TableDecl : public VariableBase {
         _target->valueType = SHType::Table;
         _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new SHMap();
+        fillDefaultValues(asTable(*_target), _weakType.table);
       }
       _cell = _target;
     }
@@ -2501,6 +2503,7 @@ struct TableDecl : public VariableBase {
       table->valueType = SHType::Table;
       table->payload.tableValue.api = &GetGlobals().TableInterface;
       table->payload.tableValue.opaque = new SHMap();
+      fillDefaultValues(asTable(*table), _weakType.table);
     }
   }
 
@@ -2652,6 +2655,8 @@ struct TableDecl : public VariableBase {
       // anyway you can declare nested tables within this table itself!
       // Type: @type({"x": {"y": another-type}})
       if (!_typeDesc->isNone()) {
+        // currently we copy types deeply all the time.. in the future we should optimize this, when we do that this here likely
+        // needs to change slightly, for now we just set the flag on the shallow type
         _weakType.table.fixedStructTable = deriveTableIndices(_weakType.table);
       }
 
@@ -2674,6 +2679,87 @@ struct TableDecl : public VariableBase {
     return data.inputType;
   }
 
+  void fillDefaultValues(TableVar &table, SHTableTypeInfo &tableInfo) {
+    // we need to fill the default values for the table
+    // we do this by iterating over the keys and setting the default values
+    for (uint32_t i = 0; i < tableInfo.keys.len; i++) {
+      auto key = shards::OwnedVar::Foreign(tableInfo.keys.elements[i]);
+      auto &type = tableInfo.types.elements[i];
+
+      auto &value = table[key];
+      shassert(value.valueType == SHType::None && "Table - Default value should be None");
+
+      switch (type.basicType) {
+      case SHType::None:
+      case SHType::Any:
+      case SHType::Enum:
+      case SHType::Bool:
+      case SHType::Int:
+      case SHType::Int2:
+      case SHType::Int3:
+      case SHType::Int4:
+      case SHType::Int8:
+      case SHType::Int16:
+      case SHType::Float:
+      case SHType::Float2:
+      case SHType::Float3:
+      case SHType::Float4:
+      case SHType::Color:
+      case SHType::EndOfBlittableTypes:
+      case SHType::Bytes:
+      case SHType::String:
+      case SHType::Path:
+      case SHType::ContextVar:
+      case SHType::Audio:
+      case SHType::Seq:
+      case SHType::Object: {
+        value.valueType = type.basicType;
+        memset(&value.payload, 0x0, sizeof(SHVarPayload));
+        break;
+      }
+      // following types cannot just be memset'd
+      case SHType::Table: {
+        value.valueType = SHType::Table;
+        value.payload.tableValue.api = &GetGlobals().TableInterface;
+        value.payload.tableValue.opaque = new SHMap();
+        TableVar &subTable = asTable(value);
+        fillDefaultValues(subTable, type.table);
+        break;
+      }
+      case SHType::Wire: {
+        // Point it to a static empty wire
+        static std::shared_ptr<SHWire> EmptyWire = SHWire::make("<empty>");
+        value = shards::Var(EmptyWire);
+        break;
+      }
+      case SHType::ShardRef: {
+        // Point it to a static Pass shard
+        static Shard *PassShard = shards::createShard("Pass");
+        value.valueType = SHType::ShardRef;
+        value.payload.shardValue = PassShard;
+        break;
+      }
+      case SHType::Type: {
+        // Point to static None type
+        value = shards::Var(reinterpret_cast<SHTypeInfo *>(&CoreInfo::NoneType));
+        break;
+      }
+      case SHType::Image: {
+        // Point to static empty image
+        static SHImage *emptyImage = imageNew(0);
+        value = shards::Var(emptyImage);
+        break;
+      }
+      case SHType::Trait: {
+        // Point to an empty trait
+        static SHTrait emptyTrait{};
+        value = shards::Var(&emptyTrait);
+        break;
+      }
+      }
+    }
+  }
+
   SHVar activate(SHContext *context, const SHVar &input) {
     if (unlikely(_isTable)) {
       checkIfTableChanged();
@@ -2682,7 +2768,7 @@ struct TableDecl : public VariableBase {
       }
     }
 
-    if (_clear) {
+    if (_clear && !_weakType.table.fixedStructTable) {
       TableVar &table = asTable(*_cell);
       table.clear();
     }

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2562,6 +2562,38 @@ struct TableDecl : public VariableBase {
     throw SHException("Param index out of range.");
   }
 
+  static bool deriveTableIndices(SHTableTypeInfo &info) {
+    // Early validation - O(n) scan before any allocation
+    for (uint32_t i = 0; i < info.keys.len; i++) {
+      if (info.keys.elements[i].valueType == SHType::None) {
+        return false; // Cannot proceed with incomplete type info
+      }
+    }
+
+    // Proceed with optimization
+    std::vector<uint32_t> indices(info.keys.len);
+    std::iota(indices.begin(), indices.end(), 0);
+
+    std::sort(indices.begin(), indices.end(),
+              [&](uint32_t a, uint32_t b) { return ShardsKeyCompare<SHVar>{}(info.keys.elements[a], info.keys.elements[b]); });
+
+    shards::arrayResize(info.indices, info.keys.len);
+    std::copy(indices.begin(), indices.end(), info.indices.elements);
+
+    // Recurse - fail fast propagation
+    for (uint32_t i = 0; i < info.types.len; i++) {
+      auto &type = info.types.elements[i];
+      if (type.basicType == SHType::Table) {
+        if (!deriveTableIndices(type.table)) {
+          shards::arrayFree(info.indices); // Clean up on nested failure
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
   SHTypeInfo compose(const SHInstanceData &data) {
     const auto updateTableInfo = [this] {
       _tableInfo.basicType = SHType::Table;
@@ -2620,18 +2652,7 @@ struct TableDecl : public VariableBase {
       // anyway you can declare nested tables within this table itself!
       // Type: @type({"x": {"y": another-type}})
       if (!_typeDesc->isNone()) {
-        bool hasNone = false;
-        for (uint32_t i = 0; i < _tableInfo.table.keys.len; i++) {
-          auto &key = _tableInfo.table.keys.elements[i];
-          if (key.valueType == SHType::None) {
-            hasNone = true;
-            break;
-          }
-        }
-        if (!hasNone) {
-          // Ok we can mark the table as a fixed struct table
-          _weakType.fixedStructTable = true;
-        }
+        _weakType.table.fixedStructTable = deriveTableIndices(_weakType.table);
       }
 
       if (_global) {

--- a/shards/modules/core/linalg.hpp
+++ b/shards/modules/core/linalg.hpp
@@ -70,9 +70,13 @@ template <typename TOp> struct VectorBinaryOperation {
     return opType;
   }
 
-  void operateDirect(SHVar &output, const SHVar &a, const SHVar &b) { op.apply(output, a, b); }
+  void operateDirect(SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
+    // fine to ignore failed, as we don't inline optimize this and throwing is fine here
+    op.apply(output, a, b);
+  }
 
-  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b) {
+  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
+    // fine to ignore failed, as we don't inline optimize this and throwing is fine here
     throw std::logic_error("broadcast not allowed on vector operations");
   }
 };
@@ -96,7 +100,7 @@ template <typename TOp> struct VectorUnaryOperation {
     return opType;
   }
 
-  void operateDirect(SHVar &output, const SHVar &a) { op.apply(output, a); }
+  void operateDirect(SHVar &output, const SHVar &a, bool *failed) { op.apply(output, a); }
 };
 
 struct CrossOp {
@@ -273,9 +277,9 @@ struct MatMul : public BinaryBase {
 
   static SHTypesInfo outputTypes() { return CoreInfo::MatrixOrVector; }
   static SHOptionalString outputHelp() {
-    return SHCCSTR(
-        "Outputs the result of the matrix multiplication. If a matrix is multiplied by a vector, the result is a "
-        "vector (depending on the dimensions of the matrix provided). If two matrices are multiplied, the result is a matrix with the same dimensions as the input matrix.");
+    return SHCCSTR("Outputs the result of the matrix multiplication. If a matrix is multiplied by a vector, the result is a "
+                   "vector (depending on the dimensions of the matrix provided). If two matrices are multiplied, the result is a "
+                   "matrix with the same dimensions as the input matrix.");
   }
   OpType validateTypes(const SHTypeInfo &lhs, const SHType &rhs, SHTypeInfo &resultType) {
     if (lhs.basicType == SHType::Seq && rhs == SHType::Seq) {
@@ -689,22 +693,20 @@ struct EulerToQuat {
   }
 
   static SHTypesInfo inputTypes() { return CoreInfo::Float3Type; }
-  static SHOptionalString inputHelp() { 
-    return SHCCSTR("Takes a float3 vector representing Euler angles in radians (x=yaw, y=pitch, z=roll)."); 
+  static SHOptionalString inputHelp() {
+    return SHCCSTR("Takes a float3 vector representing Euler angles in radians (x=yaw, y=pitch, z=roll).");
   }
 
   static SHTypesInfo outputTypes() { return CoreInfo::Float4Type; }
-  static SHOptionalString outputHelp() { 
-    return SHCCSTR("Outputs a float4 vector representing the rotation quaternion."); 
-  }
+  static SHOptionalString outputHelp() { return SHCCSTR("Outputs a float4 vector representing the rotation quaternion."); }
 
   SHVar activate(SHContext *context, const SHVar &input) {
     using namespace linalg::aliases;
     float3 euler = toFloat3(input);
     float yaw = euler.x;
-    float pitch = euler.y; 
+    float pitch = euler.y;
     float roll = euler.z;
-    
+
     // Convert to quaternion using ZYX order (yaw-pitch-roll)
     float cy = cos(yaw * 0.5f);
     float sy = sin(yaw * 0.5f);
@@ -718,7 +720,7 @@ struct EulerToQuat {
     quat.x = sr * cp * cy - cr * sp * sy;
     quat.y = cr * sp * cy + sr * cp * sy;
     quat.z = cr * cp * sy - sr * sp * cy;
-    
+
     _output = quat;
     return _output;
   }

--- a/shards/modules/core/math.hpp
+++ b/shards/modules/core/math.hpp
@@ -235,12 +235,12 @@ template <typename TOp, DispatchType DispatchType = DispatchType::NumberTypes> s
     return OpType::Invalid;
   }
 
-  void operateDirect(SHVar &output, const SHVar &a, const SHVar &b) {
+  void operateDirect(SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
     output.valueType = a.valueType;
-    dispatchType<DispatchType>(a.valueType, apply, output.payload, a.payload, b.payload);
+    dispatchType<DispatchType>(a.valueType, failed, apply, output.payload, a.payload, b.payload);
   }
 
-  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b) {
+  void operateBroadcast(SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
     // This implements broadcast operators on float types
     const VectorTypeTraits *scalarType = _lhsVecType;
     const VectorTypeTraits *vecType = _rhsVecType;
@@ -255,15 +255,15 @@ template <typename TOp, DispatchType DispatchType = DispatchType::NumberTypes> s
     // Expand scalars to vectors
     if (_lhsVecType->dimension == 1) {
       SHVarPayload temp = aPayload; // Need temp var if input/output are the same
-      dispatchType<DispatchType>(vecType->shType, applyBroadcast, aPayload, temp);
+      dispatchType<DispatchType>(vecType->shType, failed, applyBroadcast, aPayload, temp);
     }
     if (_rhsVecType->dimension == 1) {
       SHVarPayload temp = bPayload;
-      dispatchType<DispatchType>(vecType->shType, applyBroadcast, bPayload, temp);
+      dispatchType<DispatchType>(vecType->shType, failed, applyBroadcast, bPayload, temp);
     }
 
     output.valueType = vecType->shType;
-    dispatchType<DispatchType>(vecType->shType, apply, output.payload, aPayload, bPayload);
+    dispatchType<DispatchType>(vecType->shType, failed, apply, output.payload, aPayload, bPayload);
   }
 };
 
@@ -296,10 +296,10 @@ template <class TOp> struct BinaryOperation : public BinaryBase {
 
   SHTypeInfo composeV2(const SHInstanceData &data) { return this->genericCompose(*this, data); }
 
-  void operate(OpType opType, SHVar &output, const SHVar &a, const SHVar &b) {
+  void operate(OpType opType, SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
     shassert(opType != OpType::Invalid);
     if (opType == Broadcast) {
-      op.operateBroadcast(output, a, b);
+      op.operateBroadcast(output, a, b, failed);
     } else if (opType == SeqSeq) {
       if (output.valueType != SHType::Seq) {
         destroyVar(output);
@@ -319,7 +319,7 @@ template <class TOp> struct BinaryOperation : public BinaryBase {
         }
         const auto len = output.payload.seqValue.len;
         shards::arrayResize(output.payload.seqValue, len + 1);
-        operate(type, output.payload.seqValue.elements[len], sa, sb);
+        operate(type, output.payload.seqValue.elements[len], sa, sb, failed);
       }
     } else {
       if (opType == Direct && output.valueType == SHType::Seq) {
@@ -330,13 +330,13 @@ template <class TOp> struct BinaryOperation : public BinaryBase {
                     "but potentially slow");
         destroyVar(output);
       }
-      operateFast(opType, output, a, b);
+      operateFast(opType, output, a, b, failed);
     }
   }
 
-  ALWAYS_INLINE void operateFast(OpType opType, SHVar &output, const SHVar &a, const SHVar &b) {
+  ALWAYS_INLINE void operateFast(OpType opType, SHVar &output, const SHVar &a, const SHVar &b, bool *failed) {
     if (likely(opType == Direct)) {
-      op.operateDirect(output, a, b);
+      op.operateDirect(output, a, b, failed);
     } else if (opType == Seq1) {
       if (output.valueType != SHType::Seq) {
         destroyVar(output);
@@ -347,16 +347,25 @@ template <class TOp> struct BinaryOperation : public BinaryBase {
       for (uint32_t i = 0; i < a.payload.seqValue.len; i++) {
         const auto len = output.payload.seqValue.len;
         shards::arrayResize(output.payload.seqValue, len + 1);
-        op.operateDirect(output.payload.seqValue.elements[len], a.payload.seqValue.elements[i], b);
+        op.operateDirect(output.payload.seqValue.elements[len], a.payload.seqValue.elements[i], b, failed);
       }
     } else {
-      operate(_opType, output, a, b);
+      operate(_opType, output, a, b, failed);
     }
+  }
+
+  NO_INLINE void cancelFlow(SHContext *context, const SHVar &a, const SHVar &b) {
+    context->cancelFlow(fmt::format("Invalid types for Math operation: {} and {}", magic_enum::enum_name(a.valueType),
+                                    magic_enum::enum_name(b.valueType)));
   }
 
   ALWAYS_INLINE const SHVar &activate(SHContext *context, const SHVar &input) {
     const auto operand = _operand.get();
-    operateFast(_opType, _result, input, operand);
+    bool failed = false;
+    operateFast(_opType, _result, input, operand, &failed);
+    if (failed) {
+      cancelFlow(context, input, operand);
+    }
     return _result;
   }
 };
@@ -414,9 +423,9 @@ template <typename TOp, DispatchType DispatchType = DispatchType::NumberTypes> s
     return opType;
   }
 
-  void operateDirect(SHVar &output, const SHVar &a) {
+  void operateDirect(SHVar &output, const SHVar &a, bool *failed) {
     output.valueType = a.valueType;
-    dispatchType<DispatchType>(a.valueType, apply, output.payload, a.payload);
+    dispatchType<DispatchType>(a.valueType, failed, apply, output.payload, a.payload);
   }
 };
 
@@ -442,9 +451,14 @@ template <class TOp> struct UnaryOperation : public UnaryBase {
                    "operation is applied to each element of the sequence.");
   }
 
-  ALWAYS_INLINE void operate(SHVar &output, const SHVar &a) {
+  NO_INLINE void cancelFlow(SHContext *context, const SHVar &input, const SHVar &a) {
+    context->cancelFlow(fmt::format("Invalid types for unary operation: {} and {}", magic_enum::enum_name(a.valueType),
+                                    magic_enum::enum_name(input.valueType)));
+  }
+
+  ALWAYS_INLINE void operate(SHVar &output, const SHVar &a, bool *failed) {
     if (likely(_opType == OpType::Direct)) {
-      op.operateDirect(output, a);
+      op.operateDirect(output, a, failed);
     } else if (_opType == OpType::Seq1) {
       if (output.valueType != SHType::Seq) {
         destroyVar(output);
@@ -453,15 +467,19 @@ template <class TOp> struct UnaryOperation : public UnaryBase {
 
       shards::arrayResize(output.payload.seqValue, a.payload.seqValue.len);
       for (uint32_t i = 0; i < a.payload.seqValue.len; i++) {
-        op.operateDirect(output.payload.seqValue.elements[i], a.payload.seqValue.elements[i]);
+        op.operateDirect(output.payload.seqValue.elements[i], a.payload.seqValue.elements[i], failed);
       }
     } else {
-      throw std::logic_error("Invalid operation type for unary operation");
+      *failed = true;
     }
   }
 
   ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {
-    operate(_result, input);
+    bool failed = false;
+    operate(_result, input, &failed);
+    if (failed) {
+      cancelFlow(context, input, _result);
+    }
     return _result;
   }
 };
@@ -546,7 +564,18 @@ template <class TOp> struct UnaryVarOperation : public UnaryOperation<TOp> {
 
   void cleanup(SHContext *context) { _value.cleanup(); }
 
-  ALWAYS_INLINE void activate(SHContext *context, const SHVar &input) { this->operate(_value.get(), _value.get()); }
+  NO_INLINE void cancelFlow(SHContext *context, const SHVar &input, const SHVar &a) {
+    context->cancelFlow(fmt::format("Invalid types for unary operation: {} and {}", magic_enum::enum_name(a.valueType),
+                                    magic_enum::enum_name(input.valueType)));
+  }
+
+  ALWAYS_INLINE void activate(SHContext *context, const SHVar &input) {
+    bool failed = false;
+    this->operate(_value.get(), _value.get(), &failed);
+    if (failed) {
+      cancelFlow(context, input, _value.get());
+    }
+  }
 };
 
 #define MATH_BINARY_OPERATION(NAME, OPERATOR, DIV_BY_ZERO) using NAME = BinaryOperation<BasicBinaryOperation<NAME##Op>>;
@@ -1503,12 +1532,21 @@ struct Lerp final {
     return SHTypeInfo{.basicType = firstType};
   }
 
+  NO_INLINE void cancelFlow(SHContext *context, const SHVar &a, const SHVar &b) {
+    context->cancelFlow(fmt::format("Invalid types for ApplyLerp: {} and {}", magic_enum::enum_name(a.valueType),
+                                    magic_enum::enum_name(b.valueType)));
+  }
+
   ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {
     SHVar a = _first.get();
     SHVar b = _second.get();
     SHVar result{.valueType = a.valueType};
-    dispatchType<DispatchType::NumberTypes>(a.valueType, ApplyLerp{}, result.payload, a.payload, b.payload,
+    bool failed = false;
+    dispatchType<DispatchType::NumberTypes>(a.valueType, &failed, ApplyLerp{}, result.payload, a.payload, b.payload,
                                             input.payload.floatValue);
+    if (failed) {
+      cancelFlow(context, a, b);
+    }
     return result;
   }
 };
@@ -1596,11 +1634,21 @@ struct Clamp final {
     return SHTypeInfo{.basicType = firstType};
   }
 
+  NO_INLINE void cancelFlow(SHContext *context, const SHVar &a, const SHVar &b) {
+    context->cancelFlow(fmt::format("Invalid types for ApplyClamp: {} and {}", magic_enum::enum_name(a.valueType),
+                                    magic_enum::enum_name(b.valueType)));
+  }
+
   ALWAYS_INLINE SHVar activate(SHContext *context, const SHVar &input) {
     SHVar a = _first.get();
     SHVar b = _second.get();
     SHVar result{.valueType = a.valueType};
-    dispatchType<DispatchType::NumberTypes>(a.valueType, ApplyClamp{}, result.payload, input.payload, a.payload, b.payload);
+    bool failed = false;
+    dispatchType<DispatchType::NumberTypes>(a.valueType, &failed, ApplyClamp{}, result.payload, input.payload, a.payload,
+                                            b.payload);
+    if (failed) {
+      cancelFlow(context, a, b);
+    }
     return result;
   }
 };

--- a/shards/rust/src/types.rs
+++ b/shards/rust/src/types.rs
@@ -1278,6 +1278,7 @@ pub mod common_type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
+      fixedStructTable: false,
     }
   }
 
@@ -1313,6 +1314,7 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
+        fixedStructTable: false,
       };
 
       pub static $name_table: SHTypeInfo = SHTypeInfo {
@@ -1334,6 +1336,7 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
+        fixedStructTable: false,
       };
 
       pub static $name_var: SHTypeInfo = SHTypeInfo {
@@ -1348,6 +1351,7 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
+        fixedStructTable: false,
       };
 
       pub static $names_var: SHTypeInfo = SHTypeInfo {
@@ -1362,6 +1366,7 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
+        fixedStructTable: false,
       };
 
       pub static $name_table_var: SHTypeInfo = SHTypeInfo {
@@ -1376,6 +1381,7 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
+        fixedStructTable: false,
       };
     };
   }
@@ -1616,6 +1622,7 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
+      fixedStructTable: false,
     }
   }
 
@@ -1628,6 +1635,7 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
+      fixedStructTable: false,
     }
   }
 
@@ -1645,6 +1653,7 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
+      fixedStructTable: false,
     }
   }
 
@@ -1668,6 +1677,7 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
+      fixedStructTable: false,
     }
   }
 
@@ -1684,6 +1694,7 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
+      fixedStructTable: false,
     }
   }
 }

--- a/shards/rust/src/types.rs
+++ b/shards/rust/src/types.rs
@@ -13,12 +13,12 @@ use crate::shardsc::{
   SHBool, SHColor, SHComposeResult, SHContext, SHEnumInfo, SHEnumTypeInfo, SHExposedTypeInfo,
   SHExposedTypesInfo, SHImage, SHInstanceData, SHMeshRef, SHObjectTypeInfo, SHOptionalString,
   SHOptionalStrings, SHParameterInfo, SHParametersInfo, SHPointer, SHSeq, SHString, SHStrings,
-  SHTable, SHTableIterator, SHTableTypeInfo, SHTraits, SHTypeInfo, SHTypeInfo_Details, SHType_Any,
-  SHType_Bool, SHType_Bytes, SHType_Color, SHType_ContextVar, SHType_Enum, SHType_Float,
-  SHType_Float2, SHType_Float3, SHType_Float4, SHType_Image, SHType_Int, SHType_Int16, SHType_Int2,
-  SHType_Int3, SHType_Int4, SHType_Int8, SHType_None, SHType_Object, SHType_Path, SHType_Seq,
-  SHType_ShardRef, SHType_String, SHType_Table, SHType_Wire, SHTypesInfo, SHVar, SHVarPayload,
-  SHVarPayload__bindgen_ty_1, SHVarPayload__bindgen_ty_1__bindgen_ty_1,
+  SHTable, SHTableIndices, SHTableIterator, SHTableTypeInfo, SHTraits, SHTypeInfo,
+  SHTypeInfo_Details, SHType_Any, SHType_Bool, SHType_Bytes, SHType_Color, SHType_ContextVar,
+  SHType_Enum, SHType_Float, SHType_Float2, SHType_Float3, SHType_Float4, SHType_Image, SHType_Int,
+  SHType_Int16, SHType_Int2, SHType_Int3, SHType_Int4, SHType_Int8, SHType_None, SHType_Object,
+  SHType_Path, SHType_Seq, SHType_ShardRef, SHType_String, SHType_Table, SHType_Wire, SHTypesInfo,
+  SHVar, SHVarPayload, SHVarPayload__bindgen_ty_1, SHVarPayload__bindgen_ty_1__bindgen_ty_1,
   SHVarPayload__bindgen_ty_1__bindgen_ty_2, SHVarPayload__bindgen_ty_1__bindgen_ty_4, SHWire,
   SHWireInfo, SHWireRef, SHWireState, SHWireState_Continue, SHWireState_Rebase,
   SHWireState_Restart, SHWireState_Return, SHWireState_Stop, Shard, ShardPtr, Shards,
@@ -1232,6 +1232,7 @@ Static common type infos utility
 pub mod common_type {
   use crate::shardsc::SHSeq;
   use crate::shardsc::SHStrings;
+  use crate::shardsc::SHTableIndices;
   use crate::shardsc::SHTableTypeInfo;
   use crate::shardsc::SHType;
   use crate::shardsc::SHTypeInfo;
@@ -1278,7 +1279,6 @@ pub mod common_type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
-      fixedStructTable: false,
     }
   }
 
@@ -1314,7 +1314,6 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
-        fixedStructTable: false,
       };
 
       pub static $name_table: SHTypeInfo = SHTypeInfo {
@@ -1331,12 +1330,17 @@ pub mod common_type {
               len: 1,
               cap: 0,
             },
+            fixedStructTable: false,
+            indices: SHTableIndices {
+              elements: core::ptr::null_mut(),
+              len: 0,
+              cap: 0,
+            },
           },
         },
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
-        fixedStructTable: false,
       };
 
       pub static $name_var: SHTypeInfo = SHTypeInfo {
@@ -1351,7 +1355,6 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
-        fixedStructTable: false,
       };
 
       pub static $names_var: SHTypeInfo = SHTypeInfo {
@@ -1366,7 +1369,6 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
-        fixedStructTable: false,
       };
 
       pub static $name_table_var: SHTypeInfo = SHTypeInfo {
@@ -1381,7 +1383,6 @@ pub mod common_type {
         fixedSize: 0,
         innerType: SHType_None,
         recursiveSelf: false,
-        fixedStructTable: false,
       };
     };
   }
@@ -1622,7 +1623,6 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
-      fixedStructTable: false,
     }
   }
 
@@ -1635,7 +1635,6 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
-      fixedStructTable: false,
     }
   }
 
@@ -1653,7 +1652,6 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
-      fixedStructTable: false,
     }
   }
 
@@ -1672,12 +1670,17 @@ impl Type {
             len: types.len() as u32,
             cap: 0,
           },
+          fixedStructTable: false,
+          indices: SHTableIndices {
+            elements: core::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+          },
         },
       },
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
-      fixedStructTable: false,
     }
   }
 
@@ -1694,7 +1697,6 @@ impl Type {
       fixedSize: 0,
       innerType: SHType_None,
       recursiveSelf: false,
-      fixedStructTable: false,
     }
   }
 }

--- a/shards/tests/failures.shs
+++ b/shards/tests/failures.shs
@@ -223,12 +223,6 @@
 @schedule(root compose-fail-3-wrapper)
 @run(root FPS: 5 Iterations: 25) | Assert.Is(false)
 
-Assert.NoCompose({
-  @define(my-type @type({first: Type::Int second: {third: Type::Int}}))
-  Table(my-struct Type: @type({first: Type::Int second: {third: @my-type}}))
-  10 | Set(my-struct "another-field") ; this is forbidden
-})
-
 @wire(rename-fail {
   "Hello" = content
   "hello.txt" | FS.Write(content)

--- a/shards/tests/failures.shs
+++ b/shards/tests/failures.shs
@@ -223,6 +223,12 @@
 @schedule(root compose-fail-3-wrapper)
 @run(root FPS: 5 Iterations: 25) | Assert.Is(false)
 
+Assert.NoCompose({
+  @define(my-type @type({first: Type::Int second: {third: Type::Int}}))
+  Table(my-struct Type: @type({first: Type::Int second: {third: @my-type}}))
+  10 | Set(my-struct "another-field") ; this is forbidden
+})
+
 @wire(rename-fail {
   "Hello" = content
   "hello.txt" | FS.Write(content)

--- a/shards/tests/fixed-table.shs
+++ b/shards/tests/fixed-table.shs
@@ -1,3 +1,18 @@
 @define(my-type @type({first: Type::Int second: {third: Type::Int}}))
+
+Assert.ComposeFailure({
+  Table(my-struct Type: @type({first: Type::Int second: {third: @my-type}}))
+  10 | Set(my-struct "another-field") ; this is forbidden
+})
+
 Table(my-struct Type: @type({first: Type::Int second: {third: @my-type}}))
-my-struct | Log
+my-struct | Log | Assert.Is({first: 0 second: {third: {first: 0 second: {third: 0}}}})
+
+10 | Update(my-struct "first")
+my-struct | Log | Assert.Is({first: 10 second: {third: {first: 0 second: {third: 0}}}})
+
+Assert.ComposeFailure({
+  Erase("first" my-struct)
+})
+
+my-struct | Take("first") | Add(10) | Assert.Is(20)

--- a/shards/tests/fixed-table.shs
+++ b/shards/tests/fixed-table.shs
@@ -15,4 +15,12 @@ Assert.ComposeFailure({
   Erase("first" my-struct)
 })
 
+Assert.ComposeFailure({
+  Clear(my-struct)
+})
+
 my-struct | Take("first") | Add(10) | Assert.Is(20)
+
+Assert.ComposeFailure({
+  my-struct | Take("first") | Add(10.0)
+})

--- a/shards/tests/fixed-table.shs
+++ b/shards/tests/fixed-table.shs
@@ -24,3 +24,72 @@ my-struct | Take("first") | Add(10) | Assert.Is(20)
 Assert.ComposeFailure({
   my-struct | Take("first") | Add(10.0)
 })
+
+Assert.ComposeFailure({
+  {
+    a: 10
+    b: 20
+  } = x
+  
+  Erase("b" x)
+})
+
+Assert.ComposeFailure({
+  {
+    a: 10
+    b: 20
+  } = x0
+  
+  Clear(x0)
+})
+
+Assert.ComposeFailure({
+  {
+    a: 10
+    b: 20
+  } >= x1
+  
+  Erase("b" x1)
+})
+
+Assert.ComposeFailure({
+  {
+    a: 10
+    b: 20
+  } >= x11
+  
+  Clear(x11)
+})
+
+
+Assert.ComposeFailure({
+  10 | Set(x2 "a")
+  20 | Set(x2 "b")
+  
+  Erase("b" x2)
+})
+
+Assert.ComposeFailure({
+  10 | Set(x21 "a")
+  20 | Set(x21 "b")
+  
+  Clear(x21)
+})
+
+Table(dyn-tab Type: @type({none: Type::Any}))
+
+"a" = key1-var
+
+10 | Update(dyn-tab key1-var)
+
+Erase(key1-var dyn-tab)
+
+dyn-tab | Count | Assert.Is(0)
+
+"b" = key2-var
+
+20 | Update(dyn-tab key2-var)
+
+Clear(dyn-tab)
+
+dyn-tab | Count | Assert.Is(0)

--- a/shards/tests/fixed-table.shs
+++ b/shards/tests/fixed-table.shs
@@ -76,7 +76,7 @@ Assert.ComposeFailure({
   Clear(x21)
 })
 
-Table(dyn-tab Type: @type({none: Type::Any}))
+Table(dyn-tab)
 
 "a" = key1-var
 

--- a/shards/tests/fixed-table.shs
+++ b/shards/tests/fixed-table.shs
@@ -1,0 +1,3 @@
+@define(my-type @type({first: Type::Int second: {third: Type::Int}}))
+Table(my-struct Type: @type({first: Type::Int second: {third: @my-type}}))
+my-struct | Log

--- a/shards/tests/general.shs
+++ b/shards/tests/general.shs
@@ -830,7 +830,7 @@
   "0x0BAD" | HexToBytes | PrependTo(hexbytes-mut)
   hexbytes-mut | ToHex | Assert.Is("0x0badf00dc0ffee" true)
   StringToBytes | BytesToString | Assert.Is("0x0badf00dc0ffee" true)
-
+  
   "0xF00D" | HexToBytes | Split(Size: 1) | Log
   Assert.Is(([("0xF0" | HexToBytes) ("0x0D" | HexToBytes)]) true)
   
@@ -1166,7 +1166,9 @@
   Log
   Assert.Is([112 114 97 99] true)
   
-  {a: 1 b: 2 c: 3} >= table-abc
+  {a: 1 b: 2 c: 3}
+  ExpectTable ; to make it a dynamic table
+  >= table-abc
   Erase(["a" "c"] table-abc)
   table-abc | Assert.Is({b: 2} true)
   

--- a/shards/tests/variables.shs
+++ b/shards/tests/variables.shs
@@ -205,7 +205,7 @@
 
   ; without Table shard the rest would not work cos Table won't be exposed by When
   Table(table-decl-1 Type: @type({A: Type::Float}))
-  true | When(Is(true) {11.0 | Set(table-decl-1 "A")})
+  true | When(Is(true) {11.0 | Update(table-decl-1 "A")})
   Get(table-decl-1 "A") | Math.Add(2.0) | Assert.Is(13.0 true)
   Get(table-decl-1 "B" Default: 10.0) | Assert.Is(10.0 true)
   Get(table-decl-1 "wut?" Default: 10.0) | Assert.Is(10.0 true)


### PR DESCRIPTION
- Introduced a new member `fixedStructTable` in `SHTypeInfo` to optimize table handling.
- Updated `TableDecl` to mark tables as fixed struct tables when all keys are fixed values.
- Adjusted Rust type definitions to initialize `fixedStructTable` to false for consistency.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
