### PR TITLE
Add NULL terminators to shard collections (prep for trampoline)

### DIFF
--- a/include/shards/utility.hpp
+++ b/include/shards/utility.hpp
@@ -306,6 +306,9 @@ private:
   void destroy() {
     for (auto it = _shardsArray.rbegin(); it != _shardsArray.rend(); ++it) {
       auto blk = *it;
+      if (blk == nullptr)
+        continue; // reverse iteration!
+
       auto errors = blk->cleanup(blk, nullptr);
       if (errors.code != SH_ERROR_NONE) {
         auto msg = std::string_view(errors.message.string, errors.message.len);
@@ -328,6 +331,8 @@ public:
   void cleanup(SHContext *context) {
     for (auto it = _shardsArray.rbegin(); it != _shardsArray.rend(); ++it) {
       auto blk = *it;
+      if (blk == nullptr)
+        continue; // reverse iteration!
 
       auto errors = blk->cleanup(blk, context);
       if (errors.code != SH_ERROR_NONE) {
@@ -339,7 +344,10 @@ public:
   }
 
   void warmup(SHContext *context) {
-    for (auto &blk : _shardsArray) {
+    for (auto blk : _shardsArray) {
+      if (blk == nullptr)
+        break; // the end
+
       if (blk->warmup) {
         auto errors = blk->warmup(blk, context);
         if (errors.code != SH_ERROR_NONE) {
@@ -376,6 +384,8 @@ public:
     _shards.elements = nshards > 0 ? &_shardsArray[0] : nullptr;
     _shards.len = uint32_t(nshards);
 
+    _shardsArray.push_back(nullptr); // add null shards terminator (at end of this call, we want len to know real shards count)
+
     return _shardsParam;
   }
 
@@ -397,7 +407,9 @@ public:
       return SH_CORE::runShards(_shards, context, input, output);
   }
 
-  operator bool() const { return _shardsArray.size() > 0; }
+  operator bool() const {
+    return _shardsArray.size() > 1; // account null shards terminator here!
+  }
 
   const Shards &shards() const { return _shards; }
   const SHComposeResult &composeResult() const { return _wireValidation; }

--- a/include/shards/utility.hpp
+++ b/include/shards/utility.hpp
@@ -381,10 +381,11 @@ public:
     // We want to avoid copies in hot paths
     // So we write here the var we pass to CORE
     const auto nshards = _shardsArray.size();
+
+    _shardsArray.push_back(nullptr); // add null shards terminator BEFORE setting pointer to avoid reallocation
+
     _shards.elements = nshards > 0 ? &_shardsArray[0] : nullptr;
     _shards.len = uint32_t(nshards);
-
-    _shardsArray.push_back(nullptr); // add null shards terminator (at end of this call, we want len to know real shards count)
 
     return _shardsParam;
   }

--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -662,7 +662,11 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
     shassert(!blk->owned);
     blk->owned = true;
     shards::incRef(blk);
+    if (!shards.empty()) {
+      shards.pop_back(); // pop the null terminator
+    }
     shards.push_back(blk);
+    shards.push_back(nullptr); // push the null terminator
   }
 
   // Also removes ownership of the shard

--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -671,6 +671,9 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
 
   // Also removes ownership of the shard
   void removeShard(Shard *blk) {
+    if (blk == nullptr) {
+      throw shards::SHException("removeShard: cannot remove nullptr terminator!");
+    }
     auto findIt = std::find(shards.begin(), shards.end(), blk);
     if (findIt != shards.end()) {
       shards.erase(findIt);
@@ -810,6 +813,7 @@ struct SHWire : public std::enable_shared_from_this<SHWire> {
 private:
   SHWire(std::string_view wire_name) : name(wire_name) {
     SHLOG_TRACE("Creating wire: {}", name);
+    shards.push_back(nullptr); // Initialize with null terminator
     regenerateId();
   }
 

--- a/shards/core/hash.inl
+++ b/shards/core/hash.inl
@@ -359,6 +359,8 @@ template <typename TDigest> inline TDigest HashState<TDigest>::hash(const std::s
     shassert(error == XXH_OK);
 
     for (auto &blk : wire->shards) {
+      if (blk == nullptr)
+        break; // null terminated shards collection
       SHVar tmp{};
       tmp.valueType = SHType::ShardRef;
       tmp.payload.shardValue = blk;

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -2416,6 +2416,8 @@ void _gatherShards(const ShardsCollection &coll, std::vector<ShardInfo> &out, co
     if (!gatheringWires().count(wire)) {
       gatheringWires().insert(wire);
       for (auto blk : wire->shards) {
+        if (blk == nullptr)
+          break; // null terminated shards collection
         _gatherShards(blk, out, wire);
       }
     }

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -2492,6 +2492,8 @@ void _gatherWires(const ShardsCollection &coll, std::vector<WireNode> &out, cons
       out.emplace_back(currentWire, wire); // current, previous
       gatheringWires().insert(currentWire);
       for (auto blk : currentWire->shards) {
+        if (blk == nullptr)
+          break; // null terminated shards collection
         _gatherWires(blk, out, currentWire);
       }
     }

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1487,10 +1487,10 @@ SHComposeResult internalComposeWire(const SHWire *wire_, SHInstanceData data) {
     DEFER(wire->composing.store(false));
 
     // settle input type of wire before compose
-    if (wire->shards.size() > 0 && strncmp(wire->shards[0]->name(wire->shards[0]), "Expect", 6) == 0) {
+    if (wire->shards.size() > 0 && wire->shards[0] != nullptr && strncmp(wire->shards[0]->name(wire->shards[0]), "Expect", 6) == 0) {
       // If first shard is an Expect, this wire can accept ANY input type as the type is checked at runtime
       wire->inputType = SHTypeInfo{SHType::Any};
-    } else if (wire->shards.size() > 0 && !std::any_of(wire->shards.begin(), wire->shards.end(), [&](const auto &shard) {
+    } else if (wire->shards.size() > 0 && wire->shards[0] != nullptr && !std::any_of(wire->shards.begin(), wire->shards.end(), [&](const auto &shard) {
                  return shard != nullptr && strcmp(shard->name(shard), "Input") == 0;
                })) {
       // If first shard is a plain None, mark this wire has None input

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -3003,7 +3003,7 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
                     wire->looped,
                     wire->unsafe,
                     wire,
-                    {!wire->shards.empty() ? &wire->shards[0] : nullptr, uint32_t(wire->shards.size() - 1), 0},
+                    {&wire->shards[0], uint32_t(wire->shards.size() - 1), 0}, // Always safe, guaranteed null terminator
                     shards::isRunning(wire),
                     wire->state == SHWire::State::Failed || !wire->finishedError.empty(),
                     SHStringWithLen{wire->finishedError.c_str(), wire->finishedError.size()},

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1369,6 +1369,8 @@ SHComposeResult internalComposeWire(const std::vector<ShardPtr> &wire, SHInstanc
       size_t chsize = wire.size() > 0 && wire.back() == nullptr ? wire.size() - 1 : wire.size(); // exclude null terminator if present
       for (size_t i = 0; i < chsize; i++) {
         Shard *blk = wire[i];
+        if (blk == nullptr)
+          break; // skip null terminator or embedded nulls
         ctx.next = nullptr;
         if (i < chsize - 1)
           ctx.next = wire[i + 1];
@@ -1565,6 +1567,8 @@ SHComposeResult composeWire(const std::vector<ShardPtr> &wire, SHInstanceData da
 SHComposeResult composeWire(const Shards wire, SHInstanceData data) {
   std::vector<ShardPtr> shards;
   for (uint32_t i = 0; wire.len > i; i++) {
+    if (wire.elements[i] == nullptr)
+      break; // stop at null terminator
     shards.push_back(wire.elements[i]);
   }
   return composeWire(shards, data);
@@ -1573,7 +1577,10 @@ SHComposeResult composeWire(const Shards wire, SHInstanceData data) {
 SHComposeResult composeWire(const SHSeq wire, SHInstanceData data) {
   std::vector<ShardPtr> shards;
   for (uint32_t i = 0; wire.len > i; i++) {
-    shards.push_back(wire.elements[i].payload.shardValue);
+    auto shard = wire.elements[i].payload.shardValue;
+    if (shard == nullptr)
+      break; // stop at null terminator
+    shards.push_back(shard);
   }
   return composeWire(shards, data);
 }

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -742,7 +742,8 @@ ALWAYS_INLINE SHWireState shardsActivation(T &shards, SHContext *context, const 
   if constexpr (std::is_same<T, Shards>::value || std::is_same<T, SHSeq>::value) {
     len = shards.len;
   } else if constexpr (std::is_same<T, std::vector<ShardPtr>>::value) {
-    len = shards.size() > 0 ? shards.size() - 1 : 0; // exclude null terminator
+    shassert(shards.size() > 0 && "shards vector must be null-terminated");
+    len = shards.size() - 1; // exclude null terminator
   } else {
     shassert(false && "Unreachable shardsActivation case");
   }
@@ -2997,11 +2998,12 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
   result->getWireInfo = [](SHWireRef wireref) noexcept {
     auto &sc = SHWire::sharedFromRef(wireref);
     auto wire = sc.get();
+    shassert(wire->shards.size() > 0 && "wire->shards must be null-terminated");
     SHWireInfo info{SHStringWithLen{wire->name.c_str(), wire->name.size()},
                     wire->looped,
                     wire->unsafe,
                     wire,
-                    {!wire->shards.empty() ? &wire->shards[0] : nullptr, uint32_t(wire->shards.size() > 0 ? wire->shards.size() - 1 : 0), 0},
+                    {!wire->shards.empty() ? &wire->shards[0] : nullptr, uint32_t(wire->shards.size() - 1), 0},
                     shards::isRunning(wire),
                     wire->state == SHWire::State::Failed || !wire->finishedError.empty(),
                     SHStringWithLen{wire->finishedError.c_str(), wire->finishedError.size()},

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -742,7 +742,7 @@ ALWAYS_INLINE SHWireState shardsActivation(T &shards, SHContext *context, const 
   if constexpr (std::is_same<T, Shards>::value || std::is_same<T, SHSeq>::value) {
     len = shards.len;
   } else if constexpr (std::is_same<T, std::vector<ShardPtr>>::value) {
-    len = shards.size();
+    len = shards.size() > 0 ? shards.size() - 1 : 0; // exclude null terminator
   } else {
     shassert(false && "Unreachable shardsActivation case");
   }
@@ -1366,7 +1366,7 @@ SHComposeResult internalComposeWire(const std::vector<ShardPtr> &wire, SHInstanc
         ctx.sharedStorage.insert(item);
       }
 
-      size_t chsize = wire.size();
+      size_t chsize = wire.size() > 0 && wire.back() == nullptr ? wire.size() - 1 : wire.size(); // exclude null terminator if present
       for (size_t i = 0; i < chsize; i++) {
         Shard *blk = wire[i];
         ctx.next = nullptr;
@@ -1417,8 +1417,8 @@ SHComposeResult internalComposeWire(const std::vector<ShardPtr> &wire, SHInstanc
         }
       }
 
-      if (wire.size() > 0) {
-        auto &last = wire.back();
+      if (chsize > 0) {
+        auto &last = wire[chsize - 1]; // use chsize which excludes null terminator
         if (strcmp(last->name(last), "Restart") == 0 || strcmp(last->name(last), "Return") == 0 ||
             strcmp(last->name(last), "Fail") == 0) {
           result.flowStopper = true;
@@ -1488,7 +1488,7 @@ SHComposeResult internalComposeWire(const SHWire *wire_, SHInstanceData data) {
       // If first shard is an Expect, this wire can accept ANY input type as the type is checked at runtime
       wire->inputType = SHTypeInfo{SHType::Any};
     } else if (wire->shards.size() > 0 && !std::any_of(wire->shards.begin(), wire->shards.end(), [&](const auto &shard) {
-                 return strcmp(shard->name(shard), "Input") == 0;
+                 return shard != nullptr && strcmp(shard->name(shard), "Input") == 0;
                })) {
       // If first shard is a plain None, mark this wire has None input
       // But make sure we have no (Input) shards
@@ -2992,7 +2992,7 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
                     wire->looped,
                     wire->unsafe,
                     wire,
-                    {!wire->shards.empty() ? &wire->shards[0] : nullptr, uint32_t(wire->shards.size()), 0},
+                    {!wire->shards.empty() ? &wire->shards[0] : nullptr, uint32_t(wire->shards.size() > 0 ? wire->shards.size() - 1 : 0), 0},
                     shards::isRunning(wire),
                     wire->state == SHWire::State::Failed || !wire->finishedError.empty(),
                     SHStringWithLen{wire->finishedError.c_str(), wire->finishedError.size()},

--- a/shards/core/serialization.hpp
+++ b/shards/core/serialization.hpp
@@ -721,12 +721,14 @@ struct Serialization {
         total += sizeof(int32_t);
       }
       { // Shards len
-        uint32_t len = uint32_t(wire->shards.size());
+        uint32_t len = uint32_t(wire->shards.size() > 0 ? wire->shards.size() - 1 : 0); // exclude null terminator
         write((const uint8_t *)&len, sizeof(uint32_t));
         total += sizeof(uint32_t);
       }
       // Shards
       for (auto shard : wire->shards) {
+        if (shard == nullptr)
+          break; // null terminated shards collection
         SHVar shardVar{};
         shardVar.valueType = SHType::ShardRef;
         shardVar.payload.shardValue = shard;

--- a/shards/core/serialization.hpp
+++ b/shards/core/serialization.hpp
@@ -721,7 +721,8 @@ struct Serialization {
         total += sizeof(int32_t);
       }
       { // Shards len
-        uint32_t len = uint32_t(wire->shards.size() > 0 ? wire->shards.size() - 1 : 0); // exclude null terminator
+        shassert(wire->shards.size() > 0 && "wire->shards must be null-terminated");
+        uint32_t len = uint32_t(wire->shards.size() - 1); // exclude null terminator
         write((const uint8_t *)&len, sizeof(uint32_t));
         total += sizeof(uint32_t);
       }

--- a/shards/core/wires.cpp
+++ b/shards/core/wires.cpp
@@ -25,9 +25,13 @@ void SHWire::addTrait(SHTrait inTrait) {
 
 void SHWire::destroy() {
   for (auto it = shards.rbegin(); it != shards.rend(); ++it) {
+    if (*it == nullptr)
+      continue; // skip null terminator in reverse iteration
     (*it)->cleanup(*it, nullptr);
   }
   for (auto it = shards.rbegin(); it != shards.rend(); ++it) {
+    if (*it == nullptr)
+      continue; // skip null terminator in reverse iteration
     decRef(*it);
   }
 
@@ -64,6 +68,8 @@ void SHWire::warmup(SHContext *context) {
     context->wireStack.push_back(this);
     DEFER({ context->wireStack.pop_back(); });
     for (auto blk : shards) {
+      if (blk == nullptr)
+        break; // null terminator
       try {
         if (blk->warmup) {
           auto status = blk->warmup(blk, context);
@@ -112,6 +118,8 @@ void SHWire::cleanup(bool force) {
     // Do this in reverse to allow a safer cleanup
     for (auto it = shards.rbegin(); it != shards.rend(); ++it) {
       auto blk = *it;
+      if (blk == nullptr)
+        continue; // skip null terminator in reverse iteration
       try {
         blk->cleanup(blk, context);
       }

--- a/shards/modules/core/flow.hpp
+++ b/shards/modules/core/flow.hpp
@@ -60,12 +60,16 @@ struct Cond {
   void warmup(SHContext *ctx) {
     for (auto &blks : _conditions) {
       for (auto &blk : blks) {
+        if (blk == nullptr)
+          break; // null terminator
         if (blk->warmup)
           blk->warmup(blk, ctx);
       }
     }
     for (auto &blks : _actions) {
       for (auto &blk : blks) {
+        if (blk == nullptr)
+          break; // null terminator
         if (blk->warmup)
           blk->warmup(blk, ctx);
       }
@@ -77,6 +81,8 @@ struct Cond {
       auto &shards = *it;
       for (auto jt = shards.rbegin(); jt != shards.rend(); ++jt) {
         auto shard = *jt;
+        if (shard == nullptr)
+          continue; // skip null terminator in reverse iteration
         shard->cleanup(shard, context);
       }
     }
@@ -84,6 +90,8 @@ struct Cond {
       auto &shards = *it;
       for (auto jt = shards.rbegin(); jt != shards.rend(); ++jt) {
         auto shard = *jt;
+        if (shard == nullptr)
+          continue; // skip null terminator in reverse iteration
         shard->cleanup(shard, context);
       }
     }
@@ -127,6 +135,7 @@ struct Cond {
                 _actions[idx].push_back(blk);
               }
             }
+            _actions[idx].push_back(nullptr); // null terminator
 
             idx++;
           } else { // condition
@@ -143,6 +152,7 @@ struct Cond {
                 _conditions[idx].push_back(blk);
               }
             }
+            _conditions[idx].push_back(nullptr); // null terminator
           }
         }
       }
@@ -266,7 +276,7 @@ struct Cond {
     SHVar actionInput = input;
     SHVar finalOutput{};
     for (auto &cond : _conditions) {
-      Shards shards{&cond[0], (uint32_t)cond.size(), 0};
+      Shards shards{&cond[0], (uint32_t)(cond.size() > 0 ? cond.size() - 1 : 0), 0}; // exclude null terminator
       auto state = activateShards2(shards, context, input, _output);
       // conditional flow so we might have "returns" form (And) (Or)
       if (unlikely(state > SHWireState::Return))
@@ -276,7 +286,7 @@ struct Cond {
         // Do the action if true!
         // And stop here
         memset(&_output, 0, sizeof(SHVar));
-        Shards action{&_actions[idx][0], (uint32_t)_actions[idx].size(), 0};
+        Shards action{&_actions[idx][0], (uint32_t)(_actions[idx].size() > 0 ? _actions[idx].size() - 1 : 0), 0}; // exclude null terminator
         state = activateShards(action, context, actionInput, _output);
         if (state != SHWireState::Continue)
           return _output;

--- a/shards/modules/core/flow.hpp
+++ b/shards/modules/core/flow.hpp
@@ -276,7 +276,8 @@ struct Cond {
     SHVar actionInput = input;
     SHVar finalOutput{};
     for (auto &cond : _conditions) {
-      Shards shards{&cond[0], (uint32_t)(cond.size() > 0 ? cond.size() - 1 : 0), 0}; // exclude null terminator
+      shassert(cond.size() > 0 && "condition vector must be null-terminated");
+      Shards shards{&cond[0], (uint32_t)(cond.size() - 1), 0}; // exclude null terminator
       auto state = activateShards2(shards, context, input, _output);
       // conditional flow so we might have "returns" form (And) (Or)
       if (unlikely(state > SHWireState::Return))
@@ -286,7 +287,8 @@ struct Cond {
         // Do the action if true!
         // And stop here
         memset(&_output, 0, sizeof(SHVar));
-        Shards action{&_actions[idx][0], (uint32_t)(_actions[idx].size() > 0 ? _actions[idx].size() - 1 : 0), 0}; // exclude null terminator
+        shassert(_actions[idx].size() > 0 && "action vector must be null-terminated");
+        Shards action{&_actions[idx][0], (uint32_t)(_actions[idx].size() - 1), 0}; // exclude null terminator
         state = activateShards(action, context, actionInput, _output);
         if (state != SHWireState::Continue)
           return _output;

--- a/shards/modules/gfx/shader/composition.cpp
+++ b/shards/modules/gfx/shader/composition.cpp
@@ -103,6 +103,9 @@ struct DynamicBlockFromShards : public blocks::Block {
       }
 
       for (ShardPtr shard : shards) {
+        if (shard == nullptr)
+          break; // stop at null terminator
+
         shaderCtx.processShard(shard);
       }
       shaderCtx.finalize();

--- a/shards/modules/gfx/shader/translator.cpp
+++ b/shards/modules/gfx/shader/translator.cpp
@@ -136,6 +136,8 @@ TranslatedFunction TranslationContext::processShards(const std::vector<ShardPtr>
   stack.emplace_back(std::move(functionScope));
 
   for (ShardPtr shard : shards) {
+    if (shard == nullptr)
+      break; // null terminated shards collection
     processShard(shard);
   }
   stack.pop_back();

--- a/shards/modules/gfx/shader/translator.cpp
+++ b/shards/modules/gfx/shader/translator.cpp
@@ -396,6 +396,8 @@ void TranslationRegistry::registerHandler(const char *blockName, ITranslationHan
 }
 
 ITranslationHandler *TranslationRegistry::resolve(ShardPtr shard) {
+  if (shard == nullptr)
+    return nullptr; // null terminator or invalid shard
   auto it = handlers.find((const char *)shard->name(shard));
   if (it != handlers.end())
     return it->second;

--- a/shards/modules/gfx/shader/translator_utils.hpp
+++ b/shards/modules/gfx/shader/translator_utils.hpp
@@ -212,6 +212,8 @@ inline std::unique_ptr<IWGSLGenerated> translateParamVar(const shards::ParamVar 
 inline void processShards(boost::span<ShardPtr> shards, TranslationContext &context) {
   for (size_t i = 0; i < shards.size(); i++) {
     ShardPtr shard = shards[i];
+    if (shard == nullptr)
+      break; // null terminator
     context.processShard(shard);
   }
 }

--- a/shards/modules/json/json.cpp
+++ b/shards/modules/json/json.cpp
@@ -474,6 +474,8 @@ void to_json(json &j, const SHWireRef &wireref) {
   auto wire = SHWire::sharedFromRef(wireref);
   std::vector<json> shards;
   for (auto blk : wire->shards) {
+    if (blk == nullptr)
+      break; // null terminated shards collection
     SHVar blkVar{};
     blkVar.valueType = SHType::ShardRef;
     blkVar.payload.shardValue = blk;

--- a/shards/tests/test_runtime.cpp
+++ b/shards/tests/test_runtime.cpp
@@ -886,7 +886,7 @@ TEST_CASE("SHMap") {
 TEST_CASE("CXX-Wire-DSL") {
   // TODO, improve this
   auto wire = shards::Wire("test-wire").looped(true).let(1).shard("Log").shard("Math.Add", 2).shard("Assert.Is", 3, true);
-  assert(wire->shards.size() == 4);
+  assert(wire->shards.size() == 5); // 4 shards + null terminator
 }
 
 TEST_CASE("DynamicArray") {


### PR DESCRIPTION
## Summary
Preparation work for trampoline-based execution system to fix stack overflow issues with deeply nested control flow.

## Changes
This PR adds NULL terminators to all shard collections as a prerequisite for the upcoming trampoline optimization.

### Core Changes
- Added NULL terminators to `wire->shards` vectors
- Updated `Cond` shard internal vectors with NULL terminators
- Fixed all shard iteration loops to handle NULL terminators correctly
- Updated size calculations to exclude terminators where needed

### Files Modified
- **json.cpp**: Fixed wire->shards iteration
- **hash.inl**: Fixed wire->shards iteration  
- **shader/translator.cpp**: Fixed shards iteration
- **runtime.cpp**: Fixed shardsActivation len calculation, std::any_of, SHWireInfo, composeWire
- **serialization.hpp**: Fixed wire serialization length and iteration
- **flow.hpp**: Fixed Cond warmup/cleanup/activate with NULL checks
- **test_runtime.cpp**: Updated assertion to account for terminator

### Impact
- All shard collections now consistently use NULL-terminated arrays
- Enables future trampoline optimization for control flow shards
- No functional changes - purely structural preparation
- Should be 100% backward compatible

### Testing
- Existing tests updated where needed
- CI will validate compatibility

## Next Steps
After this merges, follow-up PRs will:
1. Refactor control flow shards to use ShardsVar consistently
2. Implement the trampoline execution system
3. Add the `nestedShards` field to Shard struct