### PR TITLE
Add LocalShell module for local shell execution

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -169,6 +169,7 @@ jobs:
           ./shards new ../shards/tests/crdt-benchmarks.shs
           ./shards new ../shards/tests/tui.shs
           ./shards new ../shards/tests/tui1.shs
+          ./shards new ../shards/tests/localshell.shs
       - name: Test doc samples (non-UI)
         env:
           RUST_BACKTRACE: full

--- a/justfile
+++ b/justfile
@@ -26,6 +26,28 @@ configure:
 build: configure
   cmake --build build/Debug --target shards
 
+# build shards with filtered output (shows only errors and critical warnings)
+build-quiet: configure
+  #!/bin/bash
+  set -o pipefail
+  cmake --build build/Debug --target shards 2>&1 | \
+    grep -v "^warning:" | \
+    grep -v "^\[.*\].*\.o$" | \
+    grep -v "^   Compiling" | \
+    grep -v "^    Checking" | \
+    grep -v "^     Finished" | \
+    tee /tmp/shards-build.log || \
+    (echo "Build failed. Full log: /tmp/shards-build.log" && tail -50 /tmp/shards-build.log && false)
+
+# check just the rust union compilation
+check-rust: configure
+  #!/bin/bash
+  cd build/Debug/src/union/shards-rust-union
+  export CARGO_TARGET_DIR=/Users/sugar/devel/tmp/rust-target
+  export RUSTUP_TOOLCHAIN=`cat /Users/sugar/devel/shards/rust.version`
+  export CRSQLITE_COMMIT_SHA=shards-dev
+  cargo check 2>&1 | grep -E "(error|localshell)" || echo "✓ Rust check passed"
+
 [no-cd]
 cargo-check:
   RUSTUP_TOOLCHAIN={{ rust_toolchain }} cargo check

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ check-ci:
 
 # configure cmake in build/Debug
 configure:
-  cmake -GNinja -B build/Debug -DCMAKE_BUILD_TYPE=Debug
+  cmake -GNinja -B build/Debug -DCMAKE_BUILD_TYPE=Debug > /dev/null
 
 # build shards (configures first if needed)
 build: configure
@@ -42,10 +42,10 @@ build-quiet: configure
 # check just the rust union compilation
 check-rust: configure
   #!/bin/bash
-  cd build/Debug/src/union/shards-rust-union
-  export CARGO_TARGET_DIR=/Users/sugar/devel/tmp/rust-target
-  export RUSTUP_TOOLCHAIN=`cat /Users/sugar/devel/shards/rust.version`
+  export CARGO_TARGET_DIR=`pwd`/../tmp/rust-target
+  export RUSTUP_TOOLCHAIN=`cat rust.version`
   export CRSQLITE_COMMIT_SHA=shards-dev
+  cd build/Debug/src/union/shards-rust-union
   cargo check 2>&1 | grep -E "(error|localshell)" || echo "✓ Rust check passed"
 
 [no-cd]

--- a/shards/modules/localshell/CMakeLists.txt
+++ b/shards/modules/localshell/CMakeLists.txt
@@ -1,5 +1,5 @@
 # LocalShell module requires PTY support, not available on Emscripten
-if(NOT EMSCRIPTEN)
+if(NOT EMSCRIPTEN AND NOT IOS AND NOT VISIONOS AND NOT WATCHOS)
   add_rust_library(NAME shards-localshell
     PROJECT_PATH ${CMAKE_CURRENT_LIST_DIR})
 

