### PR TITLE
Optimize destructuring with compose-time Expect elimination

### DIFF
--- a/docs/samples/shards/General/Erase/Erase.shs
+++ b/docs/samples/shards/General/Erase/Erase.shs
@@ -32,8 +32,8 @@ Erase([1] Name: seq Global: true) // erase from global sequence
 Get(seq Global: true) | Log // => [1, 3]
 
 // erase from same-name local and global tables
-{k1: 1 k2: 2 k3: 3} | ExpectTable >= tab // create local table   
-{k1: 1 k2: 2 k3: 3} | ExpectTable | Set(tab Global: true) // create global table   
+{k1: 1 k2: 2 k3: 3} | ToAnyTable >= tab // create local table   
+{k1: 1 k2: 2 k3: 3} | ToAnyTable | Set(tab Global: true) // create global table   
 Erase(["k3" "k1"] Name: tab) // erase from local table
 Get(tab) | Log // => {k2: 2}
 Erase(["k2"] Name: tab Global: true) // erase from global table

--- a/docs/samples/shards/General/Erase/Erase.shs
+++ b/docs/samples/shards/General/Erase/Erase.shs
@@ -11,14 +11,14 @@ seq2 | Log // => [200, 400]
 
 // erase single key-value pair from table        
 {k1: 10 k2: 20 k3: 30}
-ToAny | ExpectTable // to make it a dynamic table
+ToAnyTable // to make it a dynamic table
 >= tab1
 Erase("k2" Name: tab1)
 tab1 | Log // => {k3: 30, k1: 10}
 
 // erase multiple key-value pairs from table
 {k1: 100 k2: 200 k3: 300}
-ToAny | ExpectTable // to make it a dynamic table
+ToAnyTable // to make it a dynamic table
 >= tab2
 Erase(["k3" "k1"] Name: tab2)
 tab2 | Log // => {k2: 200}

--- a/docs/samples/shards/General/Erase/Erase.shs
+++ b/docs/samples/shards/General/Erase/Erase.shs
@@ -11,14 +11,14 @@ seq2 | Log // => [200, 400]
 
 // erase single key-value pair from table        
 {k1: 10 k2: 20 k3: 30}
-ExpectTable // to make it a dynamic table
+ToAny | ExpectTable // to make it a dynamic table
 >= tab1
 Erase("k2" Name: tab1)
 tab1 | Log // => {k3: 30, k1: 10}
 
 // erase multiple key-value pairs from table
 {k1: 100 k2: 200 k3: 300}
-ExpectTable // to make it a dynamic table
+ToAny | ExpectTable // to make it a dynamic table
 >= tab2
 Erase(["k3" "k1"] Name: tab2)
 tab2 | Log // => {k2: 200}

--- a/shards/lang/src/eval.rs
+++ b/shards/lang/src/eval.rs
@@ -3000,7 +3000,7 @@ fn add_expect_table_shard(
   line_info: LineInfo,
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
-  let shard = AutoShardRef::create("ExpectTable", Some(line_info.into())).unwrap(); // qed, Take must exist
+  let shard = AutoShardRef::create("ExpectTable", Some(line_info.into())).unwrap(); // qed, ExpectTable must exist
   e.shards.push(shard);
   Ok(())
 }
@@ -3009,7 +3009,7 @@ fn add_expect_seq_shard(
   line_info: LineInfo,
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
-  let shard = AutoShardRef::create("ExpectSeq", Some(line_info.into())).unwrap(); // qed, Take must exist
+  let shard = AutoShardRef::create("ExpectSeq", Some(line_info.into())).unwrap(); // qed, ExpectSeq must exist
   e.shards.push(shard);
   Ok(())
 }

