### PR TITLE
Add RustPython embedded interpreter support to Py module

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
       - name: Build iOS
         run: |
-          cmake -Bbuild_ios -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=iphoneos
+          cmake -Bbuild_ios -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=iphoneos -DENABLE_PYTHON_SHARDS=ON -DENABLE_RUSTPYTHON_EMBEDDED=ON
           cd build_ios
           xcodebuild -scheme shards-framework -configuration RelWithDebInfo -destination "generic/platform=iOS" build
 
@@ -80,6 +80,6 @@ jobs:
         if: ${{ steps.setup.outputs.rust-cache == 'true' }}
       - name: Build visionOS
         run: |
-          cmake -Bbuild_visionos_reldeb_frmwk -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=visionOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=xros -DDISABLE_CANDLE_METAL=ON
+          cmake -Bbuild_visionos_reldeb_frmwk -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=visionOS -DCMAKE_SYSTEM_PROCESSOR=arm64 -DXCODE_SDK=xros -DDISABLE_CANDLE_METAL=ON -DENABLE_PYTHON_SHARDS=ON -DENABLE_RUSTPYTHON_EMBEDDED=ON
           cd build_visionos_reldeb_frmwk
           xcodebuild -scheme shards-framework -configuration RelWithDebInfo -destination "generic/platform=visionOS" build

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,12 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # run on specific file changes
+    paths:
+      - "**/*.rs"
+      - "**/*.cpp"
+      - "**/*.h"
+      - "**/*.hpp"
 
 jobs:
   claude-review:

--- a/.github/workflows/test-macos-gpu.yml
+++ b/.github/workflows/test-macos-gpu.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake -Bbuild -G Ninja -DUSE_UBSAN=1 -DCODE_COVERAGE=1 -DCMAKE_BUILD_TYPE=${{ steps.setup.outputs.build-type }}
+          cmake -Bbuild -G Ninja -DUSE_UBSAN=1 -DCODE_COVERAGE=1 -DCMAKE_BUILD_TYPE=${{ steps.setup.outputs.build-type }} -DENABLE_PYTHON_SHARDS=ON -DENABLE_RUSTPYTHON_EMBEDDED=ON
           cmake --build build --target shards test-gfx
 
       - name: Checkout glTF-Sample-Assets
@@ -153,6 +153,15 @@ jobs:
 
           echo "Running physics"
           build/shards new shards/tests/physics.shs
+
+      - name: Test Python (RustPython Embedded)
+        env:
+          RUST_BACKTRACE: full
+        run: |
+          set -e
+
+          echo "Running embedded Python test"
+          build/shards new shards/tests/py-embed.shs
 
       - name: Test doc samples (GFX)
         env:

--- a/cmake/rust/union_Cargo.toml.in
+++ b/cmake/rust/union_Cargo.toml.in
@@ -23,6 +23,7 @@ security-framework = { git = "https://github.com/shards-lang/rust-security-frame
 sysctl = { git = "https://github.com/shards-lang/sysctl-rs.git", version = "=0.5.5", rev = "859c91707dfaa11d8adff35b65b1b88bb98680bd" }
 ring = { git = "https://github.com/shards-lang/ring.git", version = "=0.17.8", rev = "0a00284cd6de51d78bd687a93352369a3f4374be" }
 onig_sys = { git = "https://github.com/shards-lang/rust-onig.git", version = "=69.8.1", rev = "c4378abcbf30d58cf5f230c0d2e6375f2be05a47" }
+nix = { git = "https://github.com/fragcolor-xyz/nix.git", version = "=0.30.1", rev = "268c07f13fa64e1d493c883c5c860f08fbcbd9b3" }
 
 # Graphics patches
 objc = { git = "https://github.com/shards-lang/rust-objc.git", version = "=0.2.7", branch = "shards-0.2.7" }

--- a/shards/lang/Cargo.toml
+++ b/shards/lang/Cargo.toml
@@ -27,8 +27,6 @@ dashmap = "6.0.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.155"
 
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))'.dependencies]
-ctrlc = "3.4.0"
 
 [features]
 default = ["exported"]

--- a/shards/lang/src/cli.rs
+++ b/shards/lang/src/cli.rs
@@ -162,20 +162,8 @@ fn generate_completions(shell: Shell) {
   generate(shell, &mut cmd, name, &mut std::io::stdout());
 }
 
