### PR TITLE
Refactor: Remove ignoreInputTypeCheck flag and use proper type matching

### DIFF
--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -624,9 +624,6 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
   bool detached{false};
   std::unordered_set<void *> wireUsers;
 
-  // flag if we changed inputType to None or Any on purpose
-  mutable bool ignoreInputTypeCheck{false};
-
   mutable shards::TypeInfo inputType{};
   mutable shards::TypeInfo outputType{};
 

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1487,7 +1487,6 @@ SHComposeResult internalComposeWire(const SHWire *wire_, SHInstanceData data) {
     if (wire->shards.size() > 0 && strncmp(wire->shards[0]->name(wire->shards[0]), "Expect", 6) == 0) {
       // If first shard is an Expect, this wire can accept ANY input type as the type is checked at runtime
       wire->inputType = SHTypeInfo{SHType::Any};
-      wire->ignoreInputTypeCheck = true;
     } else if (wire->shards.size() > 0 && !std::any_of(wire->shards.begin(), wire->shards.end(), [&](const auto &shard) {
                  return strcmp(shard->name(shard), "Input") == 0;
                })) {
@@ -1496,14 +1495,11 @@ SHComposeResult internalComposeWire(const SHWire *wire_, SHInstanceData data) {
       auto inTypes = wire->shards[0]->inputTypes(wire->shards[0]);
       if (inTypes.len == 1 && inTypes.elements[0].basicType == SHType::None) {
         wire->inputType = SHTypeInfo{};
-        wire->ignoreInputTypeCheck = true;
       } else {
         wire->inputType = data.inputType;
-        wire->ignoreInputTypeCheck = false;
       }
     } else {
       wire->inputType = data.inputType;
-      wire->ignoreInputTypeCheck = false;
     }
 
     shassert(wire == data.wire); // caller must pass the same wire as data.wire

--- a/shards/modules/core/wires.cpp
+++ b/shards/modules/core/wires.cpp
@@ -49,7 +49,10 @@ void WireBase::verifyAlreadyComposed(const SHInstanceData &data, const IterableE
   SHLOG_TRACE("WireBase::verifyAlreadyComposed, source: {} composing: {} inputType: {}", data.wire ? data.wire->name : nullptr,
               wire->name, data.inputType);
   // verify input type
-  if (!passthrough && data.inputType != wire->inputType && !wire->ignoreInputTypeCheck) {
+  // Special case: None input type accepts any input (wire doesn't use input)
+  bool typeMatches = wire->inputType->basicType == SHType::None ||
+                     matchTypes(data.inputType, wire->inputType, true, true, true);
+  if (!passthrough && !typeMatches) {
     throw shards::Error(fmt::format(
         "Attempted to call an already composed wire with a different input type! wire: {}, old type: {}, new type: {}",
         wire->name, (SHTypeInfo)wire->inputType, data.inputType));

--- a/shards/modules/core/wires.cpp
+++ b/shards/modules/core/wires.cpp
@@ -48,7 +48,7 @@ std::unordered_set<const SHWire *> &WireBase::gatheringWires() {
 void WireBase::verifyAlreadyComposed(const SHInstanceData &data, const IterableExposedInfo &shared) {
   SHLOG_TRACE("WireBase::verifyAlreadyComposed, source: {} composing: {} inputType: {}", data.wire ? data.wire->name : nullptr,
               wire->name, data.inputType);
-  // verify input type
+  // Verify input type compatibility
   // Special case: None input type accepts any input (wire doesn't use input)
   bool typeMatches = wire->inputType->basicType == SHType::None ||
                      matchTypes(data.inputType, wire->inputType, true, true, true);


### PR DESCRIPTION
## Summary
- Removed the hazardous `ignoreInputTypeCheck` flag from the wire system
- Replaced strict type equality checking with proper type compatibility using `matchTypes()`
- Added special case: `None` input type now correctly accepts any input

## Changes
1. **shards/core/foundation.hpp** - Removed `ignoreInputTypeCheck` field from `SHWire` struct
2. **shards/core/runtime.cpp** - Removed all assignments to the flag (4 locations)
3. **shards/modules/core/wires.cpp** - Replaced `operator!=` with `matchTypes()` for proper type compatibility checking

## Rationale
The `ignoreInputTypeCheck` flag was a workaround for using strict equality (`operator!=`) instead of proper type compatibility checking. The strict comparison doesn't account for:
- Type compatibility (e.g., `Int` → `Any`)
- Subtyping relationships  
- Relaxed constraints for parameters
- Empty sequence/table semantics

By using `matchTypes()` with the special case that `None` input types accept any input (since the wire doesn't use the input anyway), we achieve the same behavior with cleaner, more maintainable code.

## Test plan
- [x] Build succeeded
- [x] Full test suite passes (`just tests`)