--- a/shards/lang/src/eval.rs
+++ b/shards/lang/src/eval.rs
@@ -1552,6 +1552,7 @@ fn create_take_table_chain(
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
   add_get_shard(var_name, line, e)?;
+  add_expect_table_shard(line, e)?;
   for path_part in path {
     let s = Var::ephemeral_string(path_part.as_str());
     add_take_shard(var_name, &s, line, e)?;
@@ -1566,6 +1567,7 @@ fn create_take_seq_chain(
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
   add_get_shard(var_name, line, e)?;
+  add_expect_seq_shard(line, e)?;
   for path_part in path {
     let idx = (*path_part).try_into().unwrap(); // read should have caught this
     add_take_shard(var_name, &idx, line, e)?;
@@ -2990,6 +2992,24 @@ fn add_take_shard(
     .set_parameter(0, *target)
     .map_err(|e| (format!("{}", e), line_info).into())?;
   let shard = shard_with_id_iden(shard, e, name);
+  e.shards.push(shard);
+  Ok(())
+}
+
+fn add_expect_table_shard(
+  line_info: LineInfo,
+  e: &mut EvalEnv,
+) -> Result<(), ShardsError> {
+  let shard = AutoShardRef::create("ExpectTable", Some(line_info.into())).unwrap(); // qed, Take must exist
+  e.shards.push(shard);
+  Ok(())
+}
+
+fn add_expect_seq_shard(
+  line_info: LineInfo,
+  e: &mut EvalEnv,
+) -> Result<(), ShardsError> {
+  let shard = AutoShardRef::create("ExpectSeq", Some(line_info.into())).unwrap(); // qed, Take must exist
   e.shards.push(shard);
   Ok(())
 }

--- a/shards/lang/src/eval.rs
+++ b/shards/lang/src/eval.rs
@@ -1567,7 +1567,6 @@ fn create_take_seq_chain(
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
   add_get_shard(var_name, line, e)?;
-  add_expect_seq_shard(line, e)?;
   for path_part in path {
     let idx = (*path_part).try_into().unwrap(); // read should have caught this
     add_take_shard(var_name, &idx, line, e)?;
@@ -3001,15 +3000,6 @@ fn add_expect_table_shard(
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
   let shard = AutoShardRef::create("ExpectTable", Some(line_info.into())).unwrap(); // qed, ExpectTable must exist
-  e.shards.push(shard);
-  Ok(())
-}
-
-fn add_expect_seq_shard(
-  line_info: LineInfo,
-  e: &mut EvalEnv,
-) -> Result<(), ShardsError> {
-  let shard = AutoShardRef::create("ExpectSeq", Some(line_info.into())).unwrap(); // qed, ExpectSeq must exist
   e.shards.push(shard);
   Ok(())
 }

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -639,18 +639,6 @@ struct ExpectSeq {
         "Checks if the input value is a sequence; otherwise, the shard will trigger an error, preventing further execution.");
   }
 
-  SHTypeInfo compose(const SHInstanceData &data) {
-    if (data.inputType.basicType == SHType::Seq) {
-      // Ok this is for certain then.. this Expect is not needed
-      // we can just pass (it will be inlined very quick at runtime)
-      data.shard->inlineShardId = InlineShard::NoopShard;
-    } else {
-      // Do normal activate
-      data.shard->inlineShardId = InlineShard::NotInline;
-    }
-    return CoreInfo::AnySeqType;
-  }
-
   SHVar activate(SHContext *context, const SHVar &input) {
     if (unlikely(input.valueType != SHType::Seq)) {
       SHLOG_ERROR("Unexpected value: {}", input);

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -353,6 +353,44 @@ struct ToAny {
   SHVar activate(SHContext *context, const SHVar &input) { return input; }
 };
 
+struct ToAnySeq {
+  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHOptionalString inputHelp() { return SHCCSTR("Converts the input to any sequence type"); }
+
+  static SHTypesInfo outputTypes() { return CoreInfo::AnySeqType; }
+  static SHOptionalString outputHelp() { return SHCCSTR("The same value as the input but typed as Any sequence."); }
+
+  static SHOptionalString help() {
+    return SHCCSTR("Converts the input value to any sequence type, allowing it to be used where a sequence is expected.");
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    data.shard->inlineShardId = InlineShard::NoopShard;
+    return CoreInfo::AnySeqType;
+  }
+  SHVar activate(SHContext *context, const SHVar &input) { return input; }
+};
+
+struct ToAnyTable {
+  static inline Type outputType{{SHType::Table}};
+
+  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHOptionalString inputHelp() { return SHCCSTR("Converts the input to table type"); }
+
+  static SHTypesInfo outputTypes() { return outputType; }
+  static SHOptionalString outputHelp() { return SHCCSTR("The same value as the input but typed as Table."); }
+
+  static SHOptionalString help() {
+    return SHCCSTR("Converts the input value to table type, allowing it to be used where a table is expected.");
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    data.shard->inlineShardId = InlineShard::NoopShard;
+    return outputType;
+  }
+  SHVar activate(SHContext *context, const SHVar &input) { return input; }
+};
+
 struct VarAddr {
   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
   static SHOptionalString inputHelp() { return SHCCSTR("The name of the variable whose address is to be retrieved."); }
@@ -1553,6 +1591,8 @@ SHARDS_REGISTER_FN(casting) {
   REGISTER_SHARD("ToString", ToString);
   REGISTER_SHARD("ToHex", ToHex);
   REGISTER_SHARD("ToAny", ToAny);
+  REGISTER_SHARD("ToAnySeq", ToAnySeq);
+  REGISTER_SHARD("ToAnyTable", ToAnyTable);
   REGISTER_SHARD("VarAddr!", VarAddr);
   REGISTER_SHARD("BitSwap32", BitSwap32);
   REGISTER_SHARD("BitSwap64", BitSwap64);

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -480,10 +480,13 @@ static inline void expectTypeCheck(const SHVar &input, uint64_t expectedTypeHash
 
 template <SHType ET> struct ExpectX {
   static inline Type outputType{{ET}};
+  
   SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  
   static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyType; }
 
   SHTypesInfo outputTypes() { return outputType; }
+  
   static SHOptionalString outputHelp() {
     if constexpr (ET == SHType::Int) {
       return SHCCSTR("Outputs the input value unchanged if it is of type Int.");
@@ -600,6 +603,19 @@ template <SHType ET> struct ExpectX {
                      "is of the appropriate type; otherwise, the shard will trigger an error, preventing further execution.");
     }
   }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    if (data.inputType.basicType == ET) {
+      // Ok this is for certain then.. this Expect is not needed
+      // we can just pass (it will be inlined very quick at runtime)
+      data.shard->inlineShardId = InlineShard::NoopShard;
+    } else {
+      // Do normal activate
+      data.shard->inlineShardId = InlineShard::NotInline;
+    }
+    return outputType;
+  }
+
   SHVar activate(SHContext *context, const SHVar &input) {
     if (unlikely(input.valueType != ET)) {
       SHLOG_ERROR("Unexpected value: {}", input);
@@ -611,13 +627,30 @@ template <SHType ET> struct ExpectX {
 
 struct ExpectSeq {
   SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  
   static SHOptionalString inputHelp() { return DefaultHelpText::InputHelpAnyType; }
+  
   SHTypesInfo outputTypes() { return CoreInfo::AnySeqType; }
+  
   static SHOptionalString outputHelp() { return SHCCSTR("Outputs the input value unchanged if it is a sequence."); }
+  
   static SHOptionalString help() {
     return SHCCSTR(
         "Checks if the input value is a sequence; otherwise, the shard will trigger an error, preventing further execution.");
   }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    if (data.inputType.basicType == SHType::Seq) {
+      // Ok this is for certain then.. this Expect is not needed
+      // we can just pass (it will be inlined very quick at runtime)
+      data.shard->inlineShardId = InlineShard::NoopShard;
+    } else {
+      // Do normal activate
+      data.shard->inlineShardId = InlineShard::NotInline;
+    }
+    return CoreInfo::AnySeqType;
+  }
+
   SHVar activate(SHContext *context, const SHVar &input) {
     if (unlikely(input.valueType != SHType::Seq)) {
       SHLOG_ERROR("Unexpected value: {}", input);

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -354,7 +354,7 @@ struct ToAny {
 };
 
 struct ToAnySeq {
-  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHTypesInfo inputTypes() { return CoreInfo::AnySeqType; }
   static SHOptionalString inputHelp() { return SHCCSTR("Converts the input to any sequence type"); }
 
   static SHTypesInfo outputTypes() { return CoreInfo::AnySeqType; }
@@ -368,16 +368,15 @@ struct ToAnySeq {
     data.shard->inlineShardId = InlineShard::NoopShard;
     return CoreInfo::AnySeqType;
   }
+  
   SHVar activate(SHContext *context, const SHVar &input) { return input; }
 };
 
 struct ToAnyTable {
-  static inline Type outputType{{SHType::Table}};
-
-  static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
+  static SHTypesInfo inputTypes() { return CoreInfo::AnyTableType; }
   static SHOptionalString inputHelp() { return SHCCSTR("Converts the input to table type"); }
 
-  static SHTypesInfo outputTypes() { return outputType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::AnyTableType; }
   static SHOptionalString outputHelp() { return SHCCSTR("The same value as the input but typed as Table."); }
 
   static SHOptionalString help() {
@@ -386,8 +385,9 @@ struct ToAnyTable {
 
   SHTypeInfo compose(const SHInstanceData &data) {
     data.shard->inlineShardId = InlineShard::NoopShard;
-    return outputType;
+    return CoreInfo::AnyTableType;
   }
+
   SHVar activate(SHContext *context, const SHVar &input) { return input; }
 };
 

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -609,11 +609,12 @@ template <SHType ET> struct ExpectX {
       // Ok this is for certain then.. this Expect is not needed
       // we can just pass (it will be inlined very quick at runtime)
       data.shard->inlineShardId = InlineShard::NoopShard;
+      return data.inputType;
     } else {
       // Do normal activate
       data.shard->inlineShardId = InlineShard::NotInline;
+      return outputType;
     }
-    return outputType;
   }
 
   SHVar activate(SHContext *context, const SHVar &input) {

--- a/shards/tests/general.shs
+++ b/shards/tests/general.shs
@@ -1167,7 +1167,7 @@
   Assert.Is([112 114 97 99] true)
   
   {a: 1 b: 2 c: 3}
-  ExpectTable // to make it a dynamic table
+  ToAny | ExpectTable // to make it a dynamic table
   >= table-abc
   Erase(["a" "c"] table-abc)
   table-abc | Assert.Is({b: 2} true)

--- a/shards/tests/general.shs
+++ b/shards/tests/general.shs
@@ -1167,7 +1167,7 @@
   Assert.Is([112 114 97 99] true)
   
   {a: 1 b: 2 c: 3}
-  ToAny | ExpectTable // to make it a dynamic table
+  ToAnyTable // to make it a dynamic table
   >= table-abc
   Erase(["a" "c"] table-abc)
   table-abc | Assert.Is({b: 2} true)

--- a/shards/tests/hello.shs
+++ b/shards/tests/hello.shs
@@ -330,7 +330,3 @@ trigger-1-count | Assert.Is(2)
 ; test speculative destructure (will inject ExpectTable)
 any-value:a | Assert.Is(1)
 any-value:b | Assert.Is(2)
-
-[1 2 3] | ToJson | FromJson > any-value
-any-value:0 | Assert.Is(1)
-any-value:2 | Assert.Is(3)

--- a/shards/tests/hello.shs
+++ b/shards/tests/hello.shs
@@ -322,3 +322,15 @@ trigger-1-count | Assert.Is(2)
 
 @define(has-nope-shard #("Log" | Maybe({Shards.Help | true} {false})))
 @has-nope-shard | Log("Nope")
+
+{
+  a: 1
+  b: 2
+} | ToJson | FromJson >= any-value
+; test speculative destructure (will inject ExpectTable)
+any-value:a | Assert.Is(1)
+any-value:b | Assert.Is(2)
+
+[1 2 3] | ToJson | FromJson > any-value
+any-value:0 | Assert.Is(1)
+any-value:2 | Assert.Is(3)


### PR DESCRIPTION
## Summary

This PR adds a compile-time optimization for destructuring tables and sequences. When destructuring with the `:` syntax, the compiler now injects `ExpectTable` or `ExpectSeq` shards that can optimize themselves away when types are statically known.

## Changes

- **eval.rs**: Inject `ExpectTable`/`ExpectSeq` after `Get` in destructuring chains
- **casting.cpp**: Add `compose()` methods to `ExpectX`, `ExpectSeq`, and `ExpectTable` that set `InlineShard::NoopShard` when input type matches expected type
- **hello.shs**: Add test cases for speculative destructuring with `Any` types

## Benefits

- **Zero overhead** for statically-typed destructuring (Expect becomes no-op)
- **Runtime safety** for dynamic types (proper type checking with clear errors)
- **Better error messages** when destructuring fails on wrong types

## Example

```shards
{a: 1 b: 2} | ToJson | FromJson >= any-value
any-value:a  // ExpectTable does runtime check (type is Any)

{a: 1 b: 2} >= known-table
known-table:a  // ExpectTable optimized away (type is Table)
```