### PR TITLE
Optimize Http.Stream to accumulate immediately available chunks

### DIFF
--- a/shards/modules/http/Cargo.toml
+++ b/shards/modules/http/Cargo.toml
@@ -15,3 +15,4 @@ shards = { path = "../../rust" }
 compile-time-crc32 = "0.1.2"
 reqwest = { version = "0.12.5" }
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -52,6 +52,7 @@ use std::convert::TryInto;
 use std::collections::HashMap;
 
 use std::sync::{Arc, Mutex};
+use tokio_util::sync::CancellationToken;
 
 fn print_error(e: &dyn std::error::Error) {
   shlog_error!("Error: {}", e);
@@ -216,7 +217,7 @@ struct RequestBase {
   invalid_certs: bool,
   required: ExposedTypes,
   streaming: bool,
-  task_cancel: Option<Arc<Mutex<Option<tokio::sync::oneshot::Sender<()>>>>>,
+  task_cancel: Option<CancellationToken>,
   global_client: Option<VarRef>,
 }
 
@@ -349,12 +350,9 @@ impl RequestBase {
 
   fn _cleanup(&mut self, ctx: Option<&Context>) {
     // Cancel any running task
-    if let Some(cancel) = &self.task_cancel {
-      if let Some(tx) = cancel.lock().unwrap().take() {
-        shlog_trace!("Cancelling HTTP task");
-        // Send cancellation signal - ignore error if receiver dropped
-        let _ = tx.send(());
-      }
+    if let Some(cancel_token) = &self.task_cancel {
+      shlog_trace!("Cancelling HTTP task");
+      cancel_token.cancel();
     }
     self.task_cancel = None;
 
@@ -394,19 +392,16 @@ impl RequestBase {
     let full_response = self.full_response;
     let streaming = self.streaming;
 
-    // Create a cancellation token that we'll store
-    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
-    let cancellation = Arc::new(Mutex::new(Some(cancel_tx)));
-    self.task_cancel = Some(cancellation.clone());
+    // Create a cancellation token that can be checked multiple times
+    let cancel_token = CancellationToken::new();
+    self.task_cancel = Some(cancel_token.clone());
+    let cancel_token_async = cancel_token.clone();
 
     let result = run_future(
       context,
       async move {
         let runtime = TOKIO_RUNTIME.clone();
         let request = request; // Capture request in the async block
-
-        // Setup cancellation receiver
-        let cancel_rx = cancel_rx;
 
         // Lock the runtime briefly to spawn the task
         let task: tokio::task::JoinHandle<Result<ClonedVar, String>> = {
@@ -417,7 +412,7 @@ impl RequestBase {
               resp = request.send() => resp.map_err(|e| {
                 format!("Request failed {:?}", e)
               })?,
-              _ = cancel_rx => return Err("Request cancelled".to_string())
+              _ = cancel_token_async.cancelled() => return Err("Request cancelled".to_string())
             };
 
             if !full_response && !response.status().is_success() {
@@ -516,12 +511,8 @@ impl RequestBase {
       },
       move || {
         shlog_debug!("Request cancelled");
-        // Cancel any running task
-        if let Some(tx) = cancellation.lock().unwrap().take() {
-          shlog_trace!("Cancelling HTTP task");
-          // Send cancellation signal - ignore error if receiver dropped
-          let _ = tx.send(());
-        }
+        // Cancel the token
+        cancel_token.cancel();
       },
     );
 
@@ -930,7 +921,7 @@ struct HttpStreamShard {
   output: ClonedVar,
 
   // Add cancellation support
-  task_cancel: Option<Arc<Mutex<Option<tokio::sync::oneshot::Sender<()>>>>>,
+  task_cancel: Option<CancellationToken>,
 }
 
 impl Default for HttpStreamShard {
@@ -965,12 +956,9 @@ impl Shard for HttpStreamShard {
 
   fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &'static str> {
     // Cancel any running task
-    if let Some(cancel) = &self.task_cancel {
-      if let Some(tx) = cancel.lock().unwrap().take() {
-        shlog_trace!("Cancelling HTTP stream task");
-        // Send cancellation signal - ignore error if receiver dropped
-        let _ = tx.send(());
-      }
+    if let Some(cancel_token) = &self.task_cancel {
+      shlog_trace!("Cancelling HTTP stream task");
+      cancel_token.cancel();
     }
     self.task_cancel = None;
 
@@ -986,10 +974,10 @@ impl Shard for HttpStreamShard {
   fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &'static str> {
     let stream = *self.stream.get();
 
-    // Create a cancellation token that we'll store
-    let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
-    let cancellation = Arc::new(Mutex::new(Some(cancel_tx)));
-    self.task_cancel = Some(cancellation.clone());
+    // Create a cancellation token that can be checked multiple times
+    let cancel_token = CancellationToken::new();
+    self.task_cancel = Some(cancel_token.clone());
+    let cancel_token_async = cancel_token.clone();
 
     let result = run_future(
       context,
@@ -1007,7 +995,7 @@ impl Shard for HttpStreamShard {
               chunk = response.chunk() => chunk.map_err(|e| {
                 FastError::Dynamic(format!("{:?}", e))
               }),
-              _ = &mut cancel_rx => return Err(FastError::Static("Stream read cancelled"))
+              _ = cancel_token_async.cancelled() => return Err(FastError::Static("Stream read cancelled"))
             };
 
             let bytes = bytes_result?;
@@ -1023,7 +1011,7 @@ impl Shard for HttpStreamShard {
                     tokio::time::Duration::from_millis(0),
                     response.chunk()
                   ) => result,
-                  _ = &mut cancel_rx => return Err(FastError::Static("Stream read cancelled during accumulation"))
+                  _ = cancel_token_async.cancelled() => return Err(FastError::Static("Stream read cancelled during accumulation"))
                 };
 
                 match chunk_result {
@@ -1035,7 +1023,11 @@ impl Shard for HttpStreamShard {
                     break;
                   }
                   Ok(Err(e)) => {
-                    // I/O error during chunk read - log and return partial data
+                    // I/O error during chunk read - return partial data accumulated so far
+                    // This is acceptable because:
+                    // 1. The stream interface expects partial/chunked data
+                    // 2. The first chunk was successfully read
+                    // 3. Subsequent activations will fail if the connection is broken
                     shlog_warn!("Error reading chunk during accumulation: {:?}", e);
                     break;
                   }
@@ -1057,14 +1049,10 @@ impl Shard for HttpStreamShard {
           FastError::Dynamic(e.to_string())
         })?
       },
-      || {
+      move || {
         shlog_debug!("Request cancelled");
-        // Cancel any running task
-        if let Some(tx) = cancellation.lock().unwrap().take() {
-          shlog_trace!("Cancelling HTTP task");
-          // Send cancellation signal - ignore error if receiver dropped
-          let _ = tx.send(());
-        }
+        // Cancel the token
+        cancel_token.cancel();
       },
     );
 

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -1036,7 +1036,7 @@ impl Shard for HttpStreamShard {
                   }
                   Ok(Err(e)) => {
                     // I/O error during chunk read - log and return partial data
-                    shlog_debug!("Error reading chunk during accumulation: {:?}", e);
+                    shlog_warn!("Error reading chunk during accumulation: {:?}", e);
                     break;
                   }
                   Err(_) => {

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -23,7 +23,7 @@ use shards::fourCharacterCode;
 use shards::shard::LegacyShard;
 use shards::shard::Shard;
 use shards::types::common_type;
-use shards::shard::{DynamicErrStr, push_error};
+use shards::shard::DynamicErrStr;
 
 use shards::types::AutoTableVar;
 use shards::types::ClonedVar;
@@ -526,6 +526,7 @@ impl RequestBase {
     );
 
     if let Err(e) = result {
+      shlog_error!("HTTP request failed: {}", e);
       return Err(DynamicErrStr);
     }
     let result = result.unwrap();
@@ -1067,7 +1068,8 @@ impl Shard for HttpStreamShard {
       },
     );
 
-    if let Err(_e) = result {
+    if let Err(e) = result {
+      shlog_error!("HTTP stream read failed: {}", e);
       return Err(DynamicErrStr);
     }
     let result = result.unwrap();

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -1010,8 +1010,31 @@ impl Shard for HttpStreamShard {
             };
 
             let bytes = bytes_result?;
-            if let Some(bytes) = bytes {
-              Ok(ClonedVar::new_bytes(&bytes))
+            if let Some(first_chunk) = bytes {
+              // Accumulate any additional chunks that are immediately available
+              let mut accumulated = first_chunk.to_vec();
+
+              // Try to read more chunks with zero timeout (non-blocking)
+              loop {
+                match tokio::time::timeout(
+                  tokio::time::Duration::from_millis(0),
+                  response.chunk()
+                ).await {
+                  Ok(Ok(Some(chunk))) => {
+                    accumulated.extend_from_slice(&chunk);
+                  }
+                  Ok(Ok(None)) => {
+                    // Stream ended
+                    break;
+                  }
+                  Ok(Err(_)) | Err(_) => {
+                    // Error or timeout (nothing immediately available)
+                    break;
+                  }
+                }
+              }
+
+              Ok(ClonedVar::new_bytes(&accumulated))
             } else {
               Ok(ClonedVar::new_bytes(&[]))
             }

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -986,7 +986,7 @@ impl Shard for HttpStreamShard {
     let stream = *self.stream.get();
 
     // Create a cancellation token that we'll store
-    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
     let cancellation = Arc::new(Mutex::new(Some(cancel_tx)));
     self.task_cancel = Some(cancellation.clone());
 
@@ -1006,7 +1006,7 @@ impl Shard for HttpStreamShard {
               chunk = response.chunk() => chunk.map_err(|e| {
                 FastError::Dynamic(format!("{:?}", e))
               }),
-              _ = cancel_rx => return Err(FastError::Static("Stream read cancelled"))
+              _ = &mut cancel_rx => return Err(FastError::Static("Stream read cancelled"))
             };
 
             let bytes = bytes_result?;
@@ -1015,11 +1015,17 @@ impl Shard for HttpStreamShard {
               let mut accumulated = first_chunk.to_vec();
 
               // Try to read more chunks with zero timeout (non-blocking)
+              // Each iteration checks for cancellation
               loop {
-                match tokio::time::timeout(
-                  tokio::time::Duration::from_millis(0),
-                  response.chunk()
-                ).await {
+                let chunk_result = tokio::select! {
+                  result = tokio::time::timeout(
+                    tokio::time::Duration::from_millis(0),
+                    response.chunk()
+                  ) => result,
+                  _ = &mut cancel_rx => return Err(FastError::Static("Stream read cancelled during accumulation"))
+                };
+
+                match chunk_result {
                   Ok(Ok(Some(chunk))) => {
                     accumulated.extend_from_slice(&chunk);
                   }
@@ -1027,8 +1033,13 @@ impl Shard for HttpStreamShard {
                     // Stream ended
                     break;
                   }
-                  Ok(Err(_)) | Err(_) => {
-                    // Error or timeout (nothing immediately available)
+                  Ok(Err(e)) => {
+                    // I/O error during chunk read - log and return partial data
+                    shlog_debug!("Error reading chunk during accumulation: {:?}", e);
+                    break;
+                  }
+                  Err(_) => {
+                    // Timeout (nothing immediately available)
                     break;
                   }
                 }
@@ -1056,7 +1067,7 @@ impl Shard for HttpStreamShard {
       },
     );
 
-    if let Err(e) = result {
+    if let Err(_e) = result {
       return Err(DynamicErrStr);
     }
     let result = result.unwrap();


### PR DESCRIPTION
## Summary
- Optimize `Http.Stream` to accumulate chunks that are immediately buffered instead of one-chunk-per-activation
- After reading the first chunk, poll with zero timeout to grab any additional chunks already available
- Reduces per-activation overhead when streaming data arrives in bursts

## Performance Impact
- Previously: Each activation read exactly one chunk, requiring N activations for N buffered chunks
- Now: Accumulates all immediately available chunks in a single activation
- No behavioral change when data arrives slowly (still blocks on first chunk)

## Test Plan
- [x] Code compiles with `cargo check`
- [ ] Test with streaming HTTP endpoint to verify chunk accumulation
- [ ] Verify backward compatibility with existing streaming code