### PR TITLE
Add maxDeltaTime parameter to Delta and TimerShard structures

### DIFF
--- a/shards/modules/anim/anim.cpp
+++ b/shards/modules/anim/anim.cpp
@@ -18,6 +18,7 @@
 namespace shards::Animations {
 using namespace linalg::aliases;
 using shards::Time::DeltaTimer;
+using shards::Time::DoubleSecDuration;
 
 static auto getKeyframeTime(const SHVar &keyframe) { return (float)((TableVar &)keyframe).get<Var>(Var("Time")); };
 static auto getKeyframeValue(const SHVar &keyframe) { return ((TableVar &)keyframe).get<Var>(Var("Value")); };
@@ -64,8 +65,9 @@ struct TimerShard {
                  {CoreInfo::NoneType, CoreInfo::FloatVarType});
   PARAM(ShardsVar, _action, "Action", "The shards to execute whenever the shard reached the specified duration.",
         {CoreInfo::Shards, {CoreInfo::NoneType}});
+  PARAM_VAR(_maxDeltaTime, "MaxDeltaTime", "The maximum delta time", {CoreInfo::FloatType});
   PARAM_IMPL(PARAM_IMPL_FOR(_animation), PARAM_IMPL_FOR(_duration), PARAM_IMPL_FOR(_looped), PARAM_IMPL_FOR(_rate),
-             PARAM_IMPL_FOR(_offset), PARAM_IMPL_FOR(_action), PARAM_IMPL_FOR(_variable));
+             PARAM_IMPL_FOR(_offset), PARAM_IMPL_FOR(_action), PARAM_IMPL_FOR(_variable), PARAM_IMPL_FOR(_maxDeltaTime));
 
   double _internalTime{};
   bool _hasCallback{};
@@ -77,12 +79,14 @@ struct TimerShard {
   TimerShard() {
     _looped = Var{true};
     _rate = Var{1.0f};
+    _maxDeltaTime = Var(1.0f / 15.0f);
   }
 
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
     _internalTime = 0.0f;
     _deltaTimer.reset();
+    _deltaTimer.maxDeltaTime = DoubleSecDuration(_maxDeltaTime.payload.floatValue);
   }
 
   double &getTime() { return _variable.isVariable() ? _variable.get().payload.floatValue : _internalTime; }

--- a/shards/modules/core/time.cpp
+++ b/shards/modules/core/time.cpp
@@ -43,6 +43,8 @@ struct NowMs : public Now {
 struct Delta {
   DeltaTimer _deltaTimer;
 
+  Delta() { _maxDeltaTime = Var(1.0f / 15.0f); }
+
   static SHOptionalString help() {
     return SHCCSTR(R"(Outputs the time between the last call of this shard and the current call in seconds, capped to a limit)");
   }
@@ -54,11 +56,14 @@ struct Delta {
   static SHTypesInfo outputTypes() { return CoreInfo::FloatType; }
 
   PARAM_VAR(_uncapped, "Uncapped", "If true, returns uncapped delta time", {CoreInfo::BoolType});
-  PARAM_IMPL(PARAM_IMPL_FOR(_uncapped))
+  PARAM_VAR(_maxDeltaTime, "MaxDeltaTime", "The maximum delta time", {CoreInfo::FloatType});
+  PARAM_IMPL(PARAM_IMPL_FOR(_uncapped), PARAM_IMPL_FOR(_maxDeltaTime))
 
   SHTypeInfo composeV2(SHInstanceData &data) {
     if (_uncapped.payload.boolValue) {
       OVERRIDE_ACTIVATE(data, activateUncapped);
+    } else {
+      OVERRIDE_ACTIVATE(data, activate);
     }
     return CoreInfo::FloatType;
   }
@@ -66,6 +71,7 @@ struct Delta {
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
     _deltaTimer.reset();
+    _deltaTimer.maxDeltaTime = DoubleSecDuration(_maxDeltaTime.payload.floatValue);
   }
 
   void cleanup(SHContext *context) { PARAM_CLEANUP(context); }

--- a/shards/modules/core/time.cpp
+++ b/shards/modules/core/time.cpp
@@ -12,12 +12,14 @@ struct Now {
   static inline ProcessClock _clock{};
   static SHOptionalString help() {
     return SHCCSTR(
-        "This shard outputs the amount of time that has elapsed since the shards application or script was launched in seconds.");
+        "This shard outputs the amount of time that has elapsed since the shards application or script started in seconds.");
   }
   static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHOptionalString outputHelp() { return SHCCSTR("Outputs the amount of time that has elapsed in seconds."); }
   static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
   static SHTypesInfo outputTypes() { return CoreInfo::FloatType; }
+
+  void warmup(SHContext *context) { _clock.Start = std::chrono::high_resolution_clock::now(); }
 
   SHVar activate(SHContext *context, const SHVar &input) {
     auto tnow = std::chrono::high_resolution_clock::now();
@@ -28,11 +30,14 @@ struct Now {
 
 struct NowMs : public Now {
   static SHOptionalString help() {
-    return SHCCSTR("This shard outputs the amount of time that has elapsed since the shards application or script was launched "
-                   "in milliseconds.");
+    return SHCCSTR(
+        "This shard outputs the amount of time that has elapsed since the shards application or script started in milliseconds.");
   }
   static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpIgnored; }
   static SHOptionalString outputHelp() { return SHCCSTR("Outputs the amount of time that has elapsed in milliseconds."); }
+
+  void warmup(SHContext *context) { _clock.Start = std::chrono::high_resolution_clock::now(); }
+
   SHVar activate(SHContext *context, const SHVar &input) {
     auto tnow = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double, std::milli> dt = tnow - _clock.Start;

--- a/shards/modules/core/time.hpp
+++ b/shards/modules/core/time.hpp
@@ -17,14 +17,14 @@ struct ProcessClock {
 using namespace std::chrono_literals;
 struct DeltaTimer {
   // Limit delta time to avoid jumps after unpausing wires
-  static inline const auto MaxDeltaTime = DoubleSecDuration(1.0f / 15.0f);
+  DoubleSecDuration maxDeltaTime = DoubleSecDuration(1.0f / 15.0f);
 
   TimePoint lastActivation;
 
   void reset() { lastActivation = Clock::now(); }
 
   template <typename TDur = DoubleSecDuration> typename TDur::rep update() {
-    return std::min<TDur>(std::chrono::duration_cast<TDur>(MaxDeltaTime), updateRaw()).count();
+    return std::min<TDur>(std::chrono::duration_cast<TDur>(maxDeltaTime), updateRaw()).count();
   }
   template <typename TDur = DoubleSecDuration> TDur updateRaw() {
     auto now = Clock::now();


### PR DESCRIPTION
Introduce a new parameter, maxDeltaTime, to the Delta and TimerShard structures to control the maximum delta time. Update the warmup methods to initialize maxDeltaTime and adjust the delta timer accordingly. This change enhances the flexibility of time management in animations and delta calculations.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
