### PR TITLE
Review SQLite Module Implementation

### DIFF
--- a/shards/core/async.hpp
+++ b/shards/core/async.hpp
@@ -264,9 +264,7 @@ inline SHVar awaitne(SHContext *context, FUNC &&func, CANCELLATION &&cancel) noe
   if (unlikely(!call.complete)) {
     cancel();
     while (!call.complete) {
-      // Use sleep instead of yield to prevent iOS watchdog from killing the app
-      // during cancellation wait
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      std::this_thread::yield();
     }
   }
 
@@ -332,9 +330,7 @@ template <typename FUNC, typename CANCELLATION> inline void await(SHContext *con
   if (unlikely(!call.complete)) {
     cancel();
     while (!call.complete) {
-      // Use sleep instead of yield to prevent iOS watchdog from killing the app
-      // during cancellation wait
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      std::this_thread::yield();
     }
   }
 

--- a/shards/core/async.hpp
+++ b/shards/core/async.hpp
@@ -264,7 +264,9 @@ inline SHVar awaitne(SHContext *context, FUNC &&func, CANCELLATION &&cancel) noe
   if (unlikely(!call.complete)) {
     cancel();
     while (!call.complete) {
-      std::this_thread::yield();
+      // Use sleep instead of yield to prevent iOS watchdog from killing the app
+      // during cancellation wait
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
 
@@ -330,7 +332,9 @@ template <typename FUNC, typename CANCELLATION> inline void await(SHContext *con
   if (unlikely(!call.complete)) {
     cancel();
     while (!call.complete) {
-      std::this_thread::yield();
+      // Use sleep instead of yield to prevent iOS watchdog from killing the app
+      // during cancellation wait
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
 

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -518,6 +518,11 @@ struct Query : public Base {
     do {
       rc = sqlite3_step(prepared->get());
       if (rc == SQLITE_ROW) {
+        // Check for cancellation during row processing to allow cancelling long queries
+        if (!context->shouldContinue() || cancelled.load()) {
+          throw ActivationError("Query cancelled during row processing");
+        }
+
         auto numCols = sqlite3_column_count(prepared->get());
         if (numCols == 0) {
           continue;
@@ -581,6 +586,11 @@ struct Query : public Base {
     do {
       rc = sqlite3_step(prepared->get());
       if (rc == SQLITE_ROW) {
+        // Check for cancellation during row processing to allow cancelling long queries
+        if (!context->shouldContinue() || cancelled.load()) {
+          throw ActivationError("Query cancelled during row processing");
+        }
+
         auto numCols = sqlite3_column_count(prepared->get());
         if (numCols == 0) {
           continue;

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -513,7 +513,7 @@ struct Query : public Base {
     bool empty = true;
     int rc;
     bool retry = _retry.payload.boolValue;
-    auto retryStartTime = std::chrono::steady_clock::now();
+    std::optional<std::chrono::steady_clock::time_point> retryStartTime;
     const auto maxRetryDuration = std::chrono::seconds(30);
     do {
       rc = sqlite3_step(prepared->get());
@@ -551,8 +551,12 @@ struct Query : public Base {
           if (!context->shouldContinue() || cancelled.load()) {
             throw ActivationError("Query cancelled while waiting for database");
           }
-          // Check for timeout
-          auto elapsed = std::chrono::steady_clock::now() - retryStartTime;
+          // Start timer on first SQLITE_BUSY (not before, to avoid timing legitimate long queries)
+          if (!retryStartTime.has_value()) {
+            retryStartTime = std::chrono::steady_clock::now();
+          }
+          // Check for timeout - only counts time spent in SQLITE_BUSY retry, not total query time
+          auto elapsed = std::chrono::steady_clock::now() - *retryStartTime;
           if (elapsed > maxRetryDuration) {
             throw ActivationError("Database busy timeout exceeded (30 seconds)");
           }
@@ -581,7 +585,7 @@ struct Query : public Base {
     bool empty = true;
     int rc;
     bool retry = _retry.payload.boolValue;
-    auto retryStartTime = std::chrono::steady_clock::now();
+    std::optional<std::chrono::steady_clock::time_point> retryStartTime;
     const auto maxRetryDuration = std::chrono::seconds(30);
     do {
       rc = sqlite3_step(prepared->get());
@@ -626,8 +630,12 @@ struct Query : public Base {
           if (!context->shouldContinue() || cancelled.load()) {
             throw ActivationError("Query cancelled while waiting for database");
           }
-          // Check for timeout
-          auto elapsed = std::chrono::steady_clock::now() - retryStartTime;
+          // Start timer on first SQLITE_BUSY (not before, to avoid timing legitimate long queries)
+          if (!retryStartTime.has_value()) {
+            retryStartTime = std::chrono::steady_clock::now();
+          }
+          // Check for timeout - only counts time spent in SQLITE_BUSY retry, not total query time
+          auto elapsed = std::chrono::steady_clock::now() - *retryStartTime;
           if (elapsed > maxRetryDuration) {
             throw ActivationError("Database busy timeout exceeded (30 seconds)");
           }

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -595,7 +595,7 @@ struct Query : public Base {
         // Check for cancellation during row processing to allow cancelling long queries
         if (!context->shouldContinue() || cancelled.load()) {
           // Notice, avoid throwing cos this might just be a stop, or another error (the real one)
-          return empty ? emptySeqOutput : output.output;
+          return empty ? emptyTableOutput : output.output;
         }
 
         auto numCols = sqlite3_column_count(prepared->get());
@@ -632,7 +632,7 @@ struct Query : public Base {
           // Check for cancellation
           if (!context->shouldContinue() || cancelled.load()) {
             // Notice, avoid throwing cos this might just be a stop, or another error (the real one)
-            return empty ? emptySeqOutput : output.output;
+            return empty ? emptyTableOutput : output.output;
           }
           // Start timer on first SQLITE_BUSY (not before, to avoid timing legitimate long queries)
           if (!retryStartTime.has_value()) {

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -824,8 +824,6 @@ struct Transaction : public Base {
         throw ActivationError("Transaction cancelled while waiting for lock");
       }
       SH_SUSPEND(context, 0);
-      // Add small sleep to prevent iOS watchdog if SH_SUSPEND doesn't actually suspend
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
     await(

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -520,7 +520,8 @@ struct Query : public Base {
       if (rc == SQLITE_ROW) {
         // Check for cancellation during row processing to allow cancelling long queries
         if (!context->shouldContinue() || cancelled.load()) {
-          throw ActivationError("Query cancelled during row processing");
+          // Notice, avoid throwing cos this might just be a stop, or another error (the real one)
+          return empty ? emptySeqOutput : output.output;
         }
 
         auto numCols = sqlite3_column_count(prepared->get());
@@ -549,7 +550,8 @@ struct Query : public Base {
         if (retry) {
           // Check for cancellation
           if (!context->shouldContinue() || cancelled.load()) {
-            throw ActivationError("Query cancelled while waiting for database");
+            // Notice, avoid throwing cos this might just be a stop, or another error (the real one)
+            return empty ? emptySeqOutput : output.output;
           }
           // Start timer on first SQLITE_BUSY (not before, to avoid timing legitimate long queries)
           if (!retryStartTime.has_value()) {
@@ -592,7 +594,8 @@ struct Query : public Base {
       if (rc == SQLITE_ROW) {
         // Check for cancellation during row processing to allow cancelling long queries
         if (!context->shouldContinue() || cancelled.load()) {
-          throw ActivationError("Query cancelled during row processing");
+          // Notice, avoid throwing cos this might just be a stop, or another error (the real one)
+          return empty ? emptySeqOutput : output.output;
         }
 
         auto numCols = sqlite3_column_count(prepared->get());
@@ -628,7 +631,8 @@ struct Query : public Base {
         if (retry) {
           // Check for cancellation
           if (!context->shouldContinue() || cancelled.load()) {
-            throw ActivationError("Query cancelled while waiting for database");
+            // Notice, avoid throwing cos this might just be a stop, or another error (the real one)
+            return empty ? emptySeqOutput : output.output;
           }
           // Start timer on first SQLITE_BUSY (not before, to avoid timing legitimate long queries)
           if (!retryStartTime.has_value()) {
@@ -828,9 +832,7 @@ struct Transaction : public Base {
     std::unique_lock<std::mutex> lock(_connection->transactionMutex, std::defer_lock);
     // try to lock, if we can't we suspend until the lock is available
     while (!lock.try_lock()) {
-      if (!context->shouldContinue()) {
-        throw ActivationError("Transaction cancelled while waiting for lock");
-      }
+      // SH_SUSPEND already checks if we should continue here, and returns if not! (macro)
       SH_SUSPEND(context, 0);
     }
 

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -501,7 +501,7 @@ struct Query : public Base {
     }
   }
 
-  SHVar getOutputRows(SHContext *context, OutputType &output_) {
+  SHVar getOutputRows(SHContext *context, OutputType &output_, const std::atomic<bool> &cancelled) {
     RowOutput *ptr = std::get_if<RowOutput>(&output_);
     if (!ptr)
       ptr = &output_.emplace<RowOutput>();
@@ -513,6 +513,8 @@ struct Query : public Base {
     bool empty = true;
     int rc;
     bool retry = _retry.payload.boolValue;
+    auto retryStartTime = std::chrono::steady_clock::now();
+    const auto maxRetryDuration = std::chrono::seconds(30);
     do {
       rc = sqlite3_step(prepared->get());
       if (rc == SQLITE_ROW) {
@@ -540,8 +542,17 @@ struct Query : public Base {
         }
       } else if (rc == SQLITE_BUSY) {
         if (retry) {
-          // Try again after yield or next frame
-          std::this_thread::yield();
+          // Check for cancellation
+          if (!context->shouldContinue() || cancelled.load()) {
+            throw ActivationError("Query cancelled while waiting for database");
+          }
+          // Check for timeout
+          auto elapsed = std::chrono::steady_clock::now() - retryStartTime;
+          if (elapsed > maxRetryDuration) {
+            throw ActivationError("Database busy timeout exceeded (30 seconds)");
+          }
+          // Use sleep instead of yield to avoid iOS watchdog killing the app
+          std::this_thread::sleep_for(std::chrono::milliseconds(10));
         } else {
           throw ActivationError("SQLite database is busy and retry is disabled");
         }
@@ -555,7 +566,7 @@ struct Query : public Base {
     return empty ? emptySeqOutput : output.output;
   }
 
-  SHVar getOutputCols(SHContext *context, OutputType &output_) {
+  SHVar getOutputCols(SHContext *context, OutputType &output_, const std::atomic<bool> &cancelled) {
     ColOutput *ptr = std::get_if<ColOutput>(&output_);
     if (!ptr)
       ptr = &output_.emplace<ColOutput>();
@@ -565,6 +576,8 @@ struct Query : public Base {
     bool empty = true;
     int rc;
     bool retry = _retry.payload.boolValue;
+    auto retryStartTime = std::chrono::steady_clock::now();
+    const auto maxRetryDuration = std::chrono::seconds(30);
     do {
       rc = sqlite3_step(prepared->get());
       if (rc == SQLITE_ROW) {
@@ -599,8 +612,17 @@ struct Query : public Base {
         }
       } else if (rc == SQLITE_BUSY) {
         if (retry) {
-          // Try again after yield or next frame
-          std::this_thread::yield();
+          // Check for cancellation
+          if (!context->shouldContinue() || cancelled.load()) {
+            throw ActivationError("Query cancelled while waiting for database");
+          }
+          // Check for timeout
+          auto elapsed = std::chrono::steady_clock::now() - retryStartTime;
+          if (elapsed > maxRetryDuration) {
+            throw ActivationError("Database busy timeout exceeded (30 seconds)");
+          }
+          // Use sleep instead of yield to avoid iOS watchdog killing the app
+          std::this_thread::sleep_for(std::chrono::milliseconds(10));
         } else {
           throw ActivationError("SQLite database is busy and retry is disabled");
         }
@@ -716,7 +738,7 @@ struct Query : public Base {
             throw ActivationError("Not enough parameters for query");
 
           SH_SQLITE_DEBUG_LOG("sqlite query, db: {}, {}", (void *)_connection->db, _query.get().payload.stringValue);
-          return _returnCols ? getOutputCols(context, output) : getOutputRows(context, output);
+          return _returnCols ? getOutputCols(context, output, cancelled) : getOutputRows(context, output, cancelled);
         },
         [&] {
           // Cancellation handler: signal to interrupt lock acquisition

--- a/shards/modules/sqlite/sqlite.cpp
+++ b/shards/modules/sqlite/sqlite.cpp
@@ -810,7 +810,12 @@ struct Transaction : public Base {
     std::unique_lock<std::mutex> lock(_connection->transactionMutex, std::defer_lock);
     // try to lock, if we can't we suspend until the lock is available
     while (!lock.try_lock()) {
+      if (!context->shouldContinue()) {
+        throw ActivationError("Transaction cancelled while waiting for lock");
+      }
       SH_SUSPEND(context, 0);
+      // Add small sleep to prevent iOS watchdog if SH_SUSPEND doesn't actually suspend
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
     await(


### PR DESCRIPTION
…vention

This commit fixes critical issues in DB.Query's SQLITE_BUSY retry loops that could cause iOS to kill the app and prevented query cancellation.

Issues fixed:
1. **iOS watchdog crash**: Replaced std::this_thread::yield() with sleep_for(10ms) to avoid tight busy-wait loop that triggers iOS watchdog

2. **Cancellation not working**: Added checks for cancelled flag and context->shouldContinue() so queries can be properly cancelled

3. **Infinite retry loops**: Added 30-second timeout to prevent queries from retrying forever if SQLITE_BUSY persists

Changes:
- getOutputRows() and getOutputCols() now accept `cancelled` parameter
- SQLITE_BUSY retry loops now check cancellation and context state
- Replaced yield() with sleep_for(10ms) for iOS compatibility
- Added timeout to prevent infinite retries

Root cause: When user cancelled a query with Retry: true that was hitting SQLITE_BUSY, the retry loop would ignore the cancellation and keep spinning with yield(), which iOS interpreted as an unresponsive app and killed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