-pub fn process_args(argc: i32, argv: *const *const c_char, no_cancellation: bool) -> i32 {
+pub fn process_args(argc: i32, argv: *const *const c_char, _no_cancellation: bool) -> i32 {
   let cancellation_token = new_cancellation_token();
-
-  #[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "visionos")))]
-  if !no_cancellation {
-    let cancellation_token_1 = cancellation_token.clone();
-    let r = ctrlc::set_handler(move || {
-      cancellation_token_1.store(true, atomic::Ordering::Relaxed);
-    });
-    if r.is_err() {
-      shlog!("Failed to set ctrl-c handler");
-      return 1;
-    }
-  }
 
   let args: Vec<String> = unsafe {
     from_raw_parts_allow_null(argv, argc as usize)

--- a/shards/modules/langffi/Cargo.toml
+++ b/shards/modules/langffi/Cargo.toml
@@ -16,7 +16,7 @@ flexbuffers = "2.0.0"
 profiling = { version = "1", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.155" 
+libc = "0.2.175" 
 
 [build-dependencies]
 cbindgen = "0.24.0"

--- a/shards/modules/py/CMakeLists.txt
+++ b/shards/modules/py/CMakeLists.txt
@@ -1,11 +1,24 @@
 if(ENABLE_PYTHON_SHARDS)
-  set(SOURCES
-    py.cpp
-  )
+  # Option to use embedded RustPython instead of dynamic Python loading
+  option(ENABLE_RUSTPYTHON_EMBEDDED "Use embedded RustPython for Py.Eval shard" OFF)
 
-  add_shards_module(py
-    SOURCES ${SOURCES}
-    REGISTER_SHARDS py)
+  # Conditionally build RustPython implementation
+  if(ENABLE_RUSTPYTHON_EMBEDDED)
+    add_rust_library(NAME shards-py
+      PROJECT_PATH ${CMAKE_CURRENT_LIST_DIR})
+    add_shards_module(py
+      RUST_TARGETS shards-py-rust
+      REGISTER_SHARDS py)
+  else()
+    set(SOURCES
+      py.cpp
+    )
 
-  target_link_libraries(shards-module-py Boost::process)
+    add_shards_module(py
+      SOURCES ${SOURCES}
+      ${RUST_TARGETS_ARG}
+      REGISTER_SHARDS py)
+
+    target_link_libraries(shards-module-py Boost::process)
+  endif()
 endif()

--- a/shards/modules/py/CMakeLists.txt
+++ b/shards/modules/py/CMakeLists.txt
@@ -16,7 +16,6 @@ if(ENABLE_PYTHON_SHARDS)
 
     add_shards_module(py
       SOURCES ${SOURCES}
-      ${RUST_TARGETS_ARG}
       REGISTER_SHARDS py)
 
     target_link_libraries(shards-module-py Boost::process)

--- a/shards/modules/py/Cargo.toml
+++ b/shards/modules/py/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "shards-py"
+description = "RustPython-based Python integration for Shards"
+license = "BSD-3-Clause"
+version = "0.1.0"
+authors = ["Giovanni Petrantoni <sinkingsugar@gmail.com>"]
+edition = "2021"
+
+[lib]
+crate-type = ["rlib", "staticlib"]
+
+[dependencies]
+lazy_static = "1.5.0"
+shards = { path = "../../rust" }
+compile-time-crc32 = "0.1.2"
+rustpython-vm = { version = "0.4.0", features = ["freeze-stdlib"] }
+rustpython-pylib = { version = "0.4.0", features = ["freeze-stdlib"] }

--- a/shards/modules/py/Cargo.toml
+++ b/shards/modules/py/Cargo.toml
@@ -16,21 +16,21 @@ compile-time-crc32 = "0.1.2"
 # Disable default features to exclude ctypes and lzma
 [dependencies.rustpython-vm]
 git = "https://github.com/fragcolor-xyz/RustPython.git"
-branch = "shards"
+rev = "45d46e69286425d0cd89d0c87994e3b7fd41eec1"
 version = "0.4.0"
 default-features = false
 features = ["freeze-stdlib", "compiler", "stdio", "threading"]
 
 [dependencies.rustpython-pylib]
 git = "https://github.com/fragcolor-xyz/RustPython.git"
-branch = "shards"
+rev = "45d46e69286425d0cd89d0c87994e3b7fd41eec1"
 version = "0.4.0"
 default-features = false
 features = ["freeze-stdlib"]
 
 [dependencies.rustpython-stdlib]
 git = "https://github.com/fragcolor-xyz/RustPython.git"
-branch = "shards"
+rev = "45d46e69286425d0cd89d0c87994e3b7fd41eec1"
 version = "0.4.0"
 default-features = false
 features = ["compiler", "threading"]

--- a/shards/modules/py/Cargo.toml
+++ b/shards/modules/py/Cargo.toml
@@ -13,6 +13,24 @@ crate-type = ["rlib", "staticlib"]
 lazy_static = "1.5.0"
 shards = { path = "../../rust" }
 compile-time-crc32 = "0.1.2"
-rustpython-vm = { git = "https://github.com/fragcolor-xyz/RustPython.git", version = "0.4.0", features = ["freeze-stdlib"] }
-rustpython-pylib = { git = "https://github.com/fragcolor-xyz/RustPython.git", version = "0.4.0", features = ["freeze-stdlib"] }
-rustpython-stdlib = { git = "https://github.com/fragcolor-xyz/RustPython.git", version = "0.4.0" }
+# Disable default features to exclude ctypes and lzma
+[dependencies.rustpython-vm]
+git = "https://github.com/fragcolor-xyz/RustPython.git"
+branch = "shards"
+version = "0.4.0"
+default-features = false
+features = ["freeze-stdlib", "compiler", "stdio", "threading"]
+
+[dependencies.rustpython-pylib]
+git = "https://github.com/fragcolor-xyz/RustPython.git"
+branch = "shards"
+version = "0.4.0"
+default-features = false
+features = ["freeze-stdlib"]
+
+[dependencies.rustpython-stdlib]
+git = "https://github.com/fragcolor-xyz/RustPython.git"
+branch = "shards"
+version = "0.4.0"
+default-features = false
+features = ["compiler", "threading"]

--- a/shards/modules/py/Cargo.toml
+++ b/shards/modules/py/Cargo.toml
@@ -15,3 +15,4 @@ shards = { path = "../../rust" }
 compile-time-crc32 = "0.1.2"
 rustpython-vm = { version = "0.4.0", features = ["freeze-stdlib"] }
 rustpython-pylib = { version = "0.4.0", features = ["freeze-stdlib"] }
+rustpython-stdlib = { version = "0.4.0" }

--- a/shards/modules/py/Cargo.toml
+++ b/shards/modules/py/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["rlib", "staticlib"]
 lazy_static = "1.5.0"
 shards = { path = "../../rust" }
 compile-time-crc32 = "0.1.2"
-rustpython-vm = { version = "0.4.0", features = ["freeze-stdlib"] }
-rustpython-pylib = { version = "0.4.0", features = ["freeze-stdlib"] }
-rustpython-stdlib = { version = "0.4.0" }
+rustpython-vm = { git = "https://github.com/fragcolor-xyz/RustPython.git", version = "0.4.0", features = ["freeze-stdlib"] }
+rustpython-pylib = { git = "https://github.com/fragcolor-xyz/RustPython.git", version = "0.4.0", features = ["freeze-stdlib"] }
+rustpython-stdlib = { git = "https://github.com/fragcolor-xyz/RustPython.git", version = "0.4.0" }

--- a/shards/modules/py/src/lib.rs
+++ b/shards/modules/py/src/lib.rs
@@ -13,8 +13,9 @@ extern crate lazy_static;
 
 use rustpython_vm as vm;
 use rustpython_vm::{Interpreter, PyObjectRef, PyResult, VirtualMachine, AsObject};
+use rustpython_stdlib;
 use shards::core::register_shard;
-use shards::shard::Shard;
+use shards::shard::{Shard, DynamicErrStr, push_error};
 use shards::types::common_type;
 use shards::types::{
     ClonedVar, Context, ExposedTypes, InstanceData, ParamVar,
@@ -332,8 +333,13 @@ impl Shard for PyEvalShard {
 
         // Create RustPython interpreter instance
         let interp = Interpreter::with_init(Default::default(), |vm| {
-            // Initialize with frozen stdlib
+            // Initialize with frozen stdlib (pure Python modules)
             vm.add_frozen(rustpython_pylib::FROZEN_STDLIB);
+
+            // Initialize native extension modules (_struct, _io, _json, etc.)
+            for (name, init_fn) in rustpython_stdlib::get_module_inits() {
+                vm.add_native_module(name, init_fn);
+            }
         });
 
         // Compile the expression
@@ -344,7 +350,7 @@ impl Shard for PyEvalShard {
             .try_into()
             .map_err(|_| "Failed to get expression string")?;
 
-        interp.enter(|vm| -> Result<(), &str> {
+        let compile_result = interp.enter(|vm| -> Result<(), String> {
             // Create globals dictionary
             self.globals = Some(vm.ctx.new_dict().into());
 
@@ -362,9 +368,8 @@ impl Shard for PyEvalShard {
 
             let code = vm.compile(expr_str, mode, "<string>".to_owned())
                 .map_err(|e| {
-                    let error_msg = format!("Failed to compile Python expression: {:?}", e);
-                    shlog_error!("{}", error_msg);
-                    Box::leak(error_msg.into_boxed_str()) as &str
+                    // Compilation errors have Display impl with detailed messages
+                    format!("Python syntax error: {}", e)
                 })?;
 
             // Store the compiled code as PyObjectRef
@@ -376,6 +381,12 @@ impl Shard for PyEvalShard {
             }
 
             Ok(())
+        });
+
+        compile_result.map_err(|e| {
+            shlog_error!("{}", e);
+            push_error(ctx, &e);
+            DynamicErrStr
         })?;
 
         // Store interpreter for later use
@@ -447,11 +458,27 @@ impl Shard for PyEvalShard {
             let code = code_obj.downcast::<PyCode>()
                 .map_err(|_| "Failed to downcast code object")?;
 
-            // Use exec_dict as both locals and globals
-            let scope = vm::scope::Scope::new(None, exec_dict.clone());
+            // Create scope with builtins so that print, len, import, etc. are available
+            // We use exec_dict for both globals and locals to maintain state
+            let scope = vm::scope::Scope::with_builtins(None, exec_dict.clone(), vm);
             let exec_result = vm
                 .run_code_obj(code, scope)
-                .map_err(|e| format!("Python execution failed: {:?}", e))?;
+                .map_err(|exc| {
+                    // Extract detailed exception information from PyBaseException
+                    let exc_type = exc.class().name();
+
+                    // Try to get the exception message using __str__
+                    let exc_msg = match exc.as_object().str(vm) {
+                        Ok(pystr) => pystr.as_str().to_string(),
+                        Err(_) => String::new()
+                    };
+
+                    if exc_msg.is_empty() {
+                        format!("Python {}", exc_type)
+                    } else {
+                        format!("Python {}: {}", exc_type, exc_msg)
+                    }
+                })?;
 
             // Update our locals after execution
             self.locals = Some(exec_dict.into());
@@ -481,10 +508,9 @@ impl Shard for PyEvalShard {
         });
 
         result.map_err(|e| {
-            // Log the detailed error message
             shlog_error!("Python evaluation failed: {}", e);
-            // Return a static error message with the leaked dynamic content for user
-            Box::leak(format!("Python error: {}", e).into_boxed_str()) as &str
+            push_error(_context, &e);
+            DynamicErrStr
         })
     }
 }

--- a/shards/modules/py/src/lib.rs
+++ b/shards/modules/py/src/lib.rs
@@ -32,9 +32,18 @@ fn shvar_to_py(vm: &VirtualMachine, var: &Var) -> PyResult<PyObjectRef> {
 
     match var.valueType {
         SHType_None => Ok(vm.ctx.none()),
-        SHType_Bool => Ok(vm.ctx.new_bool(unsafe { var.payload.__bindgen_anon_1.boolValue }).into()),
-        SHType_Int => Ok(vm.ctx.new_int(unsafe { var.payload.__bindgen_anon_1.intValue }).into()),
-        SHType_Float => Ok(vm.ctx.new_float(unsafe { var.payload.__bindgen_anon_1.floatValue }).into()),
+        SHType_Bool => {
+            // SAFETY: valueType is SHType_Bool, so boolValue field is valid
+            Ok(vm.ctx.new_bool(unsafe { var.payload.__bindgen_anon_1.boolValue }).into())
+        }
+        SHType_Int => {
+            // SAFETY: valueType is SHType_Int, so intValue field is valid
+            Ok(vm.ctx.new_int(unsafe { var.payload.__bindgen_anon_1.intValue }).into())
+        }
+        SHType_Float => {
+            // SAFETY: valueType is SHType_Float, so floatValue field is valid
+            Ok(vm.ctx.new_float(unsafe { var.payload.__bindgen_anon_1.floatValue }).into())
+        }
         SHType_String => {
             let str_val: &str = var.try_into().map_err(|e| {
                 vm.new_runtime_error(format!("Failed to convert string: {}", e))
@@ -49,10 +58,12 @@ fn shvar_to_py(vm: &VirtualMachine, var: &Var) -> PyResult<PyObjectRef> {
             Ok(vm.ctx.new_bytes(bytes.to_vec()).into())
         }
         SHType_Int2 => {
+            // SAFETY: valueType is SHType_Int2, so int2Value field is valid
             let vals = unsafe { var.payload.__bindgen_anon_1.int2Value };
             Ok(vm.ctx.new_tuple(vec![vm.ctx.new_int(vals[0]).into(), vm.ctx.new_int(vals[1]).into()]).into())
         }
         SHType_Int3 => {
+            // SAFETY: valueType is SHType_Int3, so int3Value field is valid
             let vals = unsafe { var.payload.__bindgen_anon_1.int3Value };
             Ok(vm.ctx.new_tuple(vec![
                 vm.ctx.new_int(vals[0]).into(),
@@ -61,6 +72,7 @@ fn shvar_to_py(vm: &VirtualMachine, var: &Var) -> PyResult<PyObjectRef> {
             ]).into())
         }
         SHType_Int4 => {
+            // SAFETY: valueType is SHType_Int4, so int4Value field is valid
             let vals = unsafe { var.payload.__bindgen_anon_1.int4Value };
             Ok(vm.ctx.new_tuple(vec![
                 vm.ctx.new_int(vals[0]).into(),
@@ -70,10 +82,12 @@ fn shvar_to_py(vm: &VirtualMachine, var: &Var) -> PyResult<PyObjectRef> {
             ]).into())
         }
         SHType_Float2 => {
+            // SAFETY: valueType is SHType_Float2, so float2Value field is valid
             let vals = unsafe { var.payload.__bindgen_anon_1.float2Value };
             Ok(vm.ctx.new_tuple(vec![vm.ctx.new_float(vals[0] as f64).into(), vm.ctx.new_float(vals[1] as f64).into()]).into())
         }
         SHType_Float3 => {
+            // SAFETY: valueType is SHType_Float3, so float3Value field is valid
             let vals = unsafe { var.payload.__bindgen_anon_1.float3Value };
             Ok(vm.ctx.new_tuple(vec![
                 vm.ctx.new_float(vals[0] as f64).into(),
@@ -82,6 +96,7 @@ fn shvar_to_py(vm: &VirtualMachine, var: &Var) -> PyResult<PyObjectRef> {
             ]).into())
         }
         SHType_Float4 => {
+            // SAFETY: valueType is SHType_Float4, so float4Value field is valid
             let vals = unsafe { var.payload.__bindgen_anon_1.float4Value };
             Ok(vm.ctx.new_tuple(vec![
                 vm.ctx.new_float(vals[0] as f64).into(),
@@ -169,11 +184,20 @@ fn py_to_shvar(vm: &VirtualMachine, obj: PyObjectRef, output: &mut ClonedVar) ->
                             return Ok(());
                         }
                         3 => {
-                            *output = Var::new_int3(vals[0] as i32, vals[1] as i32, vals[2] as i32).into();
+                            // Check bounds for i32
+                            let v0 = i32::try_from(vals[0]).map_err(|_| format!("Int3 element 0 out of i32 range: {}", vals[0]))?;
+                            let v1 = i32::try_from(vals[1]).map_err(|_| format!("Int3 element 1 out of i32 range: {}", vals[1]))?;
+                            let v2 = i32::try_from(vals[2]).map_err(|_| format!("Int3 element 2 out of i32 range: {}", vals[2]))?;
+                            *output = Var::new_int3(v0, v1, v2).into();
                             return Ok(());
                         }
                         4 => {
-                            *output = Var::new_int4(vals[0] as i32, vals[1] as i32, vals[2] as i32, vals[3] as i32).into();
+                            // Check bounds for i32
+                            let v0 = i32::try_from(vals[0]).map_err(|_| format!("Int4 element 0 out of i32 range: {}", vals[0]))?;
+                            let v1 = i32::try_from(vals[1]).map_err(|_| format!("Int4 element 1 out of i32 range: {}", vals[1]))?;
+                            let v2 = i32::try_from(vals[2]).map_err(|_| format!("Int4 element 2 out of i32 range: {}", vals[2]))?;
+                            let v3 = i32::try_from(vals[3]).map_err(|_| format!("Int4 element 3 out of i32 range: {}", vals[3]))?;
+                            *output = Var::new_int4(v0, v1, v2, v3).into();
                             return Ok(());
                         }
                         _ => {}
@@ -205,11 +229,26 @@ fn py_to_shvar(vm: &VirtualMachine, obj: PyObjectRef, output: &mut ClonedVar) ->
                         return Ok(());
                     }
                     3 => {
-                        *output = Var::new_float3(floats[0] as f32, floats[1] as f32, floats[2] as f32).into();
+                        // Check if f64 values fit in f32 range
+                        let v0 = floats[0] as f32;
+                        let v1 = floats[1] as f32;
+                        let v2 = floats[2] as f32;
+                        if !v0.is_finite() || !v1.is_finite() || !v2.is_finite() {
+                            return Err("Float3 values out of f32 range or non-finite".into());
+                        }
+                        *output = Var::new_float3(v0, v1, v2).into();
                         return Ok(());
                     }
                     4 => {
-                        *output = Var::new_float4(floats[0] as f32, floats[1] as f32, floats[2] as f32, floats[3] as f32).into();
+                        // Check if f64 values fit in f32 range
+                        let v0 = floats[0] as f32;
+                        let v1 = floats[1] as f32;
+                        let v2 = floats[2] as f32;
+                        let v3 = floats[3] as f32;
+                        if !v0.is_finite() || !v1.is_finite() || !v2.is_finite() || !v3.is_finite() {
+                            return Err("Float4 values out of f32 range or non-finite".into());
+                        }
+                        *output = Var::new_float4(v0, v1, v2, v3).into();
                         return Ok(());
                     }
                     _ => {}
@@ -317,7 +356,11 @@ impl Shard for PyEvalShard {
             };
 
             let code = vm.compile(expr_str, mode, "<string>".to_owned())
-                .map_err(|_| "Failed to compile Python expression")?;
+                .map_err(|e| {
+                    let error_msg = format!("Failed to compile Python expression: {:?}", e);
+                    shlog_error!("{}", error_msg);
+                    Box::leak(error_msg.into_boxed_str()) as &str
+                })?;
 
             // Store the compiled code as PyObjectRef
             self.compiled_code = Some(code.into());
@@ -427,8 +470,10 @@ impl Shard for PyEvalShard {
         });
 
         result.map_err(|e| {
-            shlog_error!("{}", e);
-            "Python evaluation failed"
+            // Log the detailed error message
+            shlog_error!("Python evaluation failed: {}", e);
+            // Return a static error message with the leaked dynamic content for user
+            Box::leak(format!("Python error: {}", e).into_boxed_str()) as &str
         })
     }
 }

--- a/shards/modules/py/src/lib.rs
+++ b/shards/modules/py/src/lib.rs
@@ -1,0 +1,443 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2025 Fragcolor Pte. Ltd. */
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate shards;
+
+#[macro_use]
+extern crate lazy_static;
+
+use rustpython_vm as vm;
+use rustpython_vm::{Interpreter, PyObjectRef, PyResult, VirtualMachine, AsObject};
+use shards::core::register_shard;
+use shards::shard::Shard;
+use shards::types::common_type;
+use shards::types::{
+    ClonedVar, Context, ExposedTypes, InstanceData, ParamVar,
+    Type, Types, Var, BOOL_TYPES, STRING_TYPES,
+};
+
+lazy_static! {
+    static ref ANY_TYPES: Vec<Type> = vec![common_type::any];
+}
+
+/// Convert SHVar to RustPython PyObject
+fn shvar_to_py(vm: &VirtualMachine, var: &Var) -> PyResult<PyObjectRef> {
+    use shards::shardsc::{SHType_None, SHType_Bool, SHType_Int, SHType_Float, SHType_String, SHType_Bytes,
+                          SHType_Int2, SHType_Int3, SHType_Int4, SHType_Float2, SHType_Float3, SHType_Float4};
+
+    match var.valueType {
+        SHType_None => Ok(vm.ctx.none()),
+        SHType_Bool => Ok(vm.ctx.new_bool(unsafe { var.payload.__bindgen_anon_1.boolValue }).into()),
+        SHType_Int => Ok(vm.ctx.new_int(unsafe { var.payload.__bindgen_anon_1.intValue }).into()),
+        SHType_Float => Ok(vm.ctx.new_float(unsafe { var.payload.__bindgen_anon_1.floatValue }).into()),
+        SHType_String => {
+            let str_val: &str = var.try_into().map_err(|e| {
+                vm.new_runtime_error(format!("Failed to convert string: {}", e))
+            })?;
+            Ok(vm.ctx.new_str(str_val).into())
+        }
+        SHType_Bytes => {
+            // Convert Var to bytes slice
+            let bytes: &[u8] = var.try_into().map_err(|e| {
+                vm.new_runtime_error(format!("Failed to convert bytes: {}", e))
+            })?;
+            Ok(vm.ctx.new_bytes(bytes.to_vec()).into())
+        }
+        SHType_Int2 => {
+            let vals = unsafe { var.payload.__bindgen_anon_1.int2Value };
+            Ok(vm.ctx.new_tuple(vec![vm.ctx.new_int(vals[0]).into(), vm.ctx.new_int(vals[1]).into()]).into())
+        }
+        SHType_Int3 => {
+            let vals = unsafe { var.payload.__bindgen_anon_1.int3Value };
+            Ok(vm.ctx.new_tuple(vec![
+                vm.ctx.new_int(vals[0]).into(),
+                vm.ctx.new_int(vals[1]).into(),
+                vm.ctx.new_int(vals[2]).into(),
+            ]).into())
+        }
+        SHType_Int4 => {
+            let vals = unsafe { var.payload.__bindgen_anon_1.int4Value };
+            Ok(vm.ctx.new_tuple(vec![
+                vm.ctx.new_int(vals[0]).into(),
+                vm.ctx.new_int(vals[1]).into(),
+                vm.ctx.new_int(vals[2]).into(),
+                vm.ctx.new_int(vals[3]).into(),
+            ]).into())
+        }
+        SHType_Float2 => {
+            let vals = unsafe { var.payload.__bindgen_anon_1.float2Value };
+            Ok(vm.ctx.new_tuple(vec![vm.ctx.new_float(vals[0] as f64).into(), vm.ctx.new_float(vals[1] as f64).into()]).into())
+        }
+        SHType_Float3 => {
+            let vals = unsafe { var.payload.__bindgen_anon_1.float3Value };
+            Ok(vm.ctx.new_tuple(vec![
+                vm.ctx.new_float(vals[0] as f64).into(),
+                vm.ctx.new_float(vals[1] as f64).into(),
+                vm.ctx.new_float(vals[2] as f64).into(),
+            ]).into())
+        }
+        SHType_Float4 => {
+            let vals = unsafe { var.payload.__bindgen_anon_1.float4Value };
+            Ok(vm.ctx.new_tuple(vec![
+                vm.ctx.new_float(vals[0] as f64).into(),
+                vm.ctx.new_float(vals[1] as f64).into(),
+                vm.ctx.new_float(vals[2] as f64).into(),
+                vm.ctx.new_float(vals[3] as f64).into(),
+            ]).into())
+        }
+        _ => Err(vm.new_runtime_error(format!(
+            "Unsupported SHVar type for conversion: {:?}",
+            var.valueType
+        ))),
+    }
+}
+
+/// Convert RustPython PyObject to SHVar
+fn py_to_shvar(vm: &VirtualMachine, obj: PyObjectRef, output: &mut ClonedVar) -> Result<(), String> {
+    // Check for None
+    if vm.is_none(&obj) {
+        *output = ClonedVar::default();
+        return Ok(());
+    }
+
+    // Check for bool (must be before int, as bool is subclass of int in Python)
+    if obj.class().is(vm.ctx.types.bool_type.as_object()) {
+        let bool_val = obj.try_to_bool(vm).map_err(|e| format!("Bool conversion failed: {:?}", e))?;
+        *output = Var::new_bool(bool_val).into();
+        return Ok(());
+    }
+
+    // Check for int
+    if obj.class().is(vm.ctx.types.int_type.as_object()) {
+        let int_val = obj
+            .try_to_value::<i64>(vm)
+            .map_err(|e| format!("Int conversion failed: {:?}", e))?;
+        *output = int_val.into();
+        return Ok(());
+    }
+
+    // Check for float
+    if obj.class().is(vm.ctx.types.float_type.as_object()) {
+        use rustpython_vm::builtins::PyFloat;
+        let py_float = obj.downcast::<PyFloat>()
+            .map_err(|_| "Failed to downcast to PyFloat")?;
+        let float_val = py_float.to_f64();
+        *output = float_val.into();
+        return Ok(());
+    }
+
+    // Check for string
+    if obj.class().is(vm.ctx.types.str_type.as_object()) {
+        let str_val = obj
+            .try_to_value::<String>(vm)
+            .map_err(|e| format!("String conversion failed: {:?}", e))?;
+        *output = Var::ephemeral_string(&str_val).into();
+        return Ok(());
+    }
+
+    // Check for bytes
+    if obj.class().is(vm.ctx.types.bytes_type.as_object()) {
+        let bytes_val = obj
+            .try_to_value::<Vec<u8>>(vm)
+            .map_err(|e| format!("Bytes conversion failed: {:?}", e))?;
+        *output = Var::ephemeral_slice(&bytes_val).into();
+        return Ok(());
+    }
+
+    // Check for tuple
+    if obj.class().is(vm.ctx.types.tuple_type.as_object()) {
+        use rustpython_vm::builtins::PyTuple;
+        let tuple = obj.clone()
+            .downcast::<PyTuple>()
+            .map_err(|_| "Failed to downcast to tuple")?;
+        let elements = tuple.as_slice();
+
+        // Try to convert to vector types (Int2-4, Float2-4)
+        if elements.len() >= 2 && elements.len() <= 4 {
+            // Check if all elements are ints
+            if elements.iter().all(|e| e.class().is(vm.ctx.types.int_type.as_object())) {
+                let ints: Result<Vec<i64>, _> = elements.iter().map(|e| e.try_to_value::<i64>(vm)).collect();
+                if let Ok(vals) = ints {
+                    match vals.len() {
+                        2 => {
+                            *output = Var::new_int2(vals[0], vals[1]).into();
+                            return Ok(());
+                        }
+                        3 => {
+                            *output = Var::new_int3(vals[0] as i32, vals[1] as i32, vals[2] as i32).into();
+                            return Ok(());
+                        }
+                        4 => {
+                            *output = Var::new_int4(vals[0] as i32, vals[1] as i32, vals[2] as i32, vals[3] as i32).into();
+                            return Ok(());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            // Check if all elements are floats (or ints that can be converted to floats)
+            if elements.iter().all(|e| {
+                e.class().is(vm.ctx.types.float_type.as_object()) || e.class().is(vm.ctx.types.int_type.as_object())
+            }) {
+                // Manually convert each element to f64
+                let mut floats: Vec<f64> = Vec::new();
+                for e in elements {
+                    if e.class().is(vm.ctx.types.float_type.as_object()) {
+                        // For float types, downcast to PyFloat and extract value
+                        use rustpython_vm::builtins::PyFloat;
+                        let py_float = e.clone().downcast::<PyFloat>().map_err(|_| "Failed to downcast to PyFloat")?;
+                        floats.push(py_float.to_f64());
+                    } else if e.class().is(vm.ctx.types.int_type.as_object()) {
+                        let i: i64 = e.try_to_value::<i64>(vm).map_err(|e| format!("Int conversion failed: {:?}", e))?;
+                        floats.push(i as f64);
+                    }
+                }
+
+                match floats.len() {
+                    2 => {
+                        *output = Var::new_float2(floats[0], floats[1]).into();
+                        return Ok(());
+                    }
+                    3 => {
+                        *output = Var::new_float3(floats[0] as f32, floats[1] as f32, floats[2] as f32).into();
+                        return Ok(());
+                    }
+                    4 => {
+                        *output = Var::new_float4(floats[0] as f32, floats[1] as f32, floats[2] as f32, floats[3] as f32).into();
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Err(format!(
+        "Unsupported Python type for conversion to SHVar: {}",
+        obj.class().name()
+    ))
+}
+
+#[derive(shards::shard)]
+#[shard_info(
+    "Py.Eval",
+    "Evaluates Python expressions using embedded RustPython interpreter"
+)]
+struct PyEvalShard {
+    #[shard_required]
+    required: ExposedTypes,
+
+    #[shard_param(
+        "Expression",
+        "Python code to evaluate. Input is available as _s. The value of the last expression is returned.",
+        STRING_TYPES
+    )]
+    expression: ParamVar,
+
+    #[shard_param(
+        "PreserveState",
+        "Whether to preserve variable state between calls",
+        BOOL_TYPES
+    )]
+    preserve_state: ParamVar,
+
+    #[shard_param(
+        "FileMode",
+        "Execute as file instead of as expression (useful for multi-line scripts)",
+        BOOL_TYPES
+    )]
+    file_mode: ParamVar,
+
+    // Internal state
+    interpreter: Option<Interpreter>,
+    compiled_code: Option<PyObjectRef>,  // Stores PyRef<PyCode>
+    locals: Option<PyObjectRef>,
+    globals: Option<PyObjectRef>,
+    output: ClonedVar,
+}
+
+impl Default for PyEvalShard {
+    fn default() -> Self {
+        Self {
+            required: ExposedTypes::new(),
+            expression: ParamVar::default(),
+            preserve_state: ParamVar::new(Var::new_bool(false)),
+            file_mode: ParamVar::new(Var::new_bool(false)),
+            interpreter: None,
+            compiled_code: None,
+            locals: None,
+            globals: None,
+            output: ClonedVar::default(),
+        }
+    }
+}
+
+#[shards::shard_impl]
+impl Shard for PyEvalShard {
+    fn input_types(&mut self) -> &Types {
+        &ANY_TYPES
+    }
+
+    fn output_types(&mut self) -> &Types {
+        &ANY_TYPES
+    }
+
+    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+        self.warmup_helper(ctx)?;
+
+        // Create RustPython interpreter instance
+        let interp = Interpreter::with_init(Default::default(), |vm| {
+            // Initialize with frozen stdlib
+            vm.add_frozen(rustpython_pylib::FROZEN_STDLIB);
+        });
+
+        // Compile the expression
+        let expr_str: &str = self
+            .expression
+            .get()
+            .as_ref()
+            .try_into()
+            .map_err(|_| "Failed to get expression string")?;
+
+        interp.enter(|vm| -> Result<(), &str> {
+            // Create globals dictionary
+            self.globals = Some(vm.ctx.new_dict().into());
+
+            // Compile the code
+            let mode = if self.file_mode.get().as_ref().try_into().unwrap_or(false) {
+                vm::compiler::Mode::Exec
+            } else {
+                vm::compiler::Mode::Eval
+            };
+
+            let code = vm.compile(expr_str, mode, "<string>".to_owned())
+                .map_err(|_| "Failed to compile Python expression")?;
+
+            // Store the compiled code as PyObjectRef
+            self.compiled_code = Some(code.into());
+
+            // Initialize locals if not preserving state
+            if !self.preserve_state.get().as_ref().try_into().unwrap_or(false) {
+                self.locals = Some(vm.ctx.new_dict().into());
+            }
+
+            Ok(())
+        })?;
+
+        // Store interpreter for later use
+        self.interpreter = Some(interp);
+        Ok(())
+    }
+
+    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+        self.cleanup_helper(ctx)?;
+        self.interpreter = None;
+        self.compiled_code = None;
+        self.locals = None;
+        self.globals = None;
+        self.output = ClonedVar::default();
+        Ok(())
+    }
+
+    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+        self.compose_helper(data)?;
+        Ok(self.output_types()[0])
+    }
+
+    fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+        let interp = self.interpreter.as_ref()
+            .ok_or("Interpreter not initialized")?;
+
+        let result = interp.enter(|vm| -> Result<Option<Var>, String> {
+            // Create or reset locals dictionary
+            let preserve_state: bool = self
+                .preserve_state
+                .get()
+                .as_ref()
+                .try_into()
+                .map_err(|_| "Failed to get preserve_state value")?;
+
+            if self.locals.is_none() || !preserve_state {
+                self.locals = Some(vm.ctx.new_dict().into());
+            }
+
+            // Use a combined dictionary for locals and globals
+            use rustpython_vm::builtins::PyDict;
+            let exec_dict = if preserve_state && self.locals.is_some() {
+                // Use existing locals merged with globals
+                let locals = self.locals.as_ref().unwrap().clone()
+                    .downcast::<PyDict>()
+                    .map_err(|_| "Failed to downcast locals to dict")?;
+                locals
+            } else {
+                // Create new dict
+                vm.ctx.new_dict()
+            };
+
+            // Convert input to Python object and set as _s
+            let py_input = shvar_to_py(vm, input)
+                .map_err(|e| format!("Failed to convert input: {:?}", e))?;
+
+            // Set _s variable
+            exec_dict.set_item("_s", py_input, vm)
+                .map_err(|e| format!("Failed to set _s variable: {:?}", e))?;
+
+            // Execute the compiled code
+            let code_obj = self
+                .compiled_code
+                .as_ref()
+                .ok_or("No compiled code available")?
+                .clone();
+
+            use rustpython_vm::builtins::PyCode;
+            let code = code_obj.downcast::<PyCode>()
+                .map_err(|_| "Failed to downcast code object")?;
+
+            // Use exec_dict as both locals and globals
+            let scope = vm::scope::Scope::new(None, exec_dict.clone());
+            let exec_result = vm
+                .run_code_obj(code, scope)
+                .map_err(|e| format!("Python execution failed: {:?}", e))?;
+
+            // Update our locals after execution
+            self.locals = Some(exec_dict.into());
+
+            // Handle result based on mode
+            let file_mode: bool = self
+                .file_mode
+                .get()
+                .as_ref()
+                .try_into()
+                .map_err(|_| "Failed to get file_mode value")?;
+
+            if file_mode {
+                // In file mode, return the input unchanged
+                Ok(Some(*input))
+            } else {
+                // In eval mode, convert and return the result
+                py_to_shvar(vm, exec_result, &mut self.output)?;
+                Ok(Some(self.output.0))
+            }
+        });
+
+        result.map_err(|e| {
+            shlog_error!("{}", e);
+            "Python evaluation failed"
+        })
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn shardsRegister_py_py(core: *mut shards::shardsc::SHCore) {
+    unsafe {
+        shards::core::Core = core;
+    }
+
+    register_shard::<PyEvalShard>();
+}

--- a/shards/modules/py/src/lib.rs
+++ b/shards/modules/py/src/lib.rs
@@ -287,11 +287,11 @@ struct PyEvalShard {
     preserve_state: ParamVar,
 
     #[shard_param(
-        "FileMode",
-        "Execute as file instead of as expression (useful for multi-line scripts)",
+        "ScriptMode",
+        "Enable script mode for statements and multi-line code. Returns last expression value or input if none. Uses Python's interactive compiler mode.",
         BOOL_TYPES
     )]
-    file_mode: ParamVar,
+    script_mode: ParamVar,
 
     // Internal state
     interpreter: Option<Interpreter>,
@@ -307,7 +307,7 @@ impl Default for PyEvalShard {
             required: ExposedTypes::new(),
             expression: ParamVar::default(),
             preserve_state: ParamVar::new(Var::new_bool(false)),
-            file_mode: ParamVar::new(Var::new_bool(false)),
+            script_mode: ParamVar::new(Var::new_bool(false)),
             interpreter: None,
             compiled_code: None,
             locals: None,
@@ -349,8 +349,13 @@ impl Shard for PyEvalShard {
             self.globals = Some(vm.ctx.new_dict().into());
 
             // Compile the code
-            let mode = if self.file_mode.get().as_ref().try_into().unwrap_or(false) {
-                vm::compiler::Mode::Exec
+            // NOTE: Mode::Single is Python's interactive/REPL mode. It's designed for single
+            // interactions but surprisingly handles complex multi-statement blocks including
+            // function definitions. It allows statements (unlike Eval) and returns the last
+            // expression value (unlike Exec which always returns None). Side effect: prints
+            // final expression to stdout like the REPL does.
+            let mode = if self.script_mode.get().as_ref().try_into().unwrap_or(false) {
+                vm::compiler::Mode::Single
             } else {
                 vm::compiler::Mode::Eval
             };
@@ -452,16 +457,22 @@ impl Shard for PyEvalShard {
             self.locals = Some(exec_dict.into());
 
             // Handle result based on mode
-            let file_mode: bool = self
-                .file_mode
+            let script_mode: bool = self
+                .script_mode
                 .get()
                 .as_ref()
                 .try_into()
-                .map_err(|_| "Failed to get file_mode value")?;
+                .map_err(|_| "Failed to get script_mode value")?;
 
-            if file_mode {
-                // In file mode, return the input unchanged
-                Ok(Some(*input))
+            if script_mode {
+                // In script mode, try to return result if available
+                // (e.g., if last line was an expression), else return input
+                if vm.is_none(&exec_result) {
+                    Ok(Some(*input))
+                } else {
+                    py_to_shvar(vm, exec_result, &mut self.output)?;
+                    Ok(Some(self.output.0))
+                }
             } else {
                 // In eval mode, convert and return the result
                 py_to_shvar(vm, exec_result, &mut self.output)?;

--- a/shards/modules/py/src/lib.rs
+++ b/shards/modules/py/src/lib.rs
@@ -283,22 +283,23 @@ struct PyEvalShard {
     #[shard_param(
         "PreserveState",
         "Whether to preserve variable state between calls",
-        [common_type::bool, common_type::bool_var]
+        [common_type::bool]
     )]
-    preserve_state: ParamVar,
+    preserve_state: ClonedVar,
 
     #[shard_param(
         "ScriptMode",
         "Enable script mode for statements and multi-line code. Returns last expression value or input if none. Uses Python's interactive compiler mode.",
-        [common_type::bool, common_type::bool_var]
+        [common_type::bool]
     )]
-    script_mode: ParamVar,
+    script_mode: ClonedVar,
 
     // Internal state
     interpreter: Option<Interpreter>,
     compiled_code: Option<PyObjectRef>,  // Stores PyRef<PyCode>
     locals: Option<PyObjectRef>,
     globals: Option<PyObjectRef>,
+    last_expression: Option<String>,  // Track last compiled expression for change detection
     output: ClonedVar,
 }
 
@@ -307,12 +308,13 @@ impl Default for PyEvalShard {
         Self {
             required: ExposedTypes::new(),
             expression: ParamVar::default(),
-            preserve_state: ParamVar::new(Var::new_bool(false)),
-            script_mode: ParamVar::new(Var::new_bool(false)),
+            preserve_state: ClonedVar::from(Var::new_bool(false)),
+            script_mode: ClonedVar::from(Var::new_bool(false)),
             interpreter: None,
             compiled_code: None,
             locals: None,
             globals: None,
+            last_expression: None,
             output: ClonedVar::default(),
         }
     }
@@ -342,52 +344,58 @@ impl Shard for PyEvalShard {
             }
         });
 
-        // Compile the expression
-        let expr_str: &str = self
-            .expression
-            .get()
-            .as_ref()
-            .try_into()
-            .map_err(|_| "Failed to get expression string")?;
+        // Try to compile the expression if it's a constant value
+        // If it's a variable, compilation will be deferred to activate()
+        if !self.expression.is_variable() {
+            let expr_str: &str = self
+                .expression
+                .get()
+                .as_ref()
+                .try_into()
+                .map_err(|_| "Failed to get expression string")?;
 
-        let compile_result = interp.enter(|vm| -> Result<(), String> {
-            // Create globals dictionary
-            self.globals = Some(vm.ctx.new_dict().into());
+            let compile_result = interp.enter(|vm| -> Result<(), String> {
+                // Create globals dictionary
+                self.globals = Some(vm.ctx.new_dict().into());
 
-            // Compile the code
-            // NOTE: Mode::Single is Python's interactive/REPL mode. It's designed for single
-            // interactions but surprisingly handles complex multi-statement blocks including
-            // function definitions. It allows statements (unlike Eval) and returns the last
-            // expression value (unlike Exec which always returns None). Side effect: prints
-            // final expression to stdout like the REPL does.
-            let mode = if self.script_mode.get().as_ref().try_into().unwrap_or(false) {
-                vm::compiler::Mode::Single
-            } else {
-                vm::compiler::Mode::Eval
-            };
+                // Compile the code
+                // NOTE: Mode::Single is Python's interactive/REPL mode. It's designed for single
+                // interactions but surprisingly handles complex multi-statement blocks including
+                // function definitions. It allows statements (unlike Eval) and returns the last
+                // expression value (unlike Exec which always returns None). Side effect: prints
+                // final expression to stdout like the REPL does.
+                let mode = if self.script_mode.0.as_ref().try_into().unwrap_or(false) {
+                    vm::compiler::Mode::Single
+                } else {
+                    vm::compiler::Mode::Eval
+                };
 
-            let code = vm.compile(expr_str, mode, "<string>".to_owned())
-                .map_err(|e| {
-                    // Compilation errors have Display impl with detailed messages
-                    format!("Python syntax error: {}", e)
-                })?;
+                let code = vm.compile(expr_str, mode, "<string>".to_owned())
+                    .map_err(|e| {
+                        // Compilation errors have Display impl with detailed messages
+                        format!("Python syntax error: {}", e)
+                    })?;
 
-            // Store the compiled code as PyObjectRef
-            self.compiled_code = Some(code.into());
+                // Store the compiled code as PyObjectRef
+                self.compiled_code = Some(code.into());
 
-            // Initialize locals if not preserving state
-            if !self.preserve_state.get().as_ref().try_into().unwrap_or(false) {
-                self.locals = Some(vm.ctx.new_dict().into());
-            }
+                // Track the compiled expression
+                self.last_expression = Some(expr_str.to_string());
 
-            Ok(())
-        });
+                // Initialize locals if not preserving state
+                if !self.preserve_state.0.as_ref().try_into().unwrap_or(false) {
+                    self.locals = Some(vm.ctx.new_dict().into());
+                }
 
-        compile_result.map_err(|e| {
-            shlog_error!("{}", e);
-            push_error(ctx, &e);
-            DynamicErrStr
-        })?;
+                Ok(())
+            });
+
+            compile_result.map_err(|e| {
+                shlog_error!("{}", e);
+                push_error(ctx, &e);
+                DynamicErrStr
+            })?;
+        }
 
         // Store interpreter for later use
         self.interpreter = Some(interp);
@@ -400,6 +408,7 @@ impl Shard for PyEvalShard {
         self.compiled_code = None;
         self.locals = None;
         self.globals = None;
+        self.last_expression = None;
         self.output = ClonedVar::default();
         Ok(())
     }
@@ -413,13 +422,54 @@ impl Shard for PyEvalShard {
         let interp = self.interpreter.as_ref()
             .ok_or("Interpreter not initialized")?;
 
+        // Get the current expression value
+        let expr_str: &str = self
+            .expression
+            .get()
+            .as_ref()
+            .try_into()
+            .map_err(|_| "Failed to get expression string")?;
+
+        // Check if we need to compile (first time or expression changed)
+        let needs_compile = self.compiled_code.is_none() ||
+            self.last_expression.as_ref().map_or(true, |last| last != expr_str);
+
+        if needs_compile {
+            let compile_result = interp.enter(|vm| -> Result<(), String> {
+                // Create globals dictionary if not exists
+                if self.globals.is_none() {
+                    self.globals = Some(vm.ctx.new_dict().into());
+                }
+
+                // Compile the code
+                let mode = if self.script_mode.0.as_ref().try_into().unwrap_or(false) {
+                    vm::compiler::Mode::Single
+                } else {
+                    vm::compiler::Mode::Eval
+                };
+
+                let code = vm.compile(expr_str, mode, "<string>".to_owned())
+                    .map_err(|e| {
+                        format!("Python syntax error: {}", e)
+                    })?;
+
+                // Store the compiled code and track the expression
+                self.compiled_code = Some(code.into());
+                self.last_expression = Some(expr_str.to_string());
+
+                Ok(())
+            });
+
+            compile_result.map_err(|e| {
+                shlog_error!("{}", e);
+                push_error(_context, &e);
+                DynamicErrStr
+            })?;
+        }
+
         let result = interp.enter(|vm| -> Result<Option<Var>, String> {
             // Create or reset locals dictionary
-            let preserve_state: bool = self
-                .preserve_state
-                .get()
-                .as_ref()
-                .try_into()
+            let preserve_state: bool = self.preserve_state.0.as_ref().try_into()
                 .map_err(|_| "Failed to get preserve_state value")?;
 
             if self.locals.is_none() || !preserve_state {
@@ -484,11 +534,7 @@ impl Shard for PyEvalShard {
             self.locals = Some(exec_dict.into());
 
             // Handle result based on mode
-            let script_mode: bool = self
-                .script_mode
-                .get()
-                .as_ref()
-                .try_into()
+            let script_mode: bool = self.script_mode.0.as_ref().try_into()
                 .map_err(|_| "Failed to get script_mode value")?;
 
             if script_mode {

--- a/shards/modules/py/src/lib.rs
+++ b/shards/modules/py/src/lib.rs
@@ -19,7 +19,7 @@ use shards::shard::{Shard, DynamicErrStr, push_error};
 use shards::types::common_type;
 use shards::types::{
     ClonedVar, Context, ExposedTypes, InstanceData, ParamVar,
-    Type, Types, Var, BOOL_TYPES, STRING_TYPES,
+    Type, Types, Var,
 };
 
 lazy_static! {
@@ -276,21 +276,21 @@ struct PyEvalShard {
     #[shard_param(
         "Expression",
         "Python code to evaluate. Input is available as _s. The value of the last expression is returned.",
-        STRING_TYPES
+        [common_type::string, common_type::string_var]
     )]
     expression: ParamVar,
 
     #[shard_param(
         "PreserveState",
         "Whether to preserve variable state between calls",
-        BOOL_TYPES
+        [common_type::bool, common_type::bool_var]
     )]
     preserve_state: ParamVar,
 
     #[shard_param(
         "ScriptMode",
         "Enable script mode for statements and multi-line code. Returns last expression value or input if none. Uses Python's interactive compiler mode.",
-        BOOL_TYPES
+        [common_type::bool, common_type::bool_var]
     )]
     script_mode: ParamVar,
 

--- a/shards/rust/src/types.rs
+++ b/shards/rust/src/types.rs
@@ -5102,7 +5102,7 @@ impl ShardsVar {
       return Ok(self.compose_result.as_ref().unwrap());
     }
 
-    let mut result = unsafe { (*Core).composeShards.unwrap_unchecked()(self.native_shards, *data) };
+    let result = unsafe { (*Core).composeShards.unwrap_unchecked()(self.native_shards, *data) };
 
     if result.failed {
       unsafe { (*Core).freeComposeResult.unwrap_unchecked()(&result as *const _ as *mut _) }

--- a/shards/tests/CLAUDE.md
+++ b/shards/tests/CLAUDE.md
@@ -49,7 +49,7 @@ Process(Input: data other-param)                            // Error! Must put u
 - Data flows through `|`
 - No braces for code blocks other than wire and template definitions, no semicolons needed
 - Whitespace flexible
-- Comments start with `//`
+- Comments are C-style
 - No imperative assignments: data flows into variables
 
 ## Identifiers & Names
@@ -168,13 +168,17 @@ They are CHANNELS that direct data flow, like:
 
 Examples showing the flow:
 
-; Creating flow channels
-5 >= counter           ; Start a mutable flow channel named 'counter'
-"hello" = message      ; Start an immutable flow channel named 'message'
+Creating flow channels
+```
+5 >= counter           // Start a mutable flow channel named 'counter'
+"hello" = message      // Start an immutable flow channel named 'message'
+```
 
-; Directing and transforming flows
-counter | Add(1) > counter    ; Take flow from counter, add 1, direct back
-input | Transform | Process > output   ; Chain of flow transformations
+Directing and transforming flows
+```
+counter | Add(1) > counter    // Take flow from counter, add 1, direct back
+input | Transform | Process > output   // Chain of flow transformations
+```
 
 Remember: The | operator is not a pipe between containers.
 It's a direction marker showing how data flows through your system.

--- a/shards/tests/py-embed.shs
+++ b/shards/tests/py-embed.shs
@@ -62,12 +62,47 @@ errored | Assert.Is(true)
 // Test that state is reset by default (no PreserveState)
 5 | Py.Eval("_s * 2") | Assert.Is(10)
 
-// FileMode vs Eval mode - Eval mode returns result
+// ScriptMode vs Eval mode - Eval mode returns result
 42 | Py.Eval("_s * 2") | Assert.Is(84)
 
-// FileMode - returns input unchanged
-"test" | Py.Eval(FileMode: true Expression: "result = _s.upper()") | Assert.Is("test")
-100 | Py.Eval(FileMode: true Expression: "x = _s * 2") | Assert.Is(100)
+// ScriptMode - allows statements and returns last expression
+10 | Py.Eval(ScriptMode: true Expression: "x = _s * 2\nx + 5") | Assert.Is(25)
+"test" | Py.Eval(ScriptMode: true Expression: "result = _s.upper()\nresult") | Assert.Is("TEST")
+
+// ScriptMode - statement only (no expression) returns input
+100 | Py.Eval(ScriptMode: true Expression: "x = _s * 2") | Assert.Is(100)
+
+// ScriptMode - more complex: multiple statements with final expression
+10 | Py.Eval(ScriptMode: true Expression: """
+x = _s * 2
+y = x + 10
+z = y * 2
+z
+""") | Assert.Is(60)
+
+// ScriptMode - with conditionals
+5 | Py.Eval(ScriptMode: true Expression: """
+if _s > 3:
+    result = _s * 10
+else:
+    result = _s * 2
+result
+""") | Assert.Is(50)
+
+// ScriptMode - with loops
+3 | Py.Eval(ScriptMode: true Expression: """
+total = 0
+for i in range(_s):
+    total += i
+total
+""") | Assert.Is(3)
+
+// ScriptMode - with function definition (tests Mode::Single capability)
+3 | Py.Eval(ScriptMode: true Expression: """
+def square(x):
+    return x * x
+square(_s)
+""") | Assert.Is(9)
 
 // Error handling - runtime error (syntax errors caught at warmup, not runtime)
 Maybe({

--- a/shards/tests/py-embed.shs
+++ b/shards/tests/py-embed.shs
@@ -1,2 +1,99 @@
-"Hello" | Py.Eval("print(_s)")
+// Basic string passthrough
 "Hello" | Py.Eval("_s") | Assert.Is("Hello")
+"World" | Py.Eval("_s.upper()") | Assert.Is("WORLD")
+
+// Integer operations
+42 | Py.Eval("_s * 2") | Assert.Is(84)
+10 | Py.Eval("_s + 5") | Assert.Is(15)
+100 | Py.Eval("_s - 50") | Assert.Is(50)
+
+// Float operations
+3.14 | Py.Eval("_s * 2.0") | Log("Float result")
+2.5 | Py.Eval("_s + 1.5") | Assert.Is(4.0)
+
+// Boolean operations
+true | Py.Eval("not _s") | Assert.Is(false)
+false | Py.Eval("_s or True") | Assert.Is(true)
+
+// Bytes operations - TODO: debug byte length issue
+"test" | ToBytes | Py.Eval("len(_s)") | Assert.Is(9) // due to Shards serialization
+
+// Vector types - Int2
+@i2(1 2) | Py.Eval("(_s[0] + 1, _s[1] + 1)") | Assert.Is(@i2(2 3))
+
+// Vector types - Int3
+@i3(1 2 3) | Py.Eval("(_s[0], _s[1], _s[2] + 1)") | Assert.Is(@i3(1 2 4))
+
+// Vector types - Int4
+@i4(1 2 3 4) | Py.Eval("tuple([x * 2 for x in _s])") | Assert.Is(@i4(2 4 6 8))
+
+// Vector types - Float2
+@f2(1.0 2.0) | Py.Eval("(_s[0] * 2.0, _s[1] * 2.0)") | Log("Float2 result")
+
+// Vector types - Float3
+@f3(1.0 2.0 3.0) | Py.Eval("(_s[0], _s[1], _s[2] * 2.0)") | Log("Float3 result")
+
+// Vector types - Float4
+@f4(1.0 2.0 3.0 4.0) | Py.Eval("tuple([x * 0.5 for x in _s])") | Log("Float4 result")
+
+// State preservation test - without PreserveState (default)
+// Using walrus operator for assignment in expression
+10 | Py.Eval("(x := _s) + 1") | Assert.Is(11)
+false >= errored
+Maybe({
+    20 | Py.Eval("x") | Log("State test 1")
+  } {
+    true > errored
+  }
+)
+errored | Assert.Is(true)
+
+// State preservation test - with PreserveState
+// Using a wire so the same Py.Eval instance is reused
+@wire(stateful-counter {
+  Py.Eval(PreserveState: true Expression: "(counter := globals().get('counter', 0) + _s)")
+})
+
+0 | Do(stateful-counter) | Assert.Is(0)
+5 | Do(stateful-counter) | Assert.Is(5)
+10 | Do(stateful-counter) | Assert.Is(15)
+20 | Do(stateful-counter) | Assert.Is(35)
+
+// Test that state is reset by default (no PreserveState)
+5 | Py.Eval("_s * 2") | Assert.Is(10)
+
+// FileMode vs Eval mode - Eval mode returns result
+42 | Py.Eval("_s * 2") | Assert.Is(84)
+
+// FileMode - returns input unchanged
+"test" | Py.Eval(FileMode: true Expression: "result = _s.upper()") | Assert.Is("test")
+100 | Py.Eval(FileMode: true Expression: "x = _s * 2") | Assert.Is(100)
+
+// Error handling - runtime error (syntax errors caught at warmup, not runtime)
+Maybe({
+    1 | Py.Eval("_s / 0") | Log("Should not reach")
+  } {
+    "Caught runtime error" | Log
+  }
+)
+
+// Edge cases - None handling
+none | Py.Eval("_s is None") | Assert.Is(true)
+10 | Py.Eval("None") | Log("None result")
+
+// Edge cases - Empty string
+"" | Py.Eval("len(_s)") | Assert.Is(0)
+
+// Edge cases - Large numbers
+1000000 | Py.Eval("_s * 2") | Assert.Is(2000000)
+
+// String formatting
+"World" | Py.Eval("f'Hello {_s}!'") | Assert.Is("Hello World!")
+
+// Type conversions
+"42" | Py.Eval("int(_s)") | Assert.Is(42)
+42 | Py.Eval("str(_s)") | Assert.Is("42")
+1 | Py.Eval("bool(_s)") | Assert.Is(true)
+0 | Py.Eval("bool(_s)") | Assert.Is(false)
+
+"All RustPython embedded tests passed!" | Log

--- a/shards/tests/py-embed.shs
+++ b/shards/tests/py-embed.shs
@@ -1,0 +1,1 @@
+"Hello" | Py.Eval("print(_s)")

--- a/shards/tests/py-embed.shs
+++ b/shards/tests/py-embed.shs
@@ -1,1 +1,2 @@
 "Hello" | Py.Eval("print(_s)")
+"Hello" | Py.Eval("_s") | Assert.Is("Hello")

--- a/shards/union/Cargo.lock
+++ b/shards/union/Cargo.lock
@@ -1334,17 +1334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
-dependencies = [
- "dispatch",
- "nix 0.30.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,9 +3390,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -4083,8 +4072,7 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+source = "git+https://github.com/fragcolor-xyz/nix.git?rev=268c07f13fa64e1d493c883c5c860f08fbcbd9b3#268c07f13fa64e1d493c883c5c860f08fbcbd9b3"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -6411,7 +6399,6 @@ dependencies = [
  "clap 4.5.49",
  "clap_complete",
  "compile-time-crc32",
- "ctrlc",
  "dashmap",
  "dunce",
  "flexbuffers",

--- a/shards/union/Cargo.lock
+++ b/shards/union/Cargo.lock
@@ -35,19 +35,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "adobe-cmap-parser"
@@ -75,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -102,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -117,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -199,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +269,7 @@ dependencies = [
  "polling",
  "rustix 1.1.2",
  "slab",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -306,7 +309,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -324,7 +327,7 @@ dependencies = [
  "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -341,7 +344,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -366,21 +378,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.0",
-]
 
 [[package]]
 name = "base64"
@@ -421,7 +418,7 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -432,10 +429,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.106",
- "which",
+ "syn 2.0.107",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -444,7 +441,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -455,10 +452,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.106",
- "which",
+ "syn 2.0.107",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -467,7 +464,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -476,9 +473,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -547,7 +544,7 @@ checksum = "ffebfc2d28a12b262c303cb3860ee77b91bd83b1f20f0bd2a9693008e2f55a9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -558,11 +555,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -582,7 +579,7 @@ checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -641,6 +638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,22 +662,22 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -689,6 +697,15 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "candle-core"
@@ -764,6 +781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -818,9 +844,9 @@ checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -865,8 +891,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
- "windows-link 0.2.0",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -910,24 +938,33 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.47",
+ "clap_derive 4.5.49",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.5",
+ "clap_lex 0.7.6",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2348487adcd4631696ced64ccdb40d38ac4d31cae7f2eec8817fcea1b9d1c43c"
+dependencies = [
+ "clap 4.5.49",
 ]
 
 [[package]]
@@ -945,14 +982,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -966,9 +1003,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -977,18 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "codex-apply-patch"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "similar",
- "thiserror 2.0.17",
- "tree-sitter",
- "tree-sitter-bash",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1032,6 +1067,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1091,6 +1140,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -1259,21 +1314,21 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -1286,7 +1341,7 @@ checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
 dependencies = [
  "dispatch",
  "nix 0.30.1",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1313,14 +1368,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "d3d12"
 version = "22.0.0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libloading",
  "winapi",
 ]
@@ -1346,7 +1401,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1357,7 +1412,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1416,7 +1471,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1436,7 +1491,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1457,7 +1512,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1467,7 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1491,6 +1546,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,7 +1601,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1514,6 +1611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853d5bcf0b73bd5e6d945b976288621825c7166e9f06c5a035ae1aaf42d1b64f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1546,6 +1655,12 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
@@ -1638,6 +1753,7 @@ dependencies = [
  "duplicate",
  "egui",
  "paste",
+ "serde",
 ]
 
 [[package]]
@@ -1699,10 +1815,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
@@ -1713,7 +1844,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1734,7 +1865,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1755,7 +1886,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1766,8 +1897,14 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "epaint"
@@ -1797,8 +1934,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -1837,6 +1980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +2012,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.2",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1893,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixedbitset"
@@ -1911,11 +2071,12 @@ checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2000,7 +2161,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2112,7 +2273,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2279,12 +2440,31 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2295,21 +2475,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
@@ -2352,12 +2532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "git-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,7 +2548,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2395,7 +2569,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "gpu-alloc-types",
 ]
 
@@ -2405,7 +2579,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2427,7 +2601,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2438,7 +2612,44 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3fee5d08eb17c47cbca241967c66154f934515b4974be48380be2dbb019586"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2 0.9.8",
 ]
 
 [[package]]
@@ -2453,7 +2664,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2462,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2472,6 +2683,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.2",
  "rand_distr 0.5.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2507,7 +2719,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "com",
  "libc",
  "libloading",
@@ -2776,7 +2988,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.1",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2931,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
@@ -2971,17 +3183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3196,18 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3086,6 +3299,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52f6e1bf39a7894f618c9d378904a11dbd7e10fe3ec20d1173600e79b1408d8"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,10 +3369,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libc"
-version = "0.2.176"
+name = "lexical-parse-float"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -3158,7 +3412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3173,7 +3427,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall",
 ]
@@ -3227,6 +3481,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libyml"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3502,27 @@ checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
 dependencies = [
  "anyhow",
  "version_check",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3268,11 +3557,10 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3303,7 +3591,7 @@ checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
 dependencies = [
  "encoding_rs",
  "flate2",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itoa",
  "log",
  "md-5",
@@ -3314,10 +3602,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+dependencies = [
+ "twox-hash 2.1.2",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -3336,6 +3643,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malachite-base"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c738d3789301e957a8f7519318fcbb1b92bb95863b28f6938ae5a05be6259f34"
+dependencies = [
+ "hashbrown 0.15.5",
+ "itertools 0.14.0",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-bigint"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f46b904a4725706c5ad0133b662c20b388a3ffb04bda5154029dcb0cd28ae34"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+ "num-integer",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1707c9a1fa36ce21749b35972bfad17bbf34cf5a7c96897c0491da321e387d3b"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "wide",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d764801aa4e96bbb69b389dcd03b50075345131cd63ca2e380bca71cc37a3675"
+dependencies = [
+ "itertools 0.14.0",
+ "malachite-base",
+ "malachite-nz",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3698,12 @@ checksum = "3f32c8c0575eee8637bf462087c00098fe16d6cb621f1abb6ebab4da414d57fd"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
@@ -3375,7 +3736,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3386,6 +3747,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
@@ -3412,6 +3779,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmap2"
@@ -3465,7 +3841,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -3479,7 +3855,7 @@ name = "metal"
 version = "0.29.0"
 source = "git+https://github.com/shards-lang/metal-rs.git?branch=shards-0.29.0#05dcaa96bfdea1f872d3084b0194ca94271e1466"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -3551,19 +3927,19 @@ source = "git+https://github.com/shards-lang/mio.git?rev=65e4240c7c8dc6dde2ccf36
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3585,17 +3961,26 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "moxcms"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+checksum = "c588e11a3082784af229e23e8e4ecf5bcc6fbe4f69101e0421ce8d79da7f0b40"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "mt19937"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7151a832e54d2d6b2c827a20e5bcdd80359281cd2c354e725d4b82e7c471de"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3604,14 +3989,14 @@ version = "22.1.0"
 dependencies = [
  "arrayvec",
  "bit-set 0.6.0",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "log",
  "petgraph",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "spirv",
  "termcolor",
@@ -3623,7 +4008,7 @@ dependencies = [
 name = "naga-native"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cbindgen",
  "naga",
 ]
@@ -3674,12 +4059,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -3692,10 +4086,11 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3720,7 +4115,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -3735,11 +4130,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3790,7 +4185,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3855,11 +4250,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
- "num_enum_derive 0.7.4",
+ "num_enum_derive 0.7.5",
  "rustversion",
 ]
 
@@ -3877,14 +4272,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3925,7 +4320,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block2",
  "libc",
  "objc2",
@@ -3941,7 +4336,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3971,7 +4366,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block2",
  "dispatch",
  "libc",
@@ -3984,7 +4379,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3996,7 +4391,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -4010,15 +4405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4039,7 +4425,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -4063,11 +4449,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -4084,7 +4470,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4095,15 +4481,27 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "optional"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
 
 [[package]]
 name = "ordered-stream"
@@ -4131,6 +4529,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,9 +4546,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4148,15 +4556,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4210,12 +4618,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4235,20 +4643,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
+checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
 dependencies = [
  "memchr",
- "thiserror 2.0.17",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663"
+checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4256,22 +4663,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4f36811dfe07f7b8573462465d5cb8965fffc2e71ae377a33aecf14c2c9a2f"
+checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420"
+checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
  "sha2 0.10.9",
@@ -4284,7 +4691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
 ]
 
 [[package]]
@@ -4338,7 +4745,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "unicase",
 ]
 
@@ -4404,10 +4811,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "quick-xml 0.38.3",
  "serde",
  "time",
+]
+
+[[package]]
+name = "pmutil"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4434,7 +4852,7 @@ dependencies = [
  "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.2",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4509,7 +4927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4528,7 +4946,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.6",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
@@ -4582,7 +5000,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "memchr",
  "unicase",
 ]
@@ -4593,7 +5011,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "memchr",
  "unicase",
 ]
@@ -4612,11 +5030,20 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
+checksum = "a3cbdf373972bf78df4d3b518d07003938e2c7d1fb5891e55f9cb6df57009d84"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "pymath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b66ab66a8610ce209d8b36cd0fecc3a15c494f715e0cb26f0586057f293abc9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4651,6 +5078,25 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1775bc532a9bfde46e26eba441ca1171b91608d14a3bae71fea371f18a00cffe"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -4708,7 +5154,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4809,18 +5255,40 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4830,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4841,9 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "renderdoc-sys"
@@ -4853,16 +5321,14 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http 1.3.1",
  "http-body",
@@ -4891,6 +5357,27 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "result-like"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffa194499266bd8a1ac7da6ac7355aa0f81ffa1a5db2baaf20dd13854fd6f4e"
+dependencies = [
+ "result-like-derive",
+]
+
+[[package]]
+name = "result-like-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d3b03471c9700a3a6bd166550daaa6124cb4a146ea139fb028e4edaa8f4277"
+dependencies = [
+ "pmutil",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4961,7 +5448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
@@ -4988,16 +5475,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e60ef3b82994702bbe4e134d98aadca4b49ed04440148985678d415c68127666"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+name = "ruff_python_ast"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+dependencies = [
+ "aho-corasick",
+ "bitflags 2.10.0",
+ "compact_str 0.8.1",
+ "is-macro",
+ "itertools 0.14.0",
+ "memchr",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "compact_str 0.8.1",
+ "memchr",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_text_size",
+ "rustc-hash 2.1.1",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2 1.3.0",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+dependencies = [
+ "itertools 0.14.0",
+ "ruff_source_file",
+ "ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+dependencies = [
+ "memchr",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
 
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -5014,7 +5562,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5027,18 +5575,18 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -5058,13 +5606,310 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rustpython-codegen"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "ahash",
+ "bitflags 2.10.0",
+ "indexmap 2.12.0",
+ "itertools 0.14.0",
+ "log",
+ "malachite-bigint",
+ "memchr",
+ "num-complex",
+ "num-traits",
+ "ruff_python_ast",
+ "ruff_text_size",
+ "rustpython-compiler-core",
+ "rustpython-literal",
+ "rustpython-wtf8",
+ "thiserror 2.0.17",
+ "unicode_names2 2.0.0",
+]
+
+[[package]]
+name = "rustpython-common"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "ascii",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "libc",
+ "lock_api",
+ "malachite-base",
+ "malachite-bigint",
+ "malachite-q",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "radium",
+ "rustpython-literal",
+ "rustpython-wtf8",
+ "siphasher 1.0.1",
+ "unicode_names2 2.0.0",
+ "widestring",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustpython-compiler"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustpython-codegen",
+ "rustpython-compiler-core",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rustpython-compiler-core"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "bitflags 2.10.0",
+ "itertools 0.14.0",
+ "lz4_flex",
+ "malachite-bigint",
+ "num-complex",
+ "ruff_source_file",
+ "rustpython-wtf8",
+]
+
+[[package]]
+name = "rustpython-derive"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "rustpython-compiler",
+ "rustpython-derive-impl",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "rustpython-derive-impl"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "itertools 0.14.0",
+ "maplit",
+ "proc-macro2",
+ "quote",
+ "rustpython-compiler-core",
+ "rustpython-doc",
+ "syn 2.0.107",
+ "syn-ext",
+ "textwrap",
+]
+
+[[package]]
+name = "rustpython-doc"
+version = "0.3.0"
+source = "git+https://github.com/RustPython/__doc__?tag=0.3.0#8b62ce5d796d68a091969c9fa5406276cb483f79"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "rustpython-literal"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "hexf-parse",
+ "is-macro",
+ "lexical-parse-float",
+ "num-traits",
+ "rustpython-wtf8",
+ "unic-ucd-category",
+]
+
+[[package]]
+name = "rustpython-pylib"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "glob",
+ "rustpython-compiler-core",
+ "rustpython-derive",
+]
+
+[[package]]
+name = "rustpython-sre_engine"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "bitflags 2.10.0",
+ "num_enum 0.7.5",
+ "optional",
+ "rustpython-wtf8",
+]
+
+[[package]]
+name = "rustpython-stdlib"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "adler32",
+ "ahash",
+ "ascii",
+ "base64 0.22.1",
+ "blake2",
+ "bzip2",
+ "cfg-if",
+ "crc32fast",
+ "crossbeam-utils",
+ "csv-core",
+ "digest 0.10.7",
+ "dns-lookup",
+ "dyn-clone",
+ "flate2",
+ "gethostname",
+ "hex",
+ "indexmap 2.12.0",
+ "itertools 0.14.0",
+ "libc",
+ "libz-rs-sys",
+ "mac_address",
+ "malachite-bigint",
+ "md-5",
+ "memchr",
+ "memmap2 0.5.10",
+ "mt19937",
+ "nix 0.30.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "num_enum 0.7.5",
+ "page_size",
+ "parking_lot",
+ "paste",
+ "pymath",
+ "rand_core 0.9.3",
+ "rustix 1.1.2",
+ "rustpython-common",
+ "rustpython-derive",
+ "rustpython-vm",
+ "schannel",
+ "sha-1",
+ "sha2 0.10.9",
+ "sha3",
+ "socket2",
+ "system-configuration",
+ "termios",
+ "ucd",
+ "unic-char-property",
+ "unic-normal",
+ "unic-ucd-age",
+ "unic-ucd-bidi",
+ "unic-ucd-category",
+ "unic-ucd-ident",
+ "unicode-bidi-mirroring 0.4.0",
+ "unicode-casing",
+ "unicode_names2 2.0.0",
+ "uuid",
+ "widestring",
+ "windows-sys 0.59.0",
+ "xml",
+]
+
+[[package]]
+name = "rustpython-vm"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "ahash",
+ "ascii",
+ "bitflags 2.10.0",
+ "bstr",
+ "caseless",
+ "cfg-if",
+ "chrono",
+ "constant_time_eq 0.4.2",
+ "crossbeam-utils",
+ "errno",
+ "exitcode",
+ "getrandom 0.3.4",
+ "glob",
+ "half",
+ "hex",
+ "indexmap 2.12.0",
+ "is-macro",
+ "itertools 0.14.0",
+ "junction",
+ "libc",
+ "log",
+ "malachite-bigint",
+ "memchr",
+ "nix 0.30.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "num_cpus",
+ "num_enum 0.7.5",
+ "once_cell",
+ "optional",
+ "parking_lot",
+ "paste",
+ "result-like",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_text_size",
+ "rustix 1.1.2",
+ "rustpython-codegen",
+ "rustpython-common",
+ "rustpython-compiler",
+ "rustpython-compiler-core",
+ "rustpython-derive",
+ "rustpython-literal",
+ "rustpython-sre_engine",
+ "rustyline",
+ "scoped-tls",
+ "scopeguard",
+ "static_assertions",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.17",
+ "thread_local",
+ "timsort",
+ "uname",
+ "unic-ucd-bidi",
+ "unic-ucd-category",
+ "unic-ucd-ident",
+ "unicode-casing",
+ "which 8.0.0",
+ "widestring",
+ "windows 0.52.0",
+ "windows-sys 0.59.0",
+ "winreg",
+]
+
+[[package]]
+name = "rustpython-wtf8"
+version = "0.4.0"
+source = "git+https://github.com/fragcolor-xyz/RustPython.git?branch=shards#e7a35f8d86353fb307f7f0e72cdf898c418ec18a"
+dependencies = [
+ "ascii",
+ "bstr",
+ "itertools 0.14.0",
+ "memchr",
 ]
 
 [[package]]
@@ -5083,10 +5928,32 @@ dependencies = [
  "bytemuck",
  "smallvec",
  "ttf-parser 0.18.1",
- "unicode-bidi-mirroring",
+ "unicode-bidi-mirroring 0.1.0",
  "unicode-ccc",
  "unicode-general-category",
  "unicode-script",
+]
+
+[[package]]
+name = "rustyline"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.30.1",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+ "utf8parse",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5094,6 +5961,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safetensors"
@@ -5120,7 +5996,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5159,7 +6035,7 @@ name = "security-framework"
 version = "2.11.0"
 source = "git+https://github.com/shards-lang/rust-security-framework.git?rev=ea683f291bb8dff51d3239e556c3236e09274c16#ea683f291bb8dff51d3239e556c3236e09274c16"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5240,7 +6116,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5249,7 +6125,6 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -5274,7 +6149,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5295,13 +6170,24 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itoa",
  "libyml",
  "memchr",
  "ryu",
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5340,6 +6226,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5362,16 +6258,6 @@ dependencies = [
  "lazy_static",
  "serde",
  "shards-macro",
-]
-
-[[package]]
-name = "shards-codex"
-version = "0.1.0"
-dependencies = [
- "codex-apply-patch",
- "compile-time-crc32",
- "lazy_static",
- "shards",
 ]
 
 [[package]]
@@ -5423,7 +6309,7 @@ dependencies = [
  "shards",
  "tiny-bip39",
  "tiny-keccak",
- "twox-hash",
+ "twox-hash 1.6.3",
  "x509-cert",
 ]
 
@@ -5435,15 +6321,6 @@ dependencies = [
  "csv",
  "lazy_static",
  "shards",
-]
-
-[[package]]
-name = "shards-debugger"
-version = "0.1.0"
-dependencies = [
- "lazy_static",
- "petname",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -5465,6 +6342,7 @@ dependencies = [
  "nanoid",
  "num-traits",
  "pest",
+ "serde",
  "shards",
  "shards-lang",
  "syntect",
@@ -5476,6 +6354,20 @@ version = "0.1.0"
 dependencies = [
  "shards",
  "shards-egui",
+]
+
+[[package]]
+name = "shards-fileops"
+version = "0.1.0"
+dependencies = [
+ "compile-time-crc32",
+ "dirs 5.0.1",
+ "grep-matcher",
+ "grep-regex",
+ "grep-searcher",
+ "lazy_static",
+ "shards",
+ "walkdir",
 ]
 
 [[package]]
@@ -5516,7 +6408,8 @@ name = "shards-lang"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
- "clap 4.5.48",
+ "clap 4.5.49",
+ "clap_complete",
  "compile-time-crc32",
  "ctrlc",
  "dashmap",
@@ -5557,7 +6450,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5625,6 +6518,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shards-py"
+version = "0.1.0"
+dependencies = [
+ "compile-time-crc32",
+ "lazy_static",
+ "rustpython-pylib",
+ "rustpython-stdlib",
+ "rustpython-vm",
+ "shards",
+]
+
+[[package]]
 name = "shards-random"
 version = "0.1.0"
 dependencies = [
@@ -5642,12 +6547,11 @@ dependencies = [
  "crsql_bundle",
  "gfx",
  "shards",
- "shards-codex",
  "shards-core",
  "shards-crypto",
  "shards-csv",
- "shards-debugger",
  "shards-egui-register",
+ "shards-fileops",
  "shards-fs",
  "shards-http",
  "shards-inputs-debug-ui",
@@ -5656,9 +6560,24 @@ dependencies = [
  "shards-ml",
  "shards-network",
  "shards-pdf",
+ "shards-py",
  "shards-random",
+ "shards-ssh",
  "shards-svg",
  "tracy-client",
+]
+
+[[package]]
+name = "shards-ssh"
+version = "0.1.0"
+dependencies = [
+ "compile-time-crc32",
+ "lazy_static",
+ "regex",
+ "shards",
+ "shellexpand",
+ "ssh2",
+ "strip-ansi-escapes",
 ]
 
 [[package]]
@@ -5671,6 +6590,15 @@ dependencies = [
  "shards",
  "tiny-skia 0.11.4",
  "usvg",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5702,12 +6630,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
@@ -5765,12 +6687,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5779,7 +6701,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -5829,22 +6751,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
+name = "ssh2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libssh2-sys",
+ "parking_lot",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strict-num"
@@ -5881,6 +6809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5891,6 +6828,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+]
 
 [[package]]
 name = "subtle"
@@ -5921,13 +6876,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-ext"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b126de4ef6c2a628a68609dd00733766c3b015894698a438ebdf374933fc31d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5947,7 +6913,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5976,7 +6942,7 @@ name = "sysctl"
 version = "0.5.5"
 source = "git+https://github.com/shards-lang/sysctl-rs.git?rev=859c91707dfaa11d8adff35b65b1b88bb98680bd#859c91707dfaa11d8adff35b65b1b88bb98680bd"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -5990,7 +6956,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -6012,10 +6978,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6036,6 +7002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6070,7 +7045,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -6081,7 +7056,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -6125,6 +7100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "timsort"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "639ce8ef6d2ba56be0383a94dd13b92138d58de44c62618303bb798fa92bdc00"
+
+[[package]]
 name = "tiny-bip39"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6133,7 +7114,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "unicode-normalization",
@@ -6245,7 +7226,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -6256,11 +7237,11 @@ checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.0",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -6283,33 +7264,30 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
- "mio 1.0.4",
+ "mio 1.1.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -6376,9 +7354,9 @@ checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
  "serde_core",
 ]
@@ -6389,28 +7367,28 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.11.4",
- "toml_datetime 0.7.2",
+ "indexmap 2.12.0",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "winnow 0.7.13",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow 0.7.13",
 ]
@@ -6436,7 +7414,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -6479,7 +7457,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -6543,36 +7521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
-dependencies = [
- "cc",
- "regex",
- "regex-syntax",
- "serde_json",
- "streaming-iterator",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-bash"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871b0606e667e98a1237ebdc1b0d7056e0aebfdc3141d12b399865d4cb6ed8a6"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-language"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6629,6 +7577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "type1-encoding-parser"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6639,9 +7593,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4fa6e588762366f1eb4991ce59ad1b93651d0b769dfb4e4d1c5c4b943d1159"
 
 [[package]]
 name = "ucd-trie"
@@ -6689,6 +7649,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-normal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09d64d33589a94628bc2aeb037f35c2e25f3f049c7348b5aa5580b48e6bba62"
+dependencies = [
+ "unic-ucd-normal",
+]
+
+[[package]]
+name = "unic-ucd-age"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8cfdfe71af46b871dc6af2c24fcd360e2f3392ee4c5111877f2947f311671c"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-bidi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d568b51222484e1f8209ce48caa6b430bf352962b877d592c29ab31fb53d8c"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-category"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8d4591f5fcfe1bd4453baaf803c40e1b1e69ff8455c47620440b46efef91c0"
+dependencies = [
+ "matches",
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-hangul"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1dc690e19010e1523edb9713224cba5ef55b54894fe33424439ec9a40c0054"
+dependencies = [
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-ident"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-normal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86aed873b8202d22b13859dda5fe7c001d271412c31d411fd9b827e030569410"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-hangul",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6705,6 +7779,18 @@ name = "unicode-bidi-mirroring"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-casing"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061dbb8cc7f108532b6087a0065eff575e892a4bcb503dc57323a197457cc202"
 
 [[package]]
 name = "unicode-ccc"
@@ -6767,6 +7853,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6777,6 +7869,48 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unicode_names2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
+dependencies = [
+ "phf",
+ "unicode_names2_generator 1.3.0",
+]
+
+[[package]]
+name = "unicode_names2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+dependencies = [
+ "phf",
+ "unicode_names2_generator 2.0.0",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+dependencies = [
+ "phf_codegen",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "universal-hash"
@@ -6903,7 +8037,8 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.3",
+ "atomic",
+ "getrandom 0.3.4",
  "js-sys",
  "rand 0.9.2",
  "wasm-bindgen",
@@ -6926,6 +8061,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -6962,15 +8106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7002,7 +8137,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -7037,7 +8172,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7071,7 +8206,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
@@ -7083,7 +8218,7 @@ version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -7145,18 +8280,18 @@ version = "22.1.0"
 dependencies = [
  "arrayvec",
  "bit-vec 0.7.0",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytemuck",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 1.0.69",
  "wgpu-hal",
@@ -7171,7 +8306,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.6.0",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
@@ -7194,7 +8329,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 1.0.69",
  "wasm-bindgen",
@@ -7224,7 +8359,7 @@ dependencies = [
 name = "wgpu-types"
 version = "22.0.0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "js-sys",
  "web-sys",
 ]
@@ -7242,10 +8377,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.0"
+name = "which"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.2",
+ "winsafe",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -7269,7 +8425,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7334,15 +8490,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7358,24 +8514,24 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.1"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.2"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -7386,9 +8542,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -7422,11 +8578,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7440,11 +8596,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7480,16 +8636,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7525,19 +8681,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.4"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.0",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7563,9 +8719,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7581,9 +8737,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7599,9 +8755,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -7611,9 +8767,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7629,9 +8785,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7647,9 +8803,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7665,9 +8821,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7683,9 +8839,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7704,6 +8860,22 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -7738,6 +8910,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xml"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a4274c410d957424a1502b21126915b45d9956b2f80a88d4f6f906af29facc"
 
 [[package]]
 name = "xml5ever"
@@ -7803,7 +8981,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -7815,7 +8993,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -7860,7 +9038,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "zvariant_utils",
 ]
 
@@ -7892,7 +9070,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -7912,15 +9090,15 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -7933,7 +9111,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -7966,7 +9144,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -7979,10 +9157,16 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
- "indexmap 2.11.4",
- "num_enum 0.7.4",
+ "indexmap 2.12.0",
+ "num_enum 0.7.5",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zvariant"
@@ -8007,7 +9191,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "zvariant_utils",
 ]
 
@@ -8019,7 +9203,7 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[patch.unused]]


### PR DESCRIPTION
## Summary
- Adds embedded RustPython interpreter as optional alternative to dynamic Python loading
- Implements Py.Eval shard using RustPython 0.4.0 with frozen stdlib
- CMake option `ENABLE_RUSTPYTHON_EMBEDDED` (default: OFF) controls build mode
- Full Python standard library embedded in binary (~30MB increase)

## Implementation Details
- **Rust Shard**: New `PyEvalShard` in `shards/modules/py/src/lib.rs`
- **Type Conversions**: SHVar ↔ Python types (int, float, string, bytes, tuples, int2/3/4, float2/3/4)
- **RustPython API**: Uses RustPython 0.4.0 with proper type checking and object handling
- **Conditional Build**: Existing DLL-based Py module unaffected when feature disabled

## Changes
- `shards/modules/py/Cargo.toml`: RustPython dependencies with freeze-stdlib
- `shards/modules/py/src/lib.rs`: 443 lines of Rust implementation
- `shards/modules/py/CMakeLists.txt`: Conditional Rust build logic
- `shards/tests/py-embed.shs`: Basic test script
- `.github/workflows/test-macos-gpu.yml`: CI integration
- `shards/rust/src/types.rs`: Minor cleanup (unused mut)

## Test Plan
- [x] Compiles with `ENABLE_RUSTPYTHON_EMBEDDED=OFF` (default)
- [x] Compiles with `ENABLE_RUSTPYTHON_EMBEDDED=ON`
- [x] `shards/tests/py-embed.shs` passes
- [ ] CI test-macos-gpu workflow passes

## Binary Size Impact
With `ENABLE_RUSTPYTHON_EMBEDDED=ON`:
- Approximately +30MB due to frozen Python stdlib
- No impact when disabled (default)