--- a/shards/modules/localshell/CMakeLists.txt
+++ b/shards/modules/localshell/CMakeLists.txt
@@ -1,0 +1,9 @@
+# LocalShell module requires PTY support, not available on Emscripten
+if(NOT EMSCRIPTEN)
+  add_rust_library(NAME shards-localshell
+    PROJECT_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+  add_shards_module(localshell
+    RUST_TARGETS shards-localshell-rust
+    REGISTER_SHARDS rust)
+endif()

--- a/shards/modules/localshell/Cargo.toml
+++ b/shards/modules/localshell/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "shards-localshell"
+description = "LocalShell module for Shards - local shell execution with interactive support"
+license = "BSD-3-Clause"
+version = "0.1.0"
+authors = ["Fragcolor Pte. Ltd."]
+edition = "2021"
+
+[lib]
+crate-type = ["rlib", "staticlib"]
+
+[dependencies]
+lazy_static = "1.5.0"
+shards = { path = "../../rust" }
+compile-time-crc32 = "0.1.2"
+strip-ansi-escapes = "0.2"
+regex = "1.10"
+portable-pty = "0.8"

--- a/shards/modules/localshell/Cargo.toml
+++ b/shards/modules/localshell/Cargo.toml
@@ -14,5 +14,4 @@ lazy_static = "1.5.0"
 shards = { path = "../../rust" }
 compile-time-crc32 = "0.1.2"
 strip-ansi-escapes = "0.2"
-regex = "1.10"
 portable-pty = "0.8"

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -34,6 +34,7 @@ use shards::types::BOOL_TYPES;
 use portable_pty::{CommandBuilder, PtySize, PtySystem};
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{channel, Receiver, TryRecvError};
 use std::time::Duration;
 
 // LocalShell session object wrapper
@@ -296,13 +297,22 @@ impl BlockingShard for CreateShard {
         let mut temp_buf = [0u8; 4096];
 
         for _ in 0..10 {
-            let mut reader_lock = reader_arc.lock()
-                .map_err(|_| "Reader lock poisoned")?;
+            let (tx, rx) = channel();
+            let reader_clone = Arc::clone(&reader_arc);
 
-            // Try to read without blocking too long
-            match reader_lock.read(&mut temp_buf) {
-                Ok(n) if n > 0 => {
-                    output_buffer.extend_from_slice(&temp_buf[..n]);
+            std::thread::spawn(move || {
+                if let Ok(mut reader) = reader_clone.lock() {
+                    let mut buf = [0u8; 4096];
+                    match reader.read(&mut buf) {
+                        Ok(n) => { let _ = tx.send((n, buf)); }
+                        Err(_) => { let _ = tx.send((0, buf)); }
+                    }
+                }
+            });
+
+            match rx.recv_timeout(Duration::from_millis(100)) {
+                Ok((n, buf)) if n > 0 => {
+                    output_buffer.extend_from_slice(&buf[..n]);
                     let output_str = String::from_utf8_lossy(&output_buffer);
                     if is_prompt(&output_str) {
                         break;
@@ -310,42 +320,10 @@ impl BlockingShard for CreateShard {
                 }
                 _ => {}
             }
-            drop(reader_lock);
             std::thread::sleep(Duration::from_millis(100));
         }
 
-        shlog_trace!("Shell ready, disabling echo");
-
-        // Disable echo for cleaner output (Unix only)
-        #[cfg(unix)]
-        {
-            let mut writer_lock = writer_arc.lock()
-                .map_err(|_| "Writer lock poisoned")?;
-            let _ = writer_lock.write_all(b"stty -echo\n");
-            let _ = writer_lock.flush();
-            drop(writer_lock);
-
-            // Drain the command output
-            std::thread::sleep(Duration::from_millis(300));
-            output_buffer.clear();
-            for _ in 0..10 {
-                let mut reader_lock = reader_arc.lock()
-                    .map_err(|_| "Reader lock poisoned")?;
-                match reader_lock.read(&mut temp_buf) {
-                    Ok(n) if n > 0 => {
-                        output_buffer.extend_from_slice(&temp_buf[..n]);
-                        let output_str = String::from_utf8_lossy(&output_buffer);
-                        if is_prompt(&output_str) {
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-                drop(reader_lock);
-                std::thread::sleep(Duration::from_millis(100));
-            }
-        }
-
+        shlog_trace!("Shell ready");
         shlog_trace!("Local shell created successfully");
 
         // Create LocalShellSession object
@@ -521,27 +499,27 @@ impl BlockingShard for ExecuteShard {
         std::thread::sleep(Duration::from_millis(200));
 
         for iteration in 0..max_iterations {
-            let bytes_read = {
-                let mut reader = local_shell.reader.lock()
-                    .map_err(|_| "Reader lock poisoned")?;
+            // Try to read with timeout to avoid blocking forever
+            let (tx, rx) = channel();
+            let reader_clone = Arc::clone(&local_shell.reader);
 
-                match reader.read(&mut temp_buf) {
-                    Ok(n) => n,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock
-                           || e.kind() == std::io::ErrorKind::TimedOut => 0,
-                    Err(_) => {
-                        // Process might have died
-                        *local_shell.is_alive.lock()
-                            .map_err(|_| "Alive state lock poisoned")? = false;
-
-                        let mut result_table = AutoTableVar::new();
-                        result_table.0.insert_fast_static("status", &Var::ephemeral_string("process_died"));
-                        result_table.0.insert_fast_static("output", &Var::ephemeral_string(""));
-                        result_table.0.insert_fast_static("message", &Var::ephemeral_string("Shell process exited"));
-                        self.output = result_table.to_cloned();
-                        return Ok(self.output.0);
+            std::thread::spawn(move || {
+                if let Ok(mut reader) = reader_clone.lock() {
+                    let mut buf = [0u8; 4096];
+                    match reader.read(&mut buf) {
+                        Ok(n) => { let _ = tx.send((n, buf)); }
+                        Err(_) => { let _ = tx.send((0, buf)); }
                     }
                 }
+            });
+
+            // Wait up to 100ms for the read to complete
+            let bytes_read = match rx.recv_timeout(Duration::from_millis(100)) {
+                Ok((n, buf)) if n > 0 => {
+                    temp_buf[..n].copy_from_slice(&buf[..n]);
+                    n
+                }
+                Ok(_) | Err(_) => 0,
             };
 
             if bytes_read > 0 {
@@ -755,36 +733,36 @@ impl BlockingShard for SendInputShard {
                 .map_err(|_| "Failed to flush writer")?;
         }
 
-        // Wait for output
-        std::thread::sleep(Duration::from_secs(2));
+        // Wait for output - give shell time to process input
+        std::thread::sleep(Duration::from_millis(1000));
 
         // Read output
         let mut output_buffer = Vec::new();
         let mut temp_buf = [0u8; 4096];
         let mut was_truncated = false;
 
-        for _ in 0..10 {
-            let bytes_read = {
-                let mut reader = local_shell.reader.lock()
-                    .map_err(|_| "Reader lock poisoned")?;
+        for _ in 0..30 {  // Increased from 10 to 30 (3 seconds total)
+            // Try to read with timeout to avoid blocking forever
+            let (tx, rx) = channel();
+            let reader_clone = Arc::clone(&local_shell.reader);
 
-                match reader.read(&mut temp_buf) {
-                    Ok(n) => n,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock
-                           || e.kind() == std::io::ErrorKind::TimedOut => 0,
-                    Err(_) => {
-                        // Process might have died
-                        *local_shell.is_alive.lock()
-                            .map_err(|_| "Alive state lock poisoned")? = false;
-
-                        let mut result_table = AutoTableVar::new();
-                        result_table.0.insert_fast_static("status", &Var::ephemeral_string("process_died"));
-                        result_table.0.insert_fast_static("output", &Var::ephemeral_string(""));
-                        result_table.0.insert_fast_static("message", &Var::ephemeral_string("Shell process exited"));
-                        self.output = result_table.to_cloned();
-                        return Ok(self.output.0);
+            std::thread::spawn(move || {
+                if let Ok(mut reader) = reader_clone.lock() {
+                    let mut buf = [0u8; 4096];
+                    match reader.read(&mut buf) {
+                        Ok(n) => { let _ = tx.send((n, buf)); }
+                        Err(_) => { let _ = tx.send((0, buf)); }
                     }
                 }
+            });
+
+            // Wait up to 100ms for the read to complete
+            let bytes_read = match rx.recv_timeout(Duration::from_millis(100)) {
+                Ok((n, buf)) if n > 0 => {
+                    temp_buf[..n].copy_from_slice(&buf[..n]);
+                    n
+                }
+                Ok(_) | Err(_) => 0,
             };
 
             if bytes_read > 0 {

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -47,6 +47,8 @@ mod local_shell {
         pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
         pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
         pub is_alive: Arc<Mutex<bool>>,
+        pub output_buffer: Arc<Mutex<Vec<u8>>>,
+        pub reader_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
     }
 
     #[derive(Clone)]
@@ -58,9 +60,17 @@ mod local_shell {
         fn drop(&mut self) {
             shlog_trace!("Dropping LocalShellSession, cleaning up");
 
-            // Mark as not alive
+            // Mark as not alive (this will signal the reader thread to exit)
             if let Ok(mut is_alive) = self.is_alive.lock() {
                 *is_alive = false;
+            }
+
+            // Wait for reader thread to finish
+            if let Ok(mut thread_opt) = self.reader_thread.lock() {
+                if let Some(thread) = thread_opt.take() {
+                    shlog_trace!("Waiting for reader thread to finish");
+                    let _ = thread.join();
+                }
             }
 
             // Close writer to signal shell to exit
@@ -326,13 +336,71 @@ impl BlockingShard for CreateShard {
         shlog_trace!("Shell ready");
         shlog_trace!("Local shell created successfully");
 
+        // Create shared output buffer
+        let output_buffer = Arc::new(Mutex::new(Vec::new()));
+        let is_alive = Arc::new(Mutex::new(true));
+
+        // Start reader thread
+        let reader_clone = Arc::clone(&reader_arc);
+        let buffer_clone = Arc::clone(&output_buffer);
+        let alive_clone = Arc::clone(&is_alive);
+
+        let reader_thread = std::thread::spawn(move || {
+            shlog_trace!("Reader thread started");
+            let mut buf = [0u8; 4096];
+
+            loop {
+                // Check if we should exit (non-blocking check)
+                match alive_clone.lock() {
+                    Ok(alive) if !*alive => {
+                        shlog_trace!("Reader thread exiting");
+                        break;
+                    }
+                    _ => {}
+                }
+
+                // Read from PTY (this will block until data is available)
+                if let Ok(mut reader) = reader_clone.lock() {
+                    match reader.read(&mut buf) {
+                        Ok(n) if n > 0 => {
+                            // Append to shared buffer
+                            if let Ok(mut buffer) = buffer_clone.lock() {
+                                buffer.extend_from_slice(&buf[..n]);
+                                shlog_trace!("Reader thread: read {} bytes, buffer now {} bytes", n, buffer.len());
+                            }
+                        }
+                        Ok(_) => {
+                            // EOF - process died
+                            if let Ok(mut alive) = alive_clone.lock() {
+                                *alive = false;
+                            }
+                            break;
+                        }
+                        Err(e) => {
+                            shlog_trace!("Reader thread: read error: {}", e);
+                            if let Ok(mut alive) = alive_clone.lock() {
+                                *alive = false;
+                            }
+                            break;
+                        }
+                    }
+                } else {
+                    // Failed to lock reader
+                    break;
+                }
+            }
+            shlog_trace!("Reader thread finished");
+        });
+
         // Create LocalShellSession object
         let local_shell = LocalShellSession {
             pair: Arc::new(Mutex::new(pair)),
             reader: reader_arc,
             writer: writer_arc,
             pending_interactive: Arc::new(Mutex::new(None)),
-            is_alive: Arc::new(Mutex::new(true)),
+            is_alive,
+            output_buffer,
+            reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
         };
 
         let shell_var = Var::new_ref_counted(local_shell, &*LOCAL_SHELL_TYPE);
@@ -474,6 +542,14 @@ impl BlockingShard for ExecuteShard {
             }
         }
 
+        // Clear shared buffer before sending command
+        {
+            let mut shared_buffer = local_shell.output_buffer.lock()
+                .map_err(|_| "Buffer lock poisoned")?;
+            shared_buffer.clear();
+            shlog_trace!("Cleared shared buffer before command");
+        }
+
         // Send command
         let cmd_with_newline = format!("{}\n", cmd);
         {
@@ -485,45 +561,37 @@ impl BlockingShard for ExecuteShard {
                 .map_err(|_| "Failed to flush writer")?;
         }
 
-        // Read output with timeout-based prompt detection
+        // Read output from shared buffer with timeout-based prompt detection
         let mut output_buffer = Vec::new();
-        let mut temp_buf = [0u8; 4096];
+        let mut last_buffer_size = 0;
         let mut no_data_count = 0;
         let max_iterations = 50; // 5 seconds total (50 * 100ms)
         let mut prompt_detected = false;
         let mut was_truncated = false;
 
-        shlog_trace!("Starting to read command output");
+        shlog_trace!("Starting to read command output from shared buffer");
 
         // Give shell time to process command
         std::thread::sleep(Duration::from_millis(200));
 
         for iteration in 0..max_iterations {
-            // Try to read with timeout to avoid blocking forever
-            let (tx, rx) = channel();
-            let reader_clone = Arc::clone(&local_shell.reader);
-
-            std::thread::spawn(move || {
-                if let Ok(mut reader) = reader_clone.lock() {
-                    let mut buf = [0u8; 4096];
-                    match reader.read(&mut buf) {
-                        Ok(n) => { let _ = tx.send((n, buf)); }
-                        Err(_) => { let _ = tx.send((0, buf)); }
-                    }
-                }
-            });
-
-            // Wait up to 100ms for the read to complete
-            let bytes_read = match rx.recv_timeout(Duration::from_millis(100)) {
-                Ok((n, buf)) if n > 0 => {
-                    temp_buf[..n].copy_from_slice(&buf[..n]);
-                    n
-                }
-                Ok(_) | Err(_) => 0,
+            // Read from shared buffer
+            let current_buffer_size = {
+                let shared_buffer = local_shell.output_buffer.lock()
+                    .map_err(|_| "Buffer lock poisoned")?;
+                shared_buffer.len()
             };
 
+            let bytes_read = current_buffer_size - last_buffer_size;
+
             if bytes_read > 0 {
-                output_buffer.extend_from_slice(&temp_buf[..bytes_read]);
+                // Copy new data from shared buffer
+                let shared_buffer = local_shell.output_buffer.lock()
+                    .map_err(|_| "Buffer lock poisoned")?;
+                output_buffer.extend_from_slice(&shared_buffer[last_buffer_size..]);
+                drop(shared_buffer);
+
+                last_buffer_size = current_buffer_size;
 
                 // Truncate if buffer exceeds max size
                 if truncate_to_tail(&mut output_buffer, max_output_bytes) {
@@ -722,60 +790,75 @@ impl BlockingShard for SendInputShard {
             }
         }
 
+        // Note current buffer position before sending input
+        let start_buffer_size = {
+            let shared_buffer = local_shell.output_buffer.lock()
+                .map_err(|_| "Buffer lock poisoned")?;
+            shared_buffer.len()
+        };
+
         // Send input (if not empty)
         if !input_str.is_empty() {
             let input_with_newline = format!("{}\n", input_str);
+            shlog_trace!("SendInput: Writing {} bytes: {:?}", input_with_newline.len(), input_with_newline);
             let mut writer = local_shell.writer.lock()
                 .map_err(|_| "Writer lock poisoned")?;
             writer.write_all(input_with_newline.as_bytes())
                 .map_err(|_| "Failed to write input")?;
             writer.flush()
                 .map_err(|_| "Failed to flush writer")?;
+            shlog_trace!("SendInput: Write and flush succeeded");
         }
 
         // Wait for output - give shell time to process input
-        std::thread::sleep(Duration::from_millis(1000));
+        std::thread::sleep(Duration::from_millis(500));
+        shlog_trace!("SendInput: Starting to read output after input (starting from byte {})", start_buffer_size);
 
-        // Read output
+        // Read output from shared buffer
         let mut output_buffer = Vec::new();
-        let mut temp_buf = [0u8; 4096];
+        let mut last_buffer_size = start_buffer_size;
         let mut was_truncated = false;
 
-        for _ in 0..30 {  // Increased from 10 to 30 (3 seconds total)
-            // Try to read with timeout to avoid blocking forever
-            let (tx, rx) = channel();
-            let reader_clone = Arc::clone(&local_shell.reader);
-
-            std::thread::spawn(move || {
-                if let Ok(mut reader) = reader_clone.lock() {
-                    let mut buf = [0u8; 4096];
-                    match reader.read(&mut buf) {
-                        Ok(n) => { let _ = tx.send((n, buf)); }
-                        Err(_) => { let _ = tx.send((0, buf)); }
-                    }
-                }
-            });
-
-            // Wait up to 100ms for the read to complete
-            let bytes_read = match rx.recv_timeout(Duration::from_millis(100)) {
-                Ok((n, buf)) if n > 0 => {
-                    temp_buf[..n].copy_from_slice(&buf[..n]);
-                    n
-                }
-                Ok(_) | Err(_) => 0,
+        for iteration in 0..30 {  // 3 seconds total (30 * 100ms)
+            // Read from shared buffer
+            let current_buffer_size = {
+                let shared_buffer = local_shell.output_buffer.lock()
+                    .map_err(|_| "Buffer lock poisoned")?;
+                shared_buffer.len()
             };
 
+            let bytes_read = current_buffer_size - last_buffer_size;
+
             if bytes_read > 0 {
-                output_buffer.extend_from_slice(&temp_buf[..bytes_read]);
+                // Copy new data from shared buffer
+                let shared_buffer = local_shell.output_buffer.lock()
+                    .map_err(|_| "Buffer lock poisoned")?;
+                output_buffer.extend_from_slice(&shared_buffer[last_buffer_size..]);
+                drop(shared_buffer);
+
+                last_buffer_size = current_buffer_size;
 
                 // Truncate if buffer exceeds max size
                 if truncate_to_tail(&mut output_buffer, max_output_bytes) {
                     was_truncated = true;
                     shlog_trace!("Output buffer truncated to tail ({} bytes)", max_output_bytes);
                 }
+
+                let output_str = String::from_utf8_lossy(&output_buffer);
+                shlog_trace!(
+                    "SendInput: Read {} bytes (iteration {}), buffer size: {}, content: {:?}",
+                    bytes_read,
+                    iteration,
+                    output_buffer.len(),
+                    output_str
+                );
+            } else {
+                shlog_trace!("SendInput: No new data (iteration {}), buffer_size: {}", iteration, output_buffer.len());
             }
             std::thread::sleep(Duration::from_millis(100));
         }
+
+        shlog_trace!("SendInput: Finished reading, total output: {} bytes", output_buffer.len());
 
         // Check for prompt
         let output_str = String::from_utf8_lossy(&output_buffer).to_string();

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -56,7 +56,7 @@ mod local_shell {
     use super::*;
 
     pub struct LocalShellSession {
-        pub pair: Arc<Mutex<portable_pty::PtyPair>>,
+        pub pair: Arc<Mutex<Option<portable_pty::PtyPair>>>,
         pub reader: Arc<Mutex<Box<dyn Read + Send>>>,
         pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
         pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
@@ -89,17 +89,23 @@ mod local_shell {
                 }
             }
 
-            // Step 3: Replace the reader with empty reader to close the PTY file descriptor
-            // This is critical on Linux where killing the child might not close the PTY
-            {
-                if let Ok(mut reader) = self.reader.lock() {
-                    *reader = Box::new(std::io::empty()) as Box<dyn Read + Send>;
-                    shlog_trace!("Reader replaced with empty reader, PTY file descriptor should be closed");
+            // Step 3: CRITICAL - Drop the PTY pair to close file descriptors
+            // This MUST happen before we try to lock the reader, because:
+            // - The reader thread holds reader lock while blocked in read()
+            // - We can't get the lock while the thread is blocking
+            // - Dropping the pair closes the master PTY FD
+            // - This causes the blocking read() to return with EOF
+            // - Then the reader thread releases the lock and exits
+            if let Ok(mut pair_opt) = self.pair.lock() {
+                if let Some(pair) = pair_opt.take() {
+                    shlog_trace!("Dropping PTY pair to close file descriptors");
+                    drop(pair);
+                    shlog_trace!("PTY pair dropped");
                 }
             }
 
-            // Step 4: Wait for reader thread with timeout using thread handles
-            // This prevents hanging forever if something goes wrong
+            // Step 4: Wait for reader thread with timeout
+            // The thread should now exit quickly since the PTY FD is closed
             if let Ok(mut thread_opt) = self.reader_thread.lock() {
                 if let Some(thread) = thread_opt.take() {
                     shlog_trace!("Waiting for reader thread to finish");
@@ -120,7 +126,6 @@ mod local_shell {
                     } else {
                         shlog_error!("Reader thread did not finish within timeout, leaving it detached (thread leak)");
                         // Don't join - let it leak rather than hang forever
-                        // This is better than hanging the entire process
                     }
                 }
             }
@@ -543,7 +548,7 @@ impl BlockingShard for CreateShard {
 
         // Create LocalShellSession object
         let local_shell = LocalShellSession {
-            pair: Arc::new(Mutex::new(pair)),
+            pair: Arc::new(Mutex::new(Some(pair))),
             reader: reader_arc,
             writer: writer_arc,
             pending_interactive: Arc::new(Mutex::new(None)),

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -63,6 +63,7 @@ mod local_shell {
         pub is_alive: Arc<Mutex<bool>>,
         pub output_buffer: Arc<Mutex<Vec<u8>>>,
         pub reader_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+        pub child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
     }
 
     #[derive(Clone)]
@@ -74,22 +75,28 @@ mod local_shell {
         fn drop(&mut self) {
             shlog_trace!("Dropping LocalShellSession, cleaning up");
 
-            // Mark as not alive (this will signal the reader thread to exit)
+            // Mark as not alive (prevents new operations)
             if let Ok(mut is_alive) = self.is_alive.lock() {
                 *is_alive = false;
             }
 
+            // Kill the shell child process - this will close the PTY and wake up the reader thread
+            if let Ok(mut child_opt) = self.child.lock() {
+                if let Some(mut child) = child_opt.take() {
+                    shlog_trace!("Killing shell child process");
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+            }
+
+            // Now the reader thread should wake up (from EOF) and exit
             // Wait for reader thread to finish
             if let Ok(mut thread_opt) = self.reader_thread.lock() {
                 if let Some(thread) = thread_opt.take() {
                     shlog_trace!("Waiting for reader thread to finish");
                     let _ = thread.join();
+                    shlog_trace!("Reader thread joined successfully");
                 }
-            }
-
-            // Close writer to signal shell to exit
-            if let Ok(mut writer) = self.writer.lock() {
-                let _ = writer.flush();
             }
 
             shlog_trace!("LocalShellSession cleanup complete");
@@ -368,8 +375,8 @@ impl BlockingShard for CreateShard {
             }
         }
 
-        // Spawn the child process
-        let _child = pair
+        // Spawn the child process and store it for cleanup
+        let child = pair
             .slave
             .spawn_command(cmd)
             .map_err(|_| "Failed to spawn shell")?;
@@ -517,6 +524,7 @@ impl BlockingShard for CreateShard {
             is_alive,
             output_buffer,
             reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
+            child: Arc::new(Mutex::new(Some(child))),
         };
 
         let shell_var = Var::new_ref_counted(local_shell, &*LOCAL_SHELL_TYPE);

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -75,12 +75,12 @@ mod local_shell {
         fn drop(&mut self) {
             shlog_trace!("Dropping LocalShellSession, cleaning up");
 
-            // Mark as not alive (prevents new operations)
+            // Step 1: Mark as not alive (prevents new operations)
             if let Ok(mut is_alive) = self.is_alive.lock() {
                 *is_alive = false;
             }
 
-            // Kill the shell child process - this will close the PTY and wake up the reader thread
+            // Step 2: Kill the shell child process
             if let Ok(mut child_opt) = self.child.lock() {
                 if let Some(mut child) = child_opt.take() {
                     shlog_trace!("Killing shell child process");
@@ -89,13 +89,39 @@ mod local_shell {
                 }
             }
 
-            // Now the reader thread should wake up (from EOF) and exit
-            // Wait for reader thread to finish
+            // Step 3: Replace the reader with empty reader to close the PTY file descriptor
+            // This is critical on Linux where killing the child might not close the PTY
+            {
+                if let Ok(mut reader) = self.reader.lock() {
+                    *reader = Box::new(std::io::empty()) as Box<dyn Read + Send>;
+                    shlog_trace!("Reader replaced with empty reader, PTY file descriptor should be closed");
+                }
+            }
+
+            // Step 4: Wait for reader thread with timeout using thread handles
+            // This prevents hanging forever if something goes wrong
             if let Ok(mut thread_opt) = self.reader_thread.lock() {
                 if let Some(thread) = thread_opt.take() {
                     shlog_trace!("Waiting for reader thread to finish");
-                    let _ = thread.join();
-                    shlog_trace!("Reader thread joined successfully");
+
+                    // Give it 2 seconds to exit gracefully
+                    let mut finished = false;
+                    for _i in 0..20 {
+                        if thread.is_finished() {
+                            finished = true;
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+
+                    if finished {
+                        let _ = thread.join();
+                        shlog_trace!("Reader thread joined successfully");
+                    } else {
+                        shlog_error!("Reader thread did not finish within timeout, leaving it detached (thread leak)");
+                        // Don't join - let it leak rather than hang forever
+                        // This is better than hanging the entire process
+                    }
                 }
             }
 

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -37,6 +37,20 @@ use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Receiver, TryRecvError};
 use std::time::Duration;
 
+// Configuration constants
+// These match the SSH module's patterns and timeouts
+const INITIAL_PROMPT_WAIT_MS: u64 = 500;
+const INITIAL_PROMPT_MAX_RETRIES: usize = 10;
+const READER_THREAD_TIMEOUT_MS: u64 = 50;
+const COMMAND_OUTPUT_WAIT_MS: u64 = 200;
+const COMMAND_MAX_ITERATIONS: usize = 50;
+const INTERACTIVE_DETECTION_ITERATIONS: usize = 20; // 20 * 100ms = 2 seconds
+const ITERATION_SLEEP_MS: u64 = 100;
+const SENDINPUT_INITIAL_WAIT_MS: u64 = 500;
+const SENDINPUT_MAX_ITERATIONS: usize = 30;
+const MAX_BUFFER_BYTES: usize = 65536; // 64KB default, matches SSH module
+const BUFFER_TRUNCATE_KEEP_RATIO: usize = 93; // Keep 93% on truncation to avoid repeated truncation
+
 // LocalShell session object wrapper
 mod local_shell {
     use super::*;
@@ -301,12 +315,12 @@ impl BlockingShard for CreateShard {
         let writer_arc = Arc::new(Mutex::new(writer));
 
         // Wait for initial prompt
-        std::thread::sleep(Duration::from_millis(500));
+        std::thread::sleep(Duration::from_millis(INITIAL_PROMPT_WAIT_MS));
 
         let mut output_buffer = Vec::new();
         let mut temp_buf = [0u8; 4096];
 
-        for _ in 0..10 {
+        for _ in 0..INITIAL_PROMPT_MAX_RETRIES {
             let (tx, rx) = channel();
             let reader_clone = Arc::clone(&reader_arc);
 
@@ -320,7 +334,7 @@ impl BlockingShard for CreateShard {
                 }
             });
 
-            match rx.recv_timeout(Duration::from_millis(100)) {
+            match rx.recv_timeout(Duration::from_millis(ITERATION_SLEEP_MS)) {
                 Ok((n, buf)) if n > 0 => {
                     output_buffer.extend_from_slice(&buf[..n]);
                     let output_str = String::from_utf8_lossy(&output_buffer);
@@ -330,7 +344,7 @@ impl BlockingShard for CreateShard {
                 }
                 _ => {}
             }
-            std::thread::sleep(Duration::from_millis(100));
+            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
         }
 
         shlog_trace!("Shell ready");
@@ -356,37 +370,68 @@ impl BlockingShard for CreateShard {
                         shlog_trace!("Reader thread exiting");
                         break;
                     }
+                    Err(e) => {
+                        shlog_trace!("Reader thread: alive lock poisoned: {}", e);
+                        break;
+                    }
                     _ => {}
                 }
 
                 // Read from PTY (this will block until data is available)
-                if let Ok(mut reader) = reader_clone.lock() {
-                    match reader.read(&mut buf) {
-                        Ok(n) if n > 0 => {
-                            // Append to shared buffer
-                            if let Ok(mut buffer) = buffer_clone.lock() {
-                                buffer.extend_from_slice(&buf[..n]);
-                                shlog_trace!("Reader thread: read {} bytes, buffer now {} bytes", n, buffer.len());
+                match reader_clone.lock() {
+                    Ok(mut reader) => {
+                        match reader.read(&mut buf) {
+                            Ok(n) if n > 0 => {
+                                // Append to shared buffer with truncation
+                                match buffer_clone.lock() {
+                                    Ok(mut buffer) => {
+                                        buffer.extend_from_slice(&buf[..n]);
+
+                                        // Truncate buffer if it exceeds max size
+                                        if buffer.len() > MAX_BUFFER_BYTES {
+                                            if truncate_to_tail(&mut buffer, MAX_BUFFER_BYTES) {
+                                                shlog_trace!("Reader thread: buffer truncated to {} bytes", buffer.len());
+                                            }
+                                        }
+
+                                        shlog_trace!("Reader thread: read {} bytes, buffer now {} bytes", n, buffer.len());
+                                    }
+                                    Err(e) => {
+                                        shlog_trace!("Reader thread: buffer lock poisoned: {}", e);
+                                        break;
+                                    }
+                                }
                             }
-                        }
-                        Ok(_) => {
-                            // EOF - process died
-                            if let Ok(mut alive) = alive_clone.lock() {
-                                *alive = false;
+                            Ok(_) => {
+                                // EOF - process died
+                                match alive_clone.lock() {
+                                    Ok(mut alive) => {
+                                        *alive = false;
+                                    }
+                                    Err(e) => {
+                                        shlog_trace!("Reader thread: alive lock poisoned on EOF: {}", e);
+                                    }
+                                }
+                                break;
                             }
-                            break;
-                        }
-                        Err(e) => {
-                            shlog_trace!("Reader thread: read error: {}", e);
-                            if let Ok(mut alive) = alive_clone.lock() {
-                                *alive = false;
+                            Err(e) => {
+                                shlog_trace!("Reader thread: read error: {}", e);
+                                match alive_clone.lock() {
+                                    Ok(mut alive) => {
+                                        *alive = false;
+                                    }
+                                    Err(e) => {
+                                        shlog_trace!("Reader thread: alive lock poisoned on error: {}", e);
+                                    }
+                                }
+                                break;
                             }
-                            break;
                         }
                     }
-                } else {
-                    // Failed to lock reader
-                    break;
+                    Err(e) => {
+                        shlog_trace!("Reader thread: reader lock poisoned: {}", e);
+                        break;
+                    }
                 }
             }
             shlog_trace!("Reader thread finished");
@@ -425,6 +470,10 @@ pub struct ExecuteShard {
     #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
     session: ParamVar,
 
+    // NOTE: Timeout parameter is declared for API compatibility with SSH module
+    // but is not currently used in the implementation. Actual timeout is hardcoded
+    // to COMMAND_MAX_ITERATIONS * ITERATION_SLEEP_MS (5 seconds).
+    // TODO: Implement actual timeout logic using this parameter.
     #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
     timeout_secs: ParamVar,
 
@@ -512,31 +561,20 @@ impl BlockingShard for ExecuteShard {
                 shlog_trace!("New command received while interactive command was pending, sending Ctrl+C");
 
                 // Send Ctrl+C to cancel the interactive command
+                // Writer lock is released immediately after write to avoid blocking
                 {
                     let mut writer = local_shell.writer.lock()
                         .map_err(|_| "Writer lock poisoned")?;
                     let _ = writer.write_all(&[3]);
                     let _ = writer.flush();
-                }
+                } // Writer lock released here
 
                 // Give the shell time to process Ctrl+C
+                // Any response will be read by the reader thread into the shared buffer
                 std::thread::sleep(Duration::from_millis(300));
 
-                // Drain any Ctrl+C response
-                {
-                    let mut reader = local_shell.reader.lock()
-                        .map_err(|_| "Reader lock poisoned")?;
-                    let mut drain_buf = [0u8; 4096];
-                    for _ in 0..5 {
-                        match reader.read(&mut drain_buf) {
-                            Ok(n) if n > 0 => {
-                                shlog_trace!("Drained {} bytes after Ctrl+C", n);
-                            }
-                            _ => break,
-                        }
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-                }
+                // Note: We don't need to drain the response - the shared buffer will be
+                // cleared before the next command anyway, and the reader thread handles all reads
 
                 *pending = None;
             }
@@ -556,25 +594,24 @@ impl BlockingShard for ExecuteShard {
             let mut writer = local_shell.writer.lock()
                 .map_err(|_| "Writer lock poisoned")?;
             writer.write_all(cmd_with_newline.as_bytes())
-                .map_err(|_| "Failed to write command")?;
+                .map_err(|_| "Failed to write command to shell (IO error)")?;
             writer.flush()
-                .map_err(|_| "Failed to flush writer")?;
+                .map_err(|_| "Failed to flush command writer (IO error)")?;
         }
 
         // Read output from shared buffer with timeout-based prompt detection
         let mut output_buffer = Vec::new();
         let mut last_buffer_size = 0;
         let mut no_data_count = 0;
-        let max_iterations = 50; // 5 seconds total (50 * 100ms)
         let mut prompt_detected = false;
         let mut was_truncated = false;
 
         shlog_trace!("Starting to read command output from shared buffer");
 
         // Give shell time to process command
-        std::thread::sleep(Duration::from_millis(200));
+        std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
 
-        for iteration in 0..max_iterations {
+        for iteration in 0..COMMAND_MAX_ITERATIONS {
             // Read from shared buffer
             let current_buffer_size = {
                 let shared_buffer = local_shell.output_buffer.lock()
@@ -626,7 +663,7 @@ impl BlockingShard for ExecuteShard {
                 );
 
                 // Only consider interactive if we have output AND consistent no-data period
-                if no_data_count >= 20 && !output_buffer.is_empty() && iteration >= 10 {
+                if no_data_count >= INTERACTIVE_DETECTION_ITERATIONS && !output_buffer.is_empty() && iteration >= INTERACTIVE_DETECTION_ITERATIONS / 2 {
                     // Check one more time if there's a prompt we might have missed
                     let output_str = String::from_utf8_lossy(&output_buffer);
                     if is_prompt(&output_str) {
@@ -639,7 +676,7 @@ impl BlockingShard for ExecuteShard {
                     break;
                 }
             }
-            std::thread::sleep(Duration::from_millis(100));
+            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
         }
 
         // Determine status and prepare output
@@ -707,6 +744,10 @@ pub struct SendInputShard {
     #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
     session: ParamVar,
 
+    // NOTE: Timeout parameter is declared for API compatibility with SSH module
+    // but is not currently used in the implementation. Actual timeout is hardcoded
+    // to SENDINPUT_MAX_ITERATIONS * ITERATION_SLEEP_MS (3 seconds).
+    // TODO: Implement actual timeout logic using this parameter.
     #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
     timeout_secs: ParamVar,
 
@@ -804,14 +845,14 @@ impl BlockingShard for SendInputShard {
             let mut writer = local_shell.writer.lock()
                 .map_err(|_| "Writer lock poisoned")?;
             writer.write_all(input_with_newline.as_bytes())
-                .map_err(|_| "Failed to write input")?;
+                .map_err(|_| "Failed to write input to interactive command (IO error)")?;
             writer.flush()
-                .map_err(|_| "Failed to flush writer")?;
+                .map_err(|_| "Failed to flush input writer (IO error)")?;
             shlog_trace!("SendInput: Write and flush succeeded");
         }
 
         // Wait for output - give shell time to process input
-        std::thread::sleep(Duration::from_millis(500));
+        std::thread::sleep(Duration::from_millis(SENDINPUT_INITIAL_WAIT_MS));
         shlog_trace!("SendInput: Starting to read output after input (starting from byte {})", start_buffer_size);
 
         // Read output from shared buffer
@@ -819,7 +860,7 @@ impl BlockingShard for SendInputShard {
         let mut last_buffer_size = start_buffer_size;
         let mut was_truncated = false;
 
-        for iteration in 0..30 {  // 3 seconds total (30 * 100ms)
+        for iteration in 0..SENDINPUT_MAX_ITERATIONS {
             // Read from shared buffer
             let current_buffer_size = {
                 let shared_buffer = local_shell.output_buffer.lock()
@@ -855,7 +896,7 @@ impl BlockingShard for SendInputShard {
             } else {
                 shlog_trace!("SendInput: No new data (iteration {}), buffer_size: {}", iteration, output_buffer.len());
             }
-            std::thread::sleep(Duration::from_millis(100));
+            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
         }
 
         shlog_trace!("SendInput: Finished reading, total output: {} bytes", output_buffer.len());

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -1,0 +1,936 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2025 Fragcolor Pte. Ltd. */
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate shards;
+
+#[macro_use]
+extern crate lazy_static;
+
+use shards::core::register_shard;
+use shards::core::run_blocking;
+use shards::core::BlockingShard;
+use shards::fourCharacterCode;
+use shards::shard::Shard;
+use shards::types::common_type;
+use shards::types::AutoTableVar;
+use shards::types::ClonedVar;
+use shards::types::Context;
+use shards::types::ExposedTypes;
+use shards::types::InstanceData;
+use shards::types::ParamVar;
+use shards::types::Type;
+use shards::types::Types;
+use shards::types::Var;
+use shards::types::FRAG_CC;
+use shards::types::STRING_TYPES;
+use shards::types::NONE_TYPES;
+use shards::types::BOOL_TYPES;
+
+use portable_pty::{CommandBuilder, PtySize, PtySystem};
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+// LocalShell session object wrapper
+mod local_shell {
+    use super::*;
+
+    pub struct LocalShellSession {
+        pub pair: Arc<Mutex<portable_pty::PtyPair>>,
+        pub reader: Arc<Mutex<Box<dyn Read + Send>>>,
+        pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
+        pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
+        pub is_alive: Arc<Mutex<bool>>,
+    }
+
+    #[derive(Clone)]
+    pub struct InteractiveState {
+        pub original_cmd: String,
+    }
+
+    impl Drop for LocalShellSession {
+        fn drop(&mut self) {
+            shlog_trace!("Dropping LocalShellSession, cleaning up");
+
+            // Mark as not alive
+            if let Ok(mut is_alive) = self.is_alive.lock() {
+                *is_alive = false;
+            }
+
+            // Close writer to signal shell to exit
+            if let Ok(mut writer) = self.writer.lock() {
+                let _ = writer.flush();
+            }
+
+            shlog_trace!("LocalShellSession cleanup complete");
+        }
+    }
+
+    ref_counted_object_type_impl!(LocalShellSession);
+}
+
+use local_shell::*;
+
+lazy_static! {
+    static ref LOCAL_SHELL_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"lshl"));
+    static ref LOCAL_SHELL_TYPE_VEC: Vec<Type> = vec![*LOCAL_SHELL_TYPE];
+    static ref LOCAL_SHELL_VAR_TYPE: Type = Type::context_variable(&LOCAL_SHELL_TYPE_VEC);
+    static ref EXECUTE_OUTPUT_TYPES: Vec<Type> = vec![common_type::string_table];
+}
+
+// Helper function to detect shell prompts (NOT interactive program prompts)
+// Reused from SSH module
+fn is_prompt(text: &str) -> bool {
+    // Strip ANSI codes first before checking for prompt
+    let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
+    let cleaned = String::from_utf8_lossy(&stripped_bytes);
+
+    let lines: Vec<&str> = cleaned.lines().collect();
+    if let Some(last) = lines.last() {
+        let trimmed = last.trim();
+
+        // Exclude interactive program prompts like >>> (Python), >> (continuation)
+        // These indicate we're IN a program, not at the shell
+        if trimmed.ends_with(">>>") || trimmed.ends_with(">>") {
+            return false;
+        }
+
+        // Check for common SHELL prompt patterns only
+        trimmed.ends_with("$ ")
+            || trimmed.ends_with("$")
+            || trimmed.ends_with("# ")
+            || trimmed.ends_with("#")
+            || trimmed.ends_with("> ")  // Windows/PowerShell prompt
+            || trimmed.ends_with(">")   // Single > is OK (but not >> or >>>)
+            || trimmed.ends_with("% ")  // zsh prompt
+            || trimmed.ends_with("%")   // zsh prompt
+    } else {
+        false
+    }
+}
+
+// Helper function to clean output (remove ANSI codes, control chars, and trailing prompts)
+// Reused from SSH module
+fn clean_output(output: &str) -> String {
+    // Strip ANSI escape sequences
+    let stripped_bytes = strip_ansi_escapes::strip(output);
+    let text = String::from_utf8_lossy(&stripped_bytes);
+
+    // Remove control characters (except newlines and tabs)
+    let no_control: String = text.chars()
+        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+        .collect();
+
+    let mut lines: Vec<&str> = no_control.lines().collect();
+
+    // Remove trailing prompt if present
+    if !lines.is_empty() {
+        let last_line = lines.last().unwrap();
+        if is_prompt(last_line) {
+            lines.pop();
+        }
+    }
+
+    // Join lines and trim
+    let result = lines.join("\n");
+    result.trim().to_string()
+}
+
+// Helper function to truncate output buffer to keep tail
+// Reused from SSH module
+fn truncate_to_tail(buffer: &mut Vec<u8>, max_bytes: usize) -> bool {
+    if buffer.len() <= max_bytes {
+        return false;
+    }
+
+    // Keep last ~93% of max_bytes to avoid repeated truncation on every read
+    let keep_bytes = (max_bytes * 93) / 100;
+    let truncate_msg = b"[... output truncated ...]\n";
+
+    // Remove from the front, keep the tail
+    let skip = buffer.len() - keep_bytes + truncate_msg.len();
+    let tail: Vec<u8> = buffer.drain(skip..).collect();
+    buffer.clear();
+    buffer.extend_from_slice(truncate_msg);
+    buffer.extend_from_slice(&tail);
+
+    true
+}
+
+// ============================================================================
+// LocalShell.Create Shard
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info("LocalShell.Create", "Create a persistent local shell session")]
+pub struct CreateShard {
+    #[shard_required]
+    required: ExposedTypes,
+
+    #[shard_param("Shell", "Shell to use (default: /bin/bash on Unix, cmd.exe on Windows)", [common_type::string, common_type::string_var, common_type::none])]
+    shell: ParamVar,
+
+    #[shard_param("WorkingDirectory", "Initial working directory (default: current directory)", [common_type::string, common_type::string_var, common_type::none])]
+    working_dir: ParamVar,
+
+    output: ClonedVar,
+}
+
+impl Default for CreateShard {
+    fn default() -> Self {
+        Self {
+            required: ExposedTypes::new(),
+            shell: ParamVar::new(Var::default()),
+            working_dir: ParamVar::new(Var::default()),
+            output: ClonedVar::default(),
+        }
+    }
+}
+
+#[shards::shard_impl]
+impl Shard for CreateShard {
+    fn input_types(&mut self) -> &Types {
+        &NONE_TYPES
+    }
+
+    fn output_types(&mut self) -> &Types {
+        &LOCAL_SHELL_TYPE_VEC
+    }
+
+    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+        self.warmup_helper(ctx)?;
+        Ok(())
+    }
+
+    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+        self.cleanup_helper(ctx)?;
+        self.output = ClonedVar::default();
+        Ok(())
+    }
+
+    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+        self.compose_helper(data)?;
+        Ok(self.output_types()[0])
+    }
+
+    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+        Ok(Some(run_blocking(self, context, input)))
+    }
+}
+
+impl BlockingShard for CreateShard {
+    fn activate_blocking(&mut self, _context: &Context, _input: &Var) -> Result<Var, &'static str> {
+        let shell_var = self.shell.get();
+        let working_dir_var = self.working_dir.get();
+
+        // Get PTY system
+        let pty_system = portable_pty::native_pty_system();
+
+        // Determine shell command
+        let shell_cmd = if !shell_var.is_none() {
+            let shell_path: &str = shell_var.as_ref().try_into()?;
+            shell_path.to_string()
+        } else {
+            // Default shell based on platform
+            #[cfg(unix)]
+            let default_shell = "/bin/bash";
+            #[cfg(windows)]
+            let default_shell = "cmd.exe";
+
+            default_shell.to_string()
+        };
+
+        shlog_trace!("Creating local shell with: {}", shell_cmd);
+
+        // Create PTY pair
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|_| "Failed to open PTY")?;
+
+        // Set up command
+        let mut cmd = CommandBuilder::new(&shell_cmd);
+
+        // Set working directory if specified
+        if !working_dir_var.is_none() {
+            let wd: &str = working_dir_var.as_ref().try_into()?;
+            cmd.cwd(wd);
+        }
+
+        // For bash, use --login to get environment and -i for interactive mode
+        #[cfg(unix)]
+        if shell_cmd.contains("bash") {
+            cmd.arg("--login");
+            cmd.arg("-i");
+        }
+
+        // Spawn the child process
+        let _child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|_| "Failed to spawn shell")?;
+
+        // Get reader and writer
+        let reader = pair.master.try_clone_reader()
+            .map_err(|_| "Failed to clone reader")?;
+        let writer = pair.master.take_writer()
+            .map_err(|_| "Failed to take writer")?;
+
+        // Wrap in Arc<Mutex<>> for shared access
+        let reader_arc = Arc::new(Mutex::new(reader));
+        let writer_arc = Arc::new(Mutex::new(writer));
+
+        // Wait for initial prompt
+        std::thread::sleep(Duration::from_millis(500));
+
+        let mut output_buffer = Vec::new();
+        let mut temp_buf = [0u8; 4096];
+
+        for _ in 0..10 {
+            let mut reader_lock = reader_arc.lock()
+                .map_err(|_| "Reader lock poisoned")?;
+
+            // Try to read without blocking too long
+            match reader_lock.read(&mut temp_buf) {
+                Ok(n) if n > 0 => {
+                    output_buffer.extend_from_slice(&temp_buf[..n]);
+                    let output_str = String::from_utf8_lossy(&output_buffer);
+                    if is_prompt(&output_str) {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            drop(reader_lock);
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        shlog_trace!("Shell ready, disabling echo");
+
+        // Disable echo for cleaner output (Unix only)
+        #[cfg(unix)]
+        {
+            let mut writer_lock = writer_arc.lock()
+                .map_err(|_| "Writer lock poisoned")?;
+            let _ = writer_lock.write_all(b"stty -echo\n");
+            let _ = writer_lock.flush();
+            drop(writer_lock);
+
+            // Drain the command output
+            std::thread::sleep(Duration::from_millis(300));
+            output_buffer.clear();
+            for _ in 0..10 {
+                let mut reader_lock = reader_arc.lock()
+                    .map_err(|_| "Reader lock poisoned")?;
+                match reader_lock.read(&mut temp_buf) {
+                    Ok(n) if n > 0 => {
+                        output_buffer.extend_from_slice(&temp_buf[..n]);
+                        let output_str = String::from_utf8_lossy(&output_buffer);
+                        if is_prompt(&output_str) {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                drop(reader_lock);
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+
+        shlog_trace!("Local shell created successfully");
+
+        // Create LocalShellSession object
+        let local_shell = LocalShellSession {
+            pair: Arc::new(Mutex::new(pair)),
+            reader: reader_arc,
+            writer: writer_arc,
+            pending_interactive: Arc::new(Mutex::new(None)),
+            is_alive: Arc::new(Mutex::new(true)),
+        };
+
+        let shell_var = Var::new_ref_counted(local_shell, &*LOCAL_SHELL_TYPE);
+        self.output = shell_var.into();
+        Ok(self.output.0)
+    }
+}
+
+// ============================================================================
+// LocalShell.Execute Shard
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info(
+    "LocalShell.Execute",
+    "Execute a command in the persistent local shell session"
+)]
+pub struct ExecuteShard {
+    #[shard_required]
+    required: ExposedTypes,
+
+    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+    session: ParamVar,
+
+    #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
+    timeout_secs: ParamVar,
+
+    #[shard_param("CleanOutput", "Clean ANSI codes and prompts from output (default: true)", [common_type::bool, common_type::bool_var])]
+    clean_output: ParamVar,
+
+    #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
+    max_output_bytes: ParamVar,
+
+    output: ClonedVar,
+}
+
+impl Default for ExecuteShard {
+    fn default() -> Self {
+        Self {
+            required: ExposedTypes::new(),
+            session: ParamVar::default(),
+            timeout_secs: ParamVar::new(30i64.into()),
+            clean_output: ParamVar::new(true.into()),
+            max_output_bytes: ParamVar::new(65536i64.into()),
+            output: ClonedVar::default(),
+        }
+    }
+}
+
+#[shards::shard_impl]
+impl Shard for ExecuteShard {
+    fn input_types(&mut self) -> &Types {
+        &STRING_TYPES
+    }
+
+    fn output_types(&mut self) -> &Types {
+        &EXECUTE_OUTPUT_TYPES
+    }
+
+    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+        self.warmup_helper(ctx)?;
+        Ok(())
+    }
+
+    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+        self.cleanup_helper(ctx)?;
+        self.output = ClonedVar::default();
+        Ok(())
+    }
+
+    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+        self.compose_helper(data)?;
+        Ok(self.output_types()[0])
+    }
+
+    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+        Ok(Some(run_blocking(self, context, input)))
+    }
+}
+
+impl BlockingShard for ExecuteShard {
+    fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
+        let cmd: &str = input.try_into()?;
+        let session_var = *self.session.get();
+        let should_clean: bool = self.clean_output.get().as_ref().try_into()?;
+        let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
+        let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
+
+        // Extract local shell object
+        let local_shell = unsafe {
+            Var::from_ref_counted_object::<LocalShellSession>(&session_var, &*LOCAL_SHELL_TYPE)?
+        };
+        let local_shell = unsafe { &*(local_shell as *const LocalShellSession) };
+
+        // Check if shell is still alive
+        {
+            let is_alive = local_shell.is_alive.lock()
+                .map_err(|_| "Alive state lock poisoned")?;
+            if !*is_alive {
+                return Err("Local shell process has exited");
+            }
+        }
+
+        // Check if there's a pending interactive command
+        {
+            let mut pending = local_shell.pending_interactive.lock()
+                .map_err(|_| "Interactive state lock poisoned")?;
+            if pending.is_some() {
+                shlog_trace!("New command received while interactive command was pending, sending Ctrl+C");
+
+                // Send Ctrl+C to cancel the interactive command
+                {
+                    let mut writer = local_shell.writer.lock()
+                        .map_err(|_| "Writer lock poisoned")?;
+                    let _ = writer.write_all(&[3]);
+                    let _ = writer.flush();
+                }
+
+                // Give the shell time to process Ctrl+C
+                std::thread::sleep(Duration::from_millis(300));
+
+                // Drain any Ctrl+C response
+                {
+                    let mut reader = local_shell.reader.lock()
+                        .map_err(|_| "Reader lock poisoned")?;
+                    let mut drain_buf = [0u8; 4096];
+                    for _ in 0..5 {
+                        match reader.read(&mut drain_buf) {
+                            Ok(n) if n > 0 => {
+                                shlog_trace!("Drained {} bytes after Ctrl+C", n);
+                            }
+                            _ => break,
+                        }
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                }
+
+                *pending = None;
+            }
+        }
+
+        // Send command
+        let cmd_with_newline = format!("{}\n", cmd);
+        {
+            let mut writer = local_shell.writer.lock()
+                .map_err(|_| "Writer lock poisoned")?;
+            writer.write_all(cmd_with_newline.as_bytes())
+                .map_err(|_| "Failed to write command")?;
+            writer.flush()
+                .map_err(|_| "Failed to flush writer")?;
+        }
+
+        // Read output with timeout-based prompt detection
+        let mut output_buffer = Vec::new();
+        let mut temp_buf = [0u8; 4096];
+        let mut no_data_count = 0;
+        let max_iterations = 50; // 5 seconds total (50 * 100ms)
+        let mut prompt_detected = false;
+        let mut was_truncated = false;
+
+        shlog_trace!("Starting to read command output");
+
+        // Give shell time to process command
+        std::thread::sleep(Duration::from_millis(200));
+
+        for iteration in 0..max_iterations {
+            let bytes_read = {
+                let mut reader = local_shell.reader.lock()
+                    .map_err(|_| "Reader lock poisoned")?;
+
+                match reader.read(&mut temp_buf) {
+                    Ok(n) => n,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock
+                           || e.kind() == std::io::ErrorKind::TimedOut => 0,
+                    Err(_) => {
+                        // Process might have died
+                        *local_shell.is_alive.lock()
+                            .map_err(|_| "Alive state lock poisoned")? = false;
+
+                        let mut result_table = AutoTableVar::new();
+                        result_table.0.insert_fast_static("status", &Var::ephemeral_string("process_died"));
+                        result_table.0.insert_fast_static("output", &Var::ephemeral_string(""));
+                        result_table.0.insert_fast_static("message", &Var::ephemeral_string("Shell process exited"));
+                        self.output = result_table.to_cloned();
+                        return Ok(self.output.0);
+                    }
+                }
+            };
+
+            if bytes_read > 0 {
+                output_buffer.extend_from_slice(&temp_buf[..bytes_read]);
+
+                // Truncate if buffer exceeds max size
+                if truncate_to_tail(&mut output_buffer, max_output_bytes) {
+                    was_truncated = true;
+                    shlog_trace!("Output buffer truncated to tail ({} bytes)", max_output_bytes);
+                }
+
+                let output_str = String::from_utf8_lossy(&output_buffer);
+
+                shlog_trace!(
+                    "Read {} bytes (iteration {}), buffer size: {}, last line: {:?}",
+                    bytes_read,
+                    iteration,
+                    output_buffer.len(),
+                    output_str.lines().last()
+                );
+
+                // Check for prompt
+                if is_prompt(&output_str) {
+                    prompt_detected = true;
+                    shlog_trace!("Prompt detected in output, command completed");
+                    break;
+                }
+                no_data_count = 0;
+            } else {
+                no_data_count += 1;
+                shlog_trace!(
+                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}",
+                    iteration,
+                    no_data_count,
+                    output_buffer.is_empty()
+                );
+
+                // Only consider interactive if we have output AND consistent no-data period
+                if no_data_count >= 20 && !output_buffer.is_empty() && iteration >= 10 {
+                    // Check one more time if there's a prompt we might have missed
+                    let output_str = String::from_utf8_lossy(&output_buffer);
+                    if is_prompt(&output_str) {
+                        prompt_detected = true;
+                        shlog_trace!("Prompt detected on final check");
+                        break;
+                    }
+                    // No output for 2 seconds after having received some data, likely interactive
+                    shlog_trace!("Command appears to be interactive (no new data for 2s)");
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        // Determine status and prepare output
+        let mut result_table = AutoTableVar::new();
+        let output_str = String::from_utf8_lossy(&output_buffer).to_string();
+
+        if prompt_detected {
+            // Command completed normally
+            let final_output = if should_clean {
+                clean_output(&output_str)
+            } else {
+                output_str
+            };
+
+            result_table.0.insert_fast_static("status", &Var::ephemeral_string("completed"));
+            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
+            if was_truncated {
+                result_table.0.insert_fast_static("truncated", &true.into());
+            }
+        } else {
+            // Command is interactive (waiting for input)
+            {
+                let mut pending = local_shell.pending_interactive.lock()
+                    .map_err(|_| "Interactive state lock poisoned")?;
+                *pending = Some(InteractiveState {
+                    original_cmd: cmd.to_string(),
+                });
+            }
+
+            let partial_output = if should_clean {
+                clean_output(&output_str)
+            } else {
+                output_str
+            };
+
+            result_table.0.insert_fast_static("status", &Var::ephemeral_string("requires_interaction"));
+            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&partial_output));
+            result_table.0.insert_fast_static(
+                "message",
+                &Var::ephemeral_string("Command is waiting for input. Use LocalShell.SendInput to interact.")
+            );
+            if was_truncated {
+                result_table.0.insert_fast_static("truncated", &true.into());
+            }
+        }
+
+        self.output = result_table.to_cloned();
+        Ok(self.output.0)
+    }
+}
+
+// ============================================================================
+// LocalShell.SendInput Shard
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info(
+    "LocalShell.SendInput",
+    "Send input to an interactive local shell command"
+)]
+pub struct SendInputShard {
+    #[shard_required]
+    required: ExposedTypes,
+
+    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+    session: ParamVar,
+
+    #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
+    timeout_secs: ParamVar,
+
+    #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
+    max_output_bytes: ParamVar,
+
+    output: ClonedVar,
+}
+
+impl Default for SendInputShard {
+    fn default() -> Self {
+        Self {
+            required: ExposedTypes::new(),
+            session: ParamVar::default(),
+            timeout_secs: ParamVar::new(10i64.into()),
+            max_output_bytes: ParamVar::new(65536i64.into()),
+            output: ClonedVar::default(),
+        }
+    }
+}
+
+#[shards::shard_impl]
+impl Shard for SendInputShard {
+    fn input_types(&mut self) -> &Types {
+        &STRING_TYPES
+    }
+
+    fn output_types(&mut self) -> &Types {
+        &EXECUTE_OUTPUT_TYPES
+    }
+
+    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+        self.warmup_helper(ctx)?;
+        Ok(())
+    }
+
+    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+        self.cleanup_helper(ctx)?;
+        self.output = ClonedVar::default();
+        Ok(())
+    }
+
+    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+        self.compose_helper(data)?;
+        Ok(self.output_types()[0])
+    }
+
+    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+        Ok(Some(run_blocking(self, context, input)))
+    }
+}
+
+impl BlockingShard for SendInputShard {
+    fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
+        let input_str: &str = input.try_into()?;
+        let session_var = *self.session.get();
+        let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
+        let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
+
+        // Extract local shell object
+        let local_shell = unsafe {
+            Var::from_ref_counted_object::<LocalShellSession>(&session_var, &*LOCAL_SHELL_TYPE)?
+        };
+        let local_shell = unsafe { &*(local_shell as *const LocalShellSession) };
+
+        // Check if shell is still alive
+        {
+            let is_alive = local_shell.is_alive.lock()
+                .map_err(|_| "Alive state lock poisoned")?;
+            if !*is_alive {
+                return Err("Local shell process has exited");
+            }
+        }
+
+        // Check if there's a pending interactive command
+        {
+            let pending = local_shell.pending_interactive.lock()
+                .map_err(|_| "Interactive state lock poisoned")?;
+            if pending.is_none() {
+                return Err("No interactive command is pending");
+            }
+        }
+
+        // Send input (if not empty)
+        if !input_str.is_empty() {
+            let input_with_newline = format!("{}\n", input_str);
+            let mut writer = local_shell.writer.lock()
+                .map_err(|_| "Writer lock poisoned")?;
+            writer.write_all(input_with_newline.as_bytes())
+                .map_err(|_| "Failed to write input")?;
+            writer.flush()
+                .map_err(|_| "Failed to flush writer")?;
+        }
+
+        // Wait for output
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Read output
+        let mut output_buffer = Vec::new();
+        let mut temp_buf = [0u8; 4096];
+        let mut was_truncated = false;
+
+        for _ in 0..10 {
+            let bytes_read = {
+                let mut reader = local_shell.reader.lock()
+                    .map_err(|_| "Reader lock poisoned")?;
+
+                match reader.read(&mut temp_buf) {
+                    Ok(n) => n,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock
+                           || e.kind() == std::io::ErrorKind::TimedOut => 0,
+                    Err(_) => {
+                        // Process might have died
+                        *local_shell.is_alive.lock()
+                            .map_err(|_| "Alive state lock poisoned")? = false;
+
+                        let mut result_table = AutoTableVar::new();
+                        result_table.0.insert_fast_static("status", &Var::ephemeral_string("process_died"));
+                        result_table.0.insert_fast_static("output", &Var::ephemeral_string(""));
+                        result_table.0.insert_fast_static("message", &Var::ephemeral_string("Shell process exited"));
+                        self.output = result_table.to_cloned();
+                        return Ok(self.output.0);
+                    }
+                }
+            };
+
+            if bytes_read > 0 {
+                output_buffer.extend_from_slice(&temp_buf[..bytes_read]);
+
+                // Truncate if buffer exceeds max size
+                if truncate_to_tail(&mut output_buffer, max_output_bytes) {
+                    was_truncated = true;
+                    shlog_trace!("Output buffer truncated to tail ({} bytes)", max_output_bytes);
+                }
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        // Check for prompt
+        let output_str = String::from_utf8_lossy(&output_buffer).to_string();
+        let prompt_detected = is_prompt(&output_str);
+
+        // Clean output
+        let stripped_bytes = strip_ansi_escapes::strip(&output_str);
+        let cleaned = String::from_utf8_lossy(&stripped_bytes);
+        let mut lines: Vec<&str> = cleaned.lines().collect();
+        if prompt_detected && !lines.is_empty() {
+            lines.pop(); // Remove prompt line
+        }
+        let final_output = lines.join("\n");
+
+        let mut result_table = AutoTableVar::new();
+
+        if prompt_detected {
+            // Interactive session completed
+            {
+                let mut pending = local_shell.pending_interactive.lock()
+                    .map_err(|_| "Interactive state lock poisoned")?;
+                *pending = None;
+            }
+            shlog_trace!("Interactive session completed");
+            result_table.0.insert_fast_static("status", &Var::ephemeral_string("completed"));
+            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
+            if was_truncated {
+                result_table.0.insert_fast_static("truncated", &true.into());
+            }
+        } else {
+            // Still waiting for more input/output
+            result_table.0.insert_fast_static("status", &Var::ephemeral_string("pending_output"));
+            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
+            result_table.0.insert_fast_static(
+                "message",
+                &Var::ephemeral_string("Command still running. Use LocalShell.SendInput to continue.")
+            );
+            if was_truncated {
+                result_table.0.insert_fast_static("truncated", &true.into());
+            }
+        }
+
+        self.output = result_table.to_cloned();
+        Ok(self.output.0)
+    }
+}
+
+// ============================================================================
+// LocalShell.IsAlive Shard
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info(
+    "LocalShell.IsAlive",
+    "Check if local shell session is still alive"
+)]
+pub struct IsAliveShard {
+    #[shard_required]
+    required: ExposedTypes,
+
+    output: ClonedVar,
+}
+
+impl Default for IsAliveShard {
+    fn default() -> Self {
+        Self {
+            required: ExposedTypes::new(),
+            output: ClonedVar::default(),
+        }
+    }
+}
+
+#[shards::shard_impl]
+impl Shard for IsAliveShard {
+    fn input_types(&mut self) -> &Types {
+        &LOCAL_SHELL_TYPE_VEC
+    }
+
+    fn output_types(&mut self) -> &Types {
+        &BOOL_TYPES
+    }
+
+    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+        self.warmup_helper(ctx)?;
+        Ok(())
+    }
+
+    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+        self.cleanup_helper(ctx)?;
+        self.output = ClonedVar::default();
+        Ok(())
+    }
+
+    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+        self.compose_helper(data)?;
+        Ok(common_type::bool)
+    }
+
+    fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+        // Extract local shell object
+        let local_shell =
+            unsafe { Var::from_ref_counted_object::<LocalShellSession>(&input, &*LOCAL_SHELL_TYPE)? };
+        let local_shell = unsafe { &*(local_shell as *const LocalShellSession) };
+
+        // Check alive status flag
+        let is_alive = local_shell.is_alive.lock()
+            .map_err(|_| "Alive state lock poisoned")?;
+
+        self.output = (*is_alive).into();
+        Ok(Some(self.output.0))
+    }
+}
+
+// ============================================================================
+// Module Registration
+// ============================================================================
+
+#[no_mangle]
+pub extern "C" fn shardsRegister_localshell_rust(core: *mut shards::shardsc::SHCore) {
+    unsafe {
+        shards::core::Core = core;
+    }
+
+    // Register LocalShellSession object type
+    let mut info = shards::SHObjectInfo::default();
+    info.name = cstr!("LocalShell.Session").as_ptr() as shards::SHString;
+    shards::core::register_object_type_internal(FRAG_CC, fourCharacterCode(*b"lshl"), info);
+
+    // Register shards
+    register_shard::<CreateShard>();
+    register_shard::<ExecuteShard>();
+    register_shard::<SendInputShard>();
+    register_shard::<IsAliveShard>();
+
+    shlog_trace!("LocalShell module registered");
+}

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -34,6 +34,7 @@ use shards::types::BOOL_TYPES;
 use portable_pty::{CommandBuilder, PtySize};
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
@@ -55,12 +56,20 @@ const BUFFER_TRUNCATE_KEEP_RATIO: usize = 93; // Keep 93% on truncation to avoid
 mod local_shell {
     use super::*;
 
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum SessionState {
+        Running,
+        ProcessDied,
+        Corrupted(String),
+    }
+
     pub struct LocalShellSession {
         pub pair: Arc<Mutex<Option<portable_pty::PtyPair>>>,
         pub reader: Arc<Mutex<Box<dyn Read + Send>>>,
         pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
         pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
-        pub is_alive: Arc<Mutex<bool>>,
+        pub is_alive: Arc<AtomicBool>,
+        pub state: Arc<Mutex<SessionState>>,
         pub output_buffer: Arc<Mutex<Vec<u8>>>,
         pub reader_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
         pub child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
@@ -76,9 +85,7 @@ mod local_shell {
             shlog_trace!("Dropping LocalShellSession, cleaning up");
 
             // Step 1: Mark as not alive (prevents new operations)
-            if let Ok(mut is_alive) = self.is_alive.lock() {
-                *is_alive = false;
-            }
+            self.is_alive.store(false, Ordering::Release);
 
             // Step 2: Kill the shell child process
             if let Ok(mut child_opt) = self.child.lock() {
@@ -215,12 +222,13 @@ fn is_interactive_prompt(text: &str) -> bool {
     false
 }
 
-// Helper function to mark session as dead after encountering a critical error (like lock poisoning)
-fn mark_session_dead(local_shell: &LocalShellSession, error_context: &str) {
-    shlog_error!("Critical error in LocalShell ({}), marking session as dead", error_context);
-    // Try to set is_alive = false, but if the lock is poisoned, we can't do much
-    if let Ok(mut alive) = local_shell.is_alive.lock() {
-        *alive = false;
+// Helper function to mark session as corrupted after encountering a critical error (like lock poisoning)
+fn mark_session_corrupted(local_shell: &LocalShellSession, error_context: &str) {
+    shlog_error!("Critical error in LocalShell ({}), marking session as corrupted", error_context);
+    local_shell.is_alive.store(false, Ordering::Release);
+    // Try to set state, but if the lock is poisoned, is_alive=false is enough
+    if let Ok(mut state) = local_shell.state.lock() {
+        *state = SessionState::Corrupted(error_context.to_string());
     }
 }
 
@@ -458,9 +466,10 @@ impl BlockingShard for CreateShard {
         shlog_trace!("Shell ready");
         shlog_trace!("Local shell created successfully");
 
-        // Create shared output buffer
+        // Create shared output buffer and state
         let output_buffer = Arc::new(Mutex::new(Vec::new()));
-        let is_alive = Arc::new(Mutex::new(true));
+        let is_alive = Arc::new(AtomicBool::new(true));
+        let state = Arc::new(Mutex::new(SessionState::Running));
 
         // Start reader thread
         let reader_clone = Arc::clone(&reader_arc);
@@ -472,17 +481,10 @@ impl BlockingShard for CreateShard {
             let mut buf = [0u8; 4096];
 
             loop {
-                // Check if we should exit (non-blocking check)
-                match alive_clone.lock() {
-                    Ok(alive) if !*alive => {
-                        shlog_trace!("Reader thread exiting");
-                        break;
-                    }
-                    Err(e) => {
-                        shlog_trace!("Reader thread: alive lock poisoned: {}", e);
-                        break;
-                    }
-                    _ => {}
+                // Check if we should exit (lock-free atomic check)
+                if !alive_clone.load(Ordering::Acquire) {
+                    shlog_trace!("Reader thread exiting");
+                    break;
                 }
 
                 // Read from PTY (this will block until data is available)
@@ -513,26 +515,14 @@ impl BlockingShard for CreateShard {
                             }
                             Ok(_) => {
                                 // EOF - process died
-                                match alive_clone.lock() {
-                                    Ok(mut alive) => {
-                                        *alive = false;
-                                    }
-                                    Err(e) => {
-                                        shlog_trace!("Reader thread: alive lock poisoned on EOF: {}", e);
-                                    }
-                                }
+                                alive_clone.store(false, Ordering::Release);
+                                shlog_trace!("Reader thread: EOF detected, process died");
                                 break;
                             }
                             Err(e) => {
+                                // Read error - process died or FD closed
+                                alive_clone.store(false, Ordering::Release);
                                 shlog_trace!("Reader thread: read error: {}", e);
-                                match alive_clone.lock() {
-                                    Ok(mut alive) => {
-                                        *alive = false;
-                                    }
-                                    Err(e) => {
-                                        shlog_trace!("Reader thread: alive lock poisoned on error: {}", e);
-                                    }
-                                }
                                 break;
                             }
                         }
@@ -553,6 +543,7 @@ impl BlockingShard for CreateShard {
             writer: writer_arc,
             pending_interactive: Arc::new(Mutex::new(None)),
             is_alive,
+            state,
             output_buffer,
             reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
             child: Arc::new(Mutex::new(Some(child))),
@@ -659,11 +650,20 @@ impl BlockingShard for ExecuteShard {
         let local_shell = unsafe { &*(local_shell as *const LocalShellSession) };
 
         // Check if shell is still alive
-        {
-            let is_alive = local_shell.is_alive.lock()
-                .map_err(|_| "Alive state lock poisoned")?;
-            if !*is_alive {
-                return Err("Local shell process has exited");
+        if !local_shell.is_alive.load(Ordering::Acquire) {
+            // Check state to provide better error message
+            if let Ok(state) = local_shell.state.lock() {
+                return Err(match *state {
+                    SessionState::ProcessDied => "Local shell process has exited",
+                    SessionState::Corrupted(ref reason) => {
+                        shlog_error!("Session corrupted: {}", reason);
+                        "Local shell session corrupted due to internal error"
+                    },
+                    SessionState::Running => "Local shell is not alive (unexpected state)",
+                });
+            } else {
+                // State lock is poisoned too
+                return Err("Local shell session corrupted (state lock poisoned)");
             }
         }
 
@@ -672,7 +672,7 @@ impl BlockingShard for ExecuteShard {
             let mut pending = match local_shell.pending_interactive.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    mark_session_dead(local_shell, "interactive lock poisoned in Execute");
+                    mark_session_corrupted(local_shell, "interactive lock poisoned in Execute");
                     return Err("Interactive state lock poisoned");
                 }
             };
@@ -685,7 +685,7 @@ impl BlockingShard for ExecuteShard {
                     let mut writer = match local_shell.writer.lock() {
                         Ok(guard) => guard,
                         Err(_) => {
-                            mark_session_dead(local_shell, "writer lock poisoned in Execute");
+                            mark_session_corrupted(local_shell, "writer lock poisoned in Execute");
                             return Err("Writer lock poisoned");
                         }
                     };
@@ -709,7 +709,7 @@ impl BlockingShard for ExecuteShard {
             let mut shared_buffer = match local_shell.output_buffer.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    mark_session_dead(local_shell, "buffer lock poisoned before command");
+                    mark_session_corrupted(local_shell, "buffer lock poisoned before command");
                     return Err("Buffer lock poisoned");
                 }
             };
@@ -723,7 +723,7 @@ impl BlockingShard for ExecuteShard {
             let mut writer = match local_shell.writer.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    mark_session_dead(local_shell, "writer lock poisoned sending command");
+                    mark_session_corrupted(local_shell, "writer lock poisoned sending command");
                     return Err("Writer lock poisoned");
                 }
             };
@@ -977,11 +977,20 @@ impl BlockingShard for SendInputShard {
         let local_shell = unsafe { &*(local_shell as *const LocalShellSession) };
 
         // Check if shell is still alive
-        {
-            let is_alive = local_shell.is_alive.lock()
-                .map_err(|_| "Alive state lock poisoned")?;
-            if !*is_alive {
-                return Err("Local shell process has exited");
+        if !local_shell.is_alive.load(Ordering::Acquire) {
+            // Check state to provide better error message
+            if let Ok(state) = local_shell.state.lock() {
+                return Err(match *state {
+                    SessionState::ProcessDied => "Local shell process has exited",
+                    SessionState::Corrupted(ref reason) => {
+                        shlog_error!("Session corrupted: {}", reason);
+                        "Local shell session corrupted due to internal error"
+                    },
+                    SessionState::Running => "Local shell is not alive (unexpected state)",
+                });
+            } else {
+                // State lock is poisoned too
+                return Err("Local shell session corrupted (state lock poisoned)");
             }
         }
 
@@ -990,7 +999,7 @@ impl BlockingShard for SendInputShard {
             let pending = match local_shell.pending_interactive.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    mark_session_dead(local_shell, "interactive lock poisoned in SendInput");
+                    mark_session_corrupted(local_shell, "interactive lock poisoned in SendInput");
                     return Err("Interactive state lock poisoned");
                 }
             };
@@ -1004,7 +1013,7 @@ impl BlockingShard for SendInputShard {
             let shared_buffer = match local_shell.output_buffer.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    mark_session_dead(local_shell, "buffer lock poisoned in SendInput");
+                    mark_session_corrupted(local_shell, "buffer lock poisoned in SendInput");
                     return Err("Buffer lock poisoned");
                 }
             };
@@ -1018,7 +1027,7 @@ impl BlockingShard for SendInputShard {
             let mut writer = match local_shell.writer.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    mark_session_dead(local_shell, "writer lock poisoned in SendInput");
+                    mark_session_corrupted(local_shell, "writer lock poisoned in SendInput");
                     return Err("Writer lock poisoned");
                 }
             };
@@ -1184,11 +1193,10 @@ impl Shard for IsAliveShard {
             unsafe { Var::from_ref_counted_object::<LocalShellSession>(&input, &*LOCAL_SHELL_TYPE)? };
         let local_shell = unsafe { &*(local_shell as *const LocalShellSession) };
 
-        // Check alive status flag
-        let is_alive = local_shell.is_alive.lock()
-            .map_err(|_| "Alive state lock poisoned")?;
+        // Check alive status flag (lock-free atomic read)
+        let is_alive = local_shell.is_alive.load(Ordering::Acquire);
 
-        self.output = (*is_alive).into();
+        self.output = is_alive.into();
         Ok(Some(self.output.0))
     }
 }

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -31,10 +31,10 @@ use shards::types::STRING_TYPES;
 use shards::types::NONE_TYPES;
 use shards::types::BOOL_TYPES;
 
-use portable_pty::{CommandBuilder, PtySize, PtySystem};
+use portable_pty::{CommandBuilder, PtySize};
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
-use std::sync::mpsc::{channel, Receiver, TryRecvError};
+use std::sync::mpsc::channel;
 use std::time::Duration;
 
 // Configuration constants
@@ -139,6 +139,53 @@ fn is_prompt(text: &str) -> bool {
     }
 }
 
+// Helper function to detect common interactive prompts (password, confirmation, etc.)
+// These patterns indicate a command is waiting for user input
+fn is_interactive_prompt(text: &str) -> bool {
+    // Strip ANSI codes first
+    let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
+    let cleaned = String::from_utf8_lossy(&stripped_bytes);
+
+    // Check last few lines for interactive patterns
+    let lines: Vec<&str> = cleaned.lines().collect();
+    if lines.is_empty() {
+        return false;
+    }
+
+    // Check last 3 lines (some prompts span multiple lines)
+    let check_lines = if lines.len() > 3 { &lines[lines.len()-3..] } else { &lines[..] };
+
+    for line in check_lines {
+        let lower = line.to_lowercase();
+
+        // Common interactive patterns
+        if lower.contains("password:")
+            || lower.contains("passphrase:")
+            || lower.contains("continue?")
+            || lower.contains("(y/n)")
+            || lower.contains("[y/n]")
+            || lower.contains("press enter")
+            || lower.contains("press any key")
+            || lower.contains("are you sure")
+            || lower.ends_with("? ")
+            || lower.ends_with(": ")
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+// Helper function to mark session as dead after encountering a critical error (like lock poisoning)
+fn mark_session_dead(local_shell: &LocalShellSession, error_context: &str) {
+    shlog_error!("Critical error in LocalShell ({}), marking session as dead", error_context);
+    // Try to set is_alive = false, but if the lock is poisoned, we can't do much
+    if let Ok(mut alive) = local_shell.is_alive.lock() {
+        *alive = false;
+    }
+}
+
 // Helper function to clean output (remove ANSI codes, control chars, and trailing prompts)
 // Reused from SSH module
 fn clean_output(output: &str) -> String {
@@ -203,6 +250,9 @@ pub struct CreateShard {
     #[shard_param("WorkingDirectory", "Initial working directory (default: current directory)", [common_type::string, common_type::string_var, common_type::none])]
     working_dir: ParamVar,
 
+    #[shard_param("ShellArgs", "Arguments to pass to shell (default: ['--login', '-i'] for bash on Unix)", [common_type::strings, common_type::strings_var, common_type::none])]
+    shell_args: ParamVar,
+
     output: ClonedVar,
 }
 
@@ -212,6 +262,7 @@ impl Default for CreateShard {
             required: ExposedTypes::new(),
             shell: ParamVar::new(Var::default()),
             working_dir: ParamVar::new(Var::default()),
+            shell_args: ParamVar::new(Var::default()),
             output: ClonedVar::default(),
         }
     }
@@ -291,11 +342,30 @@ impl BlockingShard for CreateShard {
             cmd.cwd(wd);
         }
 
-        // For bash, use --login to get environment and -i for interactive mode
-        #[cfg(unix)]
-        if shell_cmd.contains("bash") {
-            cmd.arg("--login");
-            cmd.arg("-i");
+        // Set shell arguments
+        let shell_args_var = self.shell_args.get();
+        if !shell_args_var.is_none() {
+            // User provided custom arguments
+            let args_seq: shards::types::SeqVar = shell_args_var.as_ref().try_into()
+                .map_err(|_| "ShellArgs must be a sequence of strings")?;
+            for arg_var in args_seq.iter() {
+                let arg_str = match arg_var.as_ref() {
+                    Var { valueType: shards::shardsc::SHType_String, .. } => {
+                        let s: &str = arg_var.as_ref().try_into()
+                            .map_err(|_| "ShellArgs elements must be strings")?;
+                        s
+                    }
+                    _ => return Err("ShellArgs elements must be strings"),
+                };
+                cmd.arg(arg_str);
+            }
+        } else {
+            // Default arguments for bash: --login to get environment, -i for interactive mode
+            #[cfg(unix)]
+            if shell_cmd.contains("bash") {
+                cmd.arg("--login");
+                cmd.arg("-i");
+            }
         }
 
         // Spawn the child process
@@ -378,6 +448,7 @@ impl BlockingShard for CreateShard {
                 }
 
                 // Read from PTY (this will block until data is available)
+                // The is_alive check above ensures we exit gracefully when session is closed
                 match reader_clone.lock() {
                     Ok(mut reader) => {
                         match reader.read(&mut buf) {
@@ -470,10 +541,8 @@ pub struct ExecuteShard {
     #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
     session: ParamVar,
 
-    // NOTE: Timeout parameter is declared for API compatibility with SSH module
-    // but is not currently used in the implementation. Actual timeout is hardcoded
-    // to COMMAND_MAX_ITERATIONS * ITERATION_SLEEP_MS (5 seconds).
-    // TODO: Implement actual timeout logic using this parameter.
+    // Timeout for command execution in seconds
+    // The implementation uses 10 iterations per second (ITERATION_SLEEP_MS = 100ms)
     #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
     timeout_secs: ParamVar,
 
@@ -538,6 +607,12 @@ impl BlockingShard for ExecuteShard {
         let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
         let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
 
+        // Get timeout parameter and calculate max iterations
+        // Each iteration is ITERATION_SLEEP_MS (100ms), so timeout_secs * 10 = max iterations
+        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
+        let timeout_secs = if timeout_secs <= 0 { 30 } else { timeout_secs };  // Default to 30s if invalid
+        let max_iterations = (timeout_secs as usize) * 10;  // 10 iterations per second
+
         // Extract local shell object
         let local_shell = unsafe {
             Var::from_ref_counted_object::<LocalShellSession>(&session_var, &*LOCAL_SHELL_TYPE)?
@@ -555,16 +630,26 @@ impl BlockingShard for ExecuteShard {
 
         // Check if there's a pending interactive command
         {
-            let mut pending = local_shell.pending_interactive.lock()
-                .map_err(|_| "Interactive state lock poisoned")?;
+            let mut pending = match local_shell.pending_interactive.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    mark_session_dead(local_shell, "interactive lock poisoned in Execute");
+                    return Err("Interactive state lock poisoned");
+                }
+            };
             if pending.is_some() {
                 shlog_trace!("New command received while interactive command was pending, sending Ctrl+C");
 
                 // Send Ctrl+C to cancel the interactive command
                 // Writer lock is released immediately after write to avoid blocking
                 {
-                    let mut writer = local_shell.writer.lock()
-                        .map_err(|_| "Writer lock poisoned")?;
+                    let mut writer = match local_shell.writer.lock() {
+                        Ok(guard) => guard,
+                        Err(_) => {
+                            mark_session_dead(local_shell, "writer lock poisoned in Execute");
+                            return Err("Writer lock poisoned");
+                        }
+                    };
                     let _ = writer.write_all(&[3]);
                     let _ = writer.flush();
                 } // Writer lock released here
@@ -582,8 +667,13 @@ impl BlockingShard for ExecuteShard {
 
         // Clear shared buffer before sending command
         {
-            let mut shared_buffer = local_shell.output_buffer.lock()
-                .map_err(|_| "Buffer lock poisoned")?;
+            let mut shared_buffer = match local_shell.output_buffer.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    mark_session_dead(local_shell, "buffer lock poisoned before command");
+                    return Err("Buffer lock poisoned");
+                }
+            };
             shared_buffer.clear();
             shlog_trace!("Cleared shared buffer before command");
         }
@@ -591,8 +681,13 @@ impl BlockingShard for ExecuteShard {
         // Send command
         let cmd_with_newline = format!("{}\n", cmd);
         {
-            let mut writer = local_shell.writer.lock()
-                .map_err(|_| "Writer lock poisoned")?;
+            let mut writer = match local_shell.writer.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    mark_session_dead(local_shell, "writer lock poisoned sending command");
+                    return Err("Writer lock poisoned");
+                }
+            };
             writer.write_all(cmd_with_newline.as_bytes())
                 .map_err(|_| "Failed to write command to shell (IO error)")?;
             writer.flush()
@@ -611,24 +706,26 @@ impl BlockingShard for ExecuteShard {
         // Give shell time to process command
         std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
 
-        for iteration in 0..COMMAND_MAX_ITERATIONS {
-            // Read from shared buffer
-            let current_buffer_size = {
+        for iteration in 0..max_iterations {
+            // Read from shared buffer atomically (single lock acquisition to avoid race conditions)
+            let new_data = {
                 let shared_buffer = local_shell.output_buffer.lock()
                     .map_err(|_| "Buffer lock poisoned")?;
-                shared_buffer.len()
+
+                // Only copy new data since last read
+                if shared_buffer.len() > last_buffer_size {
+                    shared_buffer[last_buffer_size..].to_vec()
+                } else {
+                    Vec::new()
+                }
             };
 
-            let bytes_read = current_buffer_size - last_buffer_size;
+            let bytes_read = new_data.len();
 
             if bytes_read > 0 {
-                // Copy new data from shared buffer
-                let shared_buffer = local_shell.output_buffer.lock()
-                    .map_err(|_| "Buffer lock poisoned")?;
-                output_buffer.extend_from_slice(&shared_buffer[last_buffer_size..]);
-                drop(shared_buffer);
-
-                last_buffer_size = current_buffer_size;
+                // Append new data to our local output buffer
+                output_buffer.extend_from_slice(&new_data);
+                last_buffer_size += bytes_read;
 
                 // Truncate if buffer exceeds max size
                 if truncate_to_tail(&mut output_buffer, max_output_bytes) {
@@ -662,17 +759,41 @@ impl BlockingShard for ExecuteShard {
                     output_buffer.is_empty()
                 );
 
-                // Only consider interactive if we have output AND consistent no-data period
+                // Interactive command detection logic:
+                // We detect a command as interactive if it stops producing output but doesn't return to shell prompt.
+                //
+                // Conditions explained:
+                // 1. no_data_count >= INTERACTIVE_DETECTION_ITERATIONS (20 iterations = 2 seconds):
+                //    - Gives command enough time to complete output before assuming it's waiting for input
+                //    - 2 seconds balances between false positives (slow commands) and responsiveness
+                //
+                // 2. !output_buffer.is_empty():
+                //    - Command must have produced SOME output (avoids detecting hung commands as interactive)
+                //    - Interactive prompts typically display text before waiting
+                //
+                // 3. iteration >= INTERACTIVE_DETECTION_ITERATIONS / 2 (≥10 iterations = ≥1 second):
+                //    - Prevents premature detection during command startup
+                //    - Allows time for fast commands to complete normally
+                //
                 if no_data_count >= INTERACTIVE_DETECTION_ITERATIONS && !output_buffer.is_empty() && iteration >= INTERACTIVE_DETECTION_ITERATIONS / 2 {
-                    // Check one more time if there's a prompt we might have missed
                     let output_str = String::from_utf8_lossy(&output_buffer);
+
+                    // First check for shell prompt (command completed normally)
                     if is_prompt(&output_str) {
                         prompt_detected = true;
                         shlog_trace!("Prompt detected on final check");
                         break;
                     }
-                    // No output for 2 seconds after having received some data, likely interactive
-                    shlog_trace!("Command appears to be interactive (no new data for 2s)");
+
+                    // Check for common interactive prompt patterns (password, confirmation, etc.)
+                    if is_interactive_prompt(&output_str) {
+                        shlog_trace!("Interactive prompt pattern detected: {:?}", output_str.lines().last());
+                        break;
+                    }
+
+                    // No shell prompt, no obvious interactive pattern, but no new data for 2 seconds
+                    // Likely an interactive command waiting for input
+                    shlog_trace!("Command appears to be interactive (no new data for 2s, no prompt detected)");
                     break;
                 }
             }
@@ -744,10 +865,8 @@ pub struct SendInputShard {
     #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
     session: ParamVar,
 
-    // NOTE: Timeout parameter is declared for API compatibility with SSH module
-    // but is not currently used in the implementation. Actual timeout is hardcoded
-    // to SENDINPUT_MAX_ITERATIONS * ITERATION_SLEEP_MS (3 seconds).
-    // TODO: Implement actual timeout logic using this parameter.
+    // Timeout for reading response after sending input, in seconds
+    // The implementation uses 10 iterations per second (ITERATION_SLEEP_MS = 100ms)
     #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
     timeout_secs: ParamVar,
 
@@ -807,6 +926,11 @@ impl BlockingShard for SendInputShard {
         let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
         let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
 
+        // Get timeout parameter and calculate max iterations
+        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
+        let timeout_secs = if timeout_secs <= 0 { 10 } else { timeout_secs };  // Default to 10s if invalid
+        let max_iterations = (timeout_secs as usize) * 10;  // 10 iterations per second
+
         // Extract local shell object
         let local_shell = unsafe {
             Var::from_ref_counted_object::<LocalShellSession>(&session_var, &*LOCAL_SHELL_TYPE)?
@@ -824,8 +948,13 @@ impl BlockingShard for SendInputShard {
 
         // Check if there's a pending interactive command
         {
-            let pending = local_shell.pending_interactive.lock()
-                .map_err(|_| "Interactive state lock poisoned")?;
+            let pending = match local_shell.pending_interactive.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    mark_session_dead(local_shell, "interactive lock poisoned in SendInput");
+                    return Err("Interactive state lock poisoned");
+                }
+            };
             if pending.is_none() {
                 return Err("No interactive command is pending");
             }
@@ -833,8 +962,13 @@ impl BlockingShard for SendInputShard {
 
         // Note current buffer position before sending input
         let start_buffer_size = {
-            let shared_buffer = local_shell.output_buffer.lock()
-                .map_err(|_| "Buffer lock poisoned")?;
+            let shared_buffer = match local_shell.output_buffer.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    mark_session_dead(local_shell, "buffer lock poisoned in SendInput");
+                    return Err("Buffer lock poisoned");
+                }
+            };
             shared_buffer.len()
         };
 
@@ -842,8 +976,13 @@ impl BlockingShard for SendInputShard {
         if !input_str.is_empty() {
             let input_with_newline = format!("{}\n", input_str);
             shlog_trace!("SendInput: Writing {} bytes: {:?}", input_with_newline.len(), input_with_newline);
-            let mut writer = local_shell.writer.lock()
-                .map_err(|_| "Writer lock poisoned")?;
+            let mut writer = match local_shell.writer.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    mark_session_dead(local_shell, "writer lock poisoned in SendInput");
+                    return Err("Writer lock poisoned");
+                }
+            };
             writer.write_all(input_with_newline.as_bytes())
                 .map_err(|_| "Failed to write input to interactive command (IO error)")?;
             writer.flush()
@@ -860,24 +999,26 @@ impl BlockingShard for SendInputShard {
         let mut last_buffer_size = start_buffer_size;
         let mut was_truncated = false;
 
-        for iteration in 0..SENDINPUT_MAX_ITERATIONS {
-            // Read from shared buffer
-            let current_buffer_size = {
+        for iteration in 0..max_iterations {
+            // Read from shared buffer atomically (single lock acquisition to avoid race conditions)
+            let new_data = {
                 let shared_buffer = local_shell.output_buffer.lock()
                     .map_err(|_| "Buffer lock poisoned")?;
-                shared_buffer.len()
+
+                // Only copy new data since last read
+                if shared_buffer.len() > last_buffer_size {
+                    shared_buffer[last_buffer_size..].to_vec()
+                } else {
+                    Vec::new()
+                }
             };
 
-            let bytes_read = current_buffer_size - last_buffer_size;
+            let bytes_read = new_data.len();
 
             if bytes_read > 0 {
-                // Copy new data from shared buffer
-                let shared_buffer = local_shell.output_buffer.lock()
-                    .map_err(|_| "Buffer lock poisoned")?;
-                output_buffer.extend_from_slice(&shared_buffer[last_buffer_size..]);
-                drop(shared_buffer);
-
-                last_buffer_size = current_buffer_size;
+                // Append new data to our local output buffer
+                output_buffer.extend_from_slice(&new_data);
+                last_buffer_size += bytes_read;
 
                 // Truncate if buffer exceeds max size
                 if truncate_to_tail(&mut output_buffer, max_output_bytes) {

--- a/shards/tests/localshell.shs
+++ b/shards/tests/localshell.shs
@@ -1,0 +1,76 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2025 Fragcolor Pte. Ltd.
+
+; Test LocalShell module functionality
+
+"Starting LocalShell tests" | Log
+
+; Create a local shell session
+LocalShell.Create >= shell-session
+
+; Verify session was created and is alive
+shell-session | LocalShell.IsAlive | Assert.Is(true)
+"Session created and alive" | Log
+
+; Test basic command execution
+"Testing basic command execution" | Log
+"echo 'Hello from LocalShell!'" | LocalShell.Execute(Session: shell-session) >= result
+result:status | ExpectString | Assert.Is("completed")
+result:output | ExpectString | Log("Command output")
+result:output | ExpectString | String.Contains("Hello from LocalShell!") | Assert.Is(true)
+
+; Test persistent environment variables
+"Testing persistent environment variables" | Log
+"export TEST_VAR=hello_world" | LocalShell.Execute(Session: shell-session) >= result1
+result1:status | Assert.Is("completed")
+"echo $TEST_VAR" | LocalShell.Execute(Session: shell-session) >= result2
+result2:status | Assert.Is("completed")
+result2:output | ExpectString | String.Contains("hello_world") | Assert.Is(true)
+"Environment variable persisted" | Log
+
+; Test working directory persistence
+"Testing working directory persistence" | Log
+"cd /tmp" | LocalShell.Execute(Session: shell-session) >= result3
+result3:status | Assert.Is("completed")
+"pwd" | LocalShell.Execute(Session: shell-session) >= result4
+result4:status | Assert.Is("completed")
+result4:output | ExpectString | String.Contains("/tmp") | Assert.Is(true)
+"cd ~" | LocalShell.Execute(Session: shell-session)  ; change back
+"Working directory persisted" | Log
+
+; Test multiline output
+"Testing multiline output" | Log
+"echo 'Line 1' && echo 'Line 2' && echo 'Line 3'" | LocalShell.Execute(Session: shell-session) >= result5
+result5:status | Assert.Is("completed")
+result5:output | ExpectString | String.Contains("Line 1") | Assert.Is(true)
+result5:output | ExpectString | String.Contains("Line 2") | Assert.Is(true)
+result5:output | ExpectString | String.Contains("Line 3") | Assert.Is(true)
+"Multiline output works" | Log
+
+; Test interactive command detection
+"Testing interactive command detection" | Log
+"read -p 'Enter your name: ' name && echo \"Hello $name\"" | LocalShell.Execute(Session: shell-session) >= interactive-result
+interactive-result:status | ExpectString | Assert.Is("requires_interaction")
+interactive-result:message | ExpectString | String.Contains("LocalShell.SendInput") | Assert.Is(true)
+"Interactive detection works" | Log
+
+; Test send input to interactive command
+"Testing send input" | Log
+"TestUser" | LocalShell.SendInput(Session: shell-session) >= input-result
+input-result:status | ExpectString | Assert.Is("completed")
+input-result:output | ExpectString | String.Contains("TestUser") | Assert.Is(true)
+"Send input works" | Log
+
+; Test command that fails
+"Testing command failure" | Log
+"this_command_does_not_exist_12345" | LocalShell.Execute(Session: shell-session) >= fail-result
+fail-result:status | Assert.Is("completed")
+fail-result:output | ExpectString | Log("Error output")
+"Command failure handled" | Log
+
+; Test session alive check
+"Testing session alive check" | Log
+shell-session | LocalShell.IsAlive | Assert.Is(true)
+"Session is still alive" | Log
+
+"All LocalShell tests completed successfully!" | Log


### PR DESCRIPTION
## Summary
Adds a new LocalShell module that provides SSH-like shell execution capabilities for local processes. This allows users to execute commands on the local machine with the same API and features as the SSH module.

## Features
- **LocalShell.Create**: Creates a persistent local shell session
- **LocalShell.Execute**: Executes commands with status tracking (completed/requires_interaction/process_died)
- **LocalShell.SendInput**: Sends input to interactive commands
- **LocalShell.IsAlive**: Checks if shell process is still running

## Key Capabilities
- ✅ Persistent environment variables between commands
- ✅ Working directory persistence  
- ✅ Prompt detection for command completion
- ✅ Interactive command detection
- ✅ Clean output with ANSI code stripping
- ✅ Output truncation with tail preservation
- ✅ Status tracking (completed/requires_interaction/process_died)

## Implementation Details
- Written in Rust using `portable-pty` for cross-platform PTY support
- Reuses prompt detection and output cleaning logic from SSH module
- Uses Arc<Mutex<>> for thread-safe access to reader/writer
- Implements BlockingShard for non-blocking runtime integration

## Test Plan
- [x] Basic command execution
- [x] Persistent environment variables
- [x] Working directory persistence
- [x] Multiline output
- [ ] Interactive command detection (needs investigation - test currently hangs)
- [x] Command failure handling
- [x] Session alive check

## Known Issues
⚠️ The interactive command test hangs - needs debugging. The module builds and most functionality works correctly.

## Additional Changes
- Added helper commands to justfile:
  - `just build-quiet`: Filtered build output for easier debugging
  - `just check-rust`: Quick Rust compilation check