### PR TITLE
Refactor ShardMetadata structure and static procedures

### DIFF
--- a/SHARD_METADATA_MIGRATION.md
+++ b/SHARD_METADATA_MIGRATION.md
@@ -1,0 +1,102 @@
+# Shard Metadata Migration Summary
+
+## Overview
+Migrated static/compile-time fields from per-instance `Shard` struct to shared `ShardMetadata` struct to reduce memory usage and improve cache locality.
+
+## Changes Made
+
+### 1. ShardMetadata struct (`include/shards/shards.h:787-807`)
+**Expanded to include:**
+- `staticName` - Static name for shards that don't override name()
+- `nameLength` - Cached name length (uint32_t)
+- `hash` - Type-level hash (crc32)
+- `help` - Static help documentation
+- `inputHelp` - Static input documentation
+- `outputHelp` - Static output documentation
+- `parameters` - Parameter structure (static for a shard type)
+
+### 2. ShardWrapper (`include/shards/shardwrapper.hpp`)
+
+**Added:**
+- `initMetadata()` static function to populate metadata fields during registration (lines 50-69)
+
+**Modified:**
+- `create()` function now uses `metadata->*` fields for shards without instance overrides:
+  - `name` → `metadata->staticName` (line 82)
+  - `hash` → `metadata->hash` (line 90)
+  - `help` → `metadata->help` (line 97)
+  - `inputHelp` → `metadata->inputHelp` (line 105)
+  - `outputHelp` → `metadata->outputHelp` (line 113)
+  - `parameters` → `metadata->parameters` (line 182)
+- Also sets `result->nameLength` directly from metadata (line 83)
+
+**Registration macros updated:**
+- `REGISTER_SHARD` now calls `initMetadata()` (line 373)
+- `REGISTER_SHARD_ALIAS` updated similarly (lines 378-382)
+
+### 3. Legacy Macros (`shards/core/shards_macros.hpp`)
+
+**All runtime shard macros updated:**
+- `RUNTIME_SHARD` - Added metadata initialization (lines 15-25)
+- `RUNTIME_CORE_SHARD` - Updated metadata initialization (lines 48-58)
+- `RUNTIME_SHARD_TYPE` - Updated metadata initialization (lines 92-102)
+- `RUNTIME_CORE_SHARD_TYPE` - Updated metadata initialization (lines 137-147)
+
+**All factory macros updated to use metadata:**
+- Name, hash, help, inputHelp, outputHelp, parameters now reference `shard->metadata->*`
+- `nameLength` set directly from metadata
+
+**Global replacement:**
+- All occurrences of parameter/help lambdas updated to use metadata (4 occurrences)
+
+## Benefits
+
+1. **Memory Savings** - One metadata copy per shard type instead of per instance
+2. **Cache Locality** - Hot instance data stays together, cold metadata separate
+3. **Clear Semantics** - Explicit separation of type-level vs instance-level data
+4. **Optimization Potential** - Static data can live in read-only memory
+
+## What Stays in Shard Struct
+
+- `inputTypes`/`outputTypes` - Can change dynamically after compose()
+- `properties` - Can be instance-variant
+- All lifecycle function pointers (setup, destroy, warmup, activate, cleanup, etc.)
+- Instance-specific fields (refCount, owned, line, column, file, debuggerId, etc.)
+
+## Build Considerations
+
+### Potential Issues:
+1. **ABI Change** - This changes the `ShardMetadata` struct layout
+2. **Initialization Order** - `initMetadata()` must be called during registration
+3. **Null Pointer** - Code must ensure `metadata` pointer is set before dereferencing
+
+### Testing Checklist:
+- [ ] Verify all shards registered via `REGISTER_SHARD` work correctly
+- [ ] Verify legacy macros (`RUNTIME_SHARD`, etc.) work correctly
+- [ ] Test shards with custom name()/hash()/help() methods
+- [ ] Test shards without custom methods (using static defaults)
+- [ ] Verify metadata fields are properly initialized
+- [ ] Check for null pointer dereferences on `shard->metadata`
+- [ ] Run full test suite: `just tests`
+
+### Debugging:
+If you see crashes related to null `metadata` pointer:
+1. Check that `REGISTER_SHARD` macro is calling `initMetadata()`
+2. Verify `result->metadata = &metadata` is set in create() functions
+3. Ensure metadata is initialized before first use
+
+## Next Steps
+
+When building locally:
+1. Run `just format` to format code
+2. Run `just build` to compile
+3. Run `just tests` to verify functionality
+4. Check for any compiler warnings about uninitialized metadata
+5. Test with real shard usage to verify runtime behavior
+
+## Notes
+
+- The abstraction via `ShardWrapper` and macros means most shard implementations don't need changes
+- Only the wrapper/macro infrastructure was updated
+- Shards that override methods (name(), hash(), help(), etc.) still work via their override functions
+- Shards without overrides now benefit from shared metadata storage

--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -789,6 +789,21 @@ struct ShardMetadata {
   SHString category;
   // Optional compile time defined alias of another shard
   SHString aliasOf;
+
+  // Static name for shards that don't override name()
+  SHString staticName;
+  // Cached name length
+  uint32_t nameLength;
+  // Type-level hash (crc32)
+  uint32_t hash;
+
+  // Static documentation strings
+  SHOptionalString help;
+  SHOptionalString inputHelp;
+  SHOptionalString outputHelp;
+
+  // Parameter structure (static for a shard type)
+  SHParametersInfo parameters;
 };
 
 struct Shard {

--- a/include/shards/shardwrapper.hpp
+++ b/include/shards/shardwrapper.hpp
@@ -44,8 +44,29 @@ template <class T> struct ShardWrapper {
 
   static inline const char *name = "";
   static inline const char *aliasOf = "";
-  static inline ShardMetadata metadata;
+  static inline ShardMetadata metadata{};
   static inline uint32_t crc = 0;
+
+  // Initialize metadata with static values (called during registration)
+  static void initMetadata() {
+    metadata.staticName = name;
+    metadata.nameLength = name ? strlen(name) : 0;
+    metadata.hash = crc;
+
+    // These will be populated if the shard type has static methods
+    if constexpr (!has_help<T>::value) {
+      metadata.help = SHOptionalString();
+    }
+    if constexpr (!has_inputHelp<T>::value) {
+      metadata.inputHelp = SHOptionalString();
+    }
+    if constexpr (!has_outputHelp<T>::value) {
+      metadata.outputHelp = SHOptionalString();
+    }
+    if constexpr (!has_parameters<T>::value) {
+      metadata.parameters = SHParametersInfo();
+    }
+  }
 
   static Shard *create() {
     auto self = new (std::align_val_t{16}) ShardWrapper<T>();
@@ -58,21 +79,22 @@ template <class T> struct ShardWrapper {
     if constexpr (has_name<T>::value) {
       result->name = static_cast<SHNameProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.name(); });
     } else {
-      result->name = static_cast<SHNameProc>([](Shard *b) { return name; });
+      result->name = static_cast<SHNameProc>([](Shard *b) { return b->metadata->staticName; });
+      result->nameLength = metadata.nameLength;
     }
 
     // hash
     if constexpr (has_hash<T>::value) {
       result->hash = static_cast<SHHashProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.hash(); });
     } else {
-      result->hash = static_cast<SHHashProc>([](Shard *b) { return crc; });
+      result->hash = static_cast<SHHashProc>([](Shard *b) { return b->metadata->hash; });
     }
 
     // help
     if constexpr (has_help<T>::value) {
       result->help = static_cast<SHHelpProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.help(); });
     } else {
-      result->help = static_cast<SHHelpProc>([](Shard *b) { return SHOptionalString(); });
+      result->help = static_cast<SHHelpProc>([](Shard *b) { return b->metadata->help; });
     }
 
     // inputHelp
@@ -80,7 +102,7 @@ template <class T> struct ShardWrapper {
       result->inputHelp =
           static_cast<SHHelpProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.inputHelp(); });
     } else {
-      result->inputHelp = static_cast<SHHelpProc>([](Shard *b) { return SHOptionalString(); });
+      result->inputHelp = static_cast<SHHelpProc>([](Shard *b) { return b->metadata->inputHelp; });
     }
 
     // outputHelp
@@ -88,7 +110,7 @@ template <class T> struct ShardWrapper {
       result->outputHelp =
           static_cast<SHHelpProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.outputHelp(); });
     } else {
-      result->outputHelp = static_cast<SHHelpProc>([](Shard *b) { return SHOptionalString(); });
+      result->outputHelp = static_cast<SHHelpProc>([](Shard *b) { return b->metadata->outputHelp; });
     }
 
     // properties
@@ -157,7 +179,7 @@ template <class T> struct ShardWrapper {
       result->parameters =
           static_cast<SHParametersProc>([](Shard *b) { return reinterpret_cast<ShardWrapper<T> *>(b)->shard.parameters(); });
     } else {
-      result->parameters = static_cast<SHParametersProc>([](Shard *b) { return SHParametersInfo(); });
+      result->parameters = static_cast<SHParametersProc>([](Shard *b) { return b->metadata->parameters; });
     }
 
     // setParam
@@ -348,11 +370,15 @@ template <typename T> inline Shard *toShard(T *self) { return &toShardWrapper(se
   ::shards::ShardWrapper<__type__>::name = __name__;                                                                   \
   ::shards::ShardWrapper<__type__>::crc = ::shards::constant<::shards::crc32(__name__ SHARDS_CURRENT_ABI_STR)>::value; \
   ::shards::ShardWrapper<__type__>::metadata.category = SHString(SHARD_MODULE_STRINGIFY(SHARDS_THIS_MODULE_ID));       \
+  ::shards::ShardWrapper<__type__>::initMetadata();                                                                    \
   ::shards::registerShard(::shards::ShardWrapper<__type__>::name, &::shards::ShardWrapper<__type__>::create,           \
                           NAMEOF_FULL_TYPE(__type__))
 
 #define REGISTER_SHARD_ALIAS(__name__, __aliasOf__, __type__)       \
+  ::shards::ShardWrapper<__type__>::name = __name__;                \
+  ::shards::ShardWrapper<__type__>::crc = ::shards::constant<::shards::crc32(__name__ SHARDS_CURRENT_ABI_STR)>::value; \
   ::shards::ShardWrapper<__type__>::metadata.aliasOf = __aliasOf__; \
+  ::shards::ShardWrapper<__type__>::initMetadata();                 \
   ::shards::registerShard(__name__, &::shards::ShardWrapper<__type__>::create, NAMEOF_FULL_TYPE(__type__))
 
 #define OVERRIDE_ACTIVATE(__data__, __func__)                                                                            \

--- a/shards/core/shards_macros.hpp
+++ b/shards/core/shards_macros.hpp
@@ -12,14 +12,25 @@
     _name_ core;                                                                                                         \
     std::string lastError;                                                                                               \
     SHVar outputStorage;                                                                                                 \
+    static inline ShardMetadata metadata{                                                                                \
+        "core",                                                                                     /* category */        \
+        "",                                                                                         /* aliasOf */         \
+        #_namespace_ "." #_name_,                                                                   /* staticName */      \
+        sizeof(#_namespace_ "." #_name_) - 1,                                                       /* nameLength */      \
+        ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value, /* hash */         \
+        SHOptionalString(),                                                                         /* help */            \
+        SHOptionalString(),                                                                         /* inputHelp */       \
+        SHOptionalString(),                                                                         /* outputHelp */      \
+        SHParametersInfo()                                                                          /* parameters */      \
+    };                                                                                                                   \
   };                                                                                                                     \
   __cdecl Shard *createShard##_name_() {                                                                                 \
     Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                       \
-    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                            \
-      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                \
-    });                                                                                                                  \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->metadata = &_name_##Runtime::metadata;                                                                       \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return shard->metadata->staticName; });                    \
+    result->nameLength = _name_##Runtime::metadata.nameLength;                                                           \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) { return shard->metadata->hash; });                          \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->help; });                             \
     result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
@@ -30,12 +41,12 @@
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
     result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
     result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return shard->metadata->parameters; });        \
     result->setParam =                                                                                                   \
         static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
     result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->inputHelp; });                \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->outputHelp; });              \
     result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
     result->cleanup = static_cast<SHCleanupProc>([](Shard *shard, SHContext *) { return SHError::Success; });
 
@@ -45,15 +56,25 @@
     _name_ core;                                                                                                         \
     std::string lastError;                                                                                               \
     SHVar outputStorage;                                                                                                 \
-    static inline ShardMetadata metadata{"core"};                                                                        \
+    static inline ShardMetadata metadata{                                                                                \
+        "core",                                                                                     /* category */        \
+        "",                                                                                         /* aliasOf */         \
+        #_name_,                                                                                    /* staticName */      \
+        sizeof(#_name_) - 1,                                                                        /* nameLength */      \
+        ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value,                /* hash */            \
+        SHOptionalString(),                                                                         /* help */            \
+        SHOptionalString(),                                                                         /* inputHelp */       \
+        SHOptionalString(),                                                                         /* outputHelp */      \
+        SHParametersInfo()                                                                          /* parameters */      \
+    };                                                                                                                   \
   };                                                                                                                     \
   __cdecl Shard *createShard##_name_() {                                                                                 \
     Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
     result->metadata = &_name_##Runtime::metadata;                                                                       \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                        \
-    result->hash = static_cast<SHHashProc>(                                                                              \
-        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });        \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return shard->metadata->staticName; });                    \
+    result->nameLength = _name_##Runtime::metadata.nameLength;                                                           \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) { return shard->metadata->hash; });                          \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->help; });                          \
     result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
@@ -64,12 +85,12 @@
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
     result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
     result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return shard->metadata->parameters; });        \
     result->setParam =                                                                                                   \
         static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
     result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->inputHelp; });                \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->outputHelp; });              \
     result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
     result->cleanup = static_cast<SHCleanupProc>([](Shard *shard, SHContext *) { return SHError::Success; });
 
@@ -79,17 +100,26 @@
     _name_ core;                                  \
     std::string lastError;                        \
     SHVar outputStorage;                          \
-    static inline ShardMetadata metadata{"core"}; \
+    static inline ShardMetadata metadata{        \
+        "core",                                                                                     /* category */        \
+        "",                                                                                         /* aliasOf */         \
+        #_namespace_ "." #_name_,                                                                   /* staticName */      \
+        sizeof(#_namespace_ "." #_name_) - 1,                                                       /* nameLength */      \
+        ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value, /* hash */         \
+        SHOptionalString(),                                                                         /* help */            \
+        SHOptionalString(),                                                                         /* inputHelp */       \
+        SHOptionalString(),                                                                         /* outputHelp */      \
+        SHParametersInfo()                                                                          /* parameters */      \
+    };                                            \
   };
 #define RUNTIME_SHARD_FACTORY(_namespace_, _name_)                                                                       \
   __cdecl Shard *createShard##_name_() {                                                                                 \
     Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
     result->metadata = &_name_##Runtime::metadata;                                                                       \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_namespace_ "." #_name_; });                       \
-    result->hash = static_cast<SHHashProc>([](Shard *shard) {                                                            \
-      return ::shards::constant<::shards::crc32(#_namespace_ "." #_name_ SHARDS_CURRENT_ABI_STR)>::value;                \
-    });                                                                                                                  \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return shard->metadata->staticName; });                    \
+    result->nameLength = _name_##Runtime::metadata.nameLength;                                                           \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) { return shard->metadata->hash; });                          \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->help; });                             \
     result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
@@ -100,12 +130,12 @@
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
     result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
     result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return shard->metadata->parameters; });        \
     result->setParam =                                                                                                   \
         static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
     result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->inputHelp; });                \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->outputHelp; });              \
     result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
     result->cleanup = static_cast<SHCleanupProc>([](Shard *shard, SHContext *) { return SHError::Success; });
 
@@ -115,17 +145,27 @@
     _name_ core;                                  \
     std::string lastError;                        \
     SHVar outputStorage;                          \
-    static inline ShardMetadata metadata{"core"}; \
+    static inline ShardMetadata metadata{        \
+        "core",                                                                                     /* category */        \
+        "",                                                                                         /* aliasOf */         \
+        #_name_,                                                                                    /* staticName */      \
+        sizeof(#_name_) - 1,                                                                        /* nameLength */      \
+        ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value,                /* hash */            \
+        SHOptionalString(),                                                                         /* help */            \
+        SHOptionalString(),                                                                         /* inputHelp */       \
+        SHOptionalString(),                                                                         /* outputHelp */      \
+        SHParametersInfo()                                                                          /* parameters */      \
+    };                                            \
   };
 
 #define RUNTIME_CORE_SHARD_FACTORY(_name_)                                                                               \
   __cdecl Shard *createShard##_name_() {                                                                                 \
     Shard *result = reinterpret_cast<Shard *>(new (std::align_val_t{16}) _name_##Runtime());                             \
     result->metadata = &_name_##Runtime::metadata;                                                                       \
-    result->name = static_cast<SHNameProc>([](Shard *shard) { return #_name_; });                                        \
-    result->hash = static_cast<SHHashProc>(                                                                              \
-        [](Shard *shard) { return ::shards::constant<::shards::crc32(#_name_ SHARDS_CURRENT_ABI_STR)>::value; });        \
-    result->help = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                             \
+    result->name = static_cast<SHNameProc>([](Shard *shard) { return shard->metadata->staticName; });                    \
+    result->nameLength = _name_##Runtime::metadata.nameLength;                                                           \
+    result->hash = static_cast<SHHashProc>([](Shard *shard) { return shard->metadata->hash; });                          \
+    result->help = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->help; });                             \
     result->setup = static_cast<SHSetupProc>([](Shard *shard) {});                                                       \
     result->destroy = static_cast<SHDestroyProc>([](Shard *shard) {                                                      \
       auto blk = (_name_##Runtime *)shard;                                                                               \
@@ -136,12 +176,12 @@
     result->outputTypes = static_cast<SHOutputTypesProc>([](Shard *shard) { return SHTypesInfo(); });                    \
     result->exposedVariables = static_cast<SHExposedVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); });   \
     result->requiredVariables = static_cast<SHRequiredVariablesProc>([](Shard *shard) { return SHExposedTypesInfo(); }); \
-    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return SHParametersInfo(); });                 \
+    result->parameters = static_cast<SHParametersProc>([](Shard *shard) { return shard->metadata->parameters; });        \
     result->setParam =                                                                                                   \
         static_cast<SHSetParamProc>([](Shard *shard, int index, const SHVar *value) { return SHError::Success; });       \
     result->getParam = static_cast<SHGetParamProc>([](Shard *shard, int index) { return SHVar(); });                     \
-    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                        \
-    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return SHOptionalString(); });                       \
+    result->inputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->inputHelp; });                \
+    result->outputHelp = static_cast<SHHelpProc>([](Shard *shard) { return shard->metadata->outputHelp; });              \
     result->properties = static_cast<SHPropertiesProc>([](Shard *shard) -> const SHTable * { return nullptr; });         \
     result->cleanup = static_cast<SHCleanupProc>([](Shard *shard, SHContext *) { return SHError::Success; });
 


### PR DESCRIPTION
Migrated compile-time/static fields from per-instance Shard struct to shared ShardMetadata struct to reduce memory usage and improve cache locality.

Changes:
- Expanded ShardMetadata with: staticName, nameLength, hash, help, inputHelp, outputHelp, parameters
- Updated ShardWrapper to populate and use metadata fields via initMetadata()
- Modified REGISTER_SHARD macros to initialize metadata
- Updated all legacy RUNTIME_SHARD macros in shards_macros.hpp

Benefits:
- One metadata copy per shard type instead of per instance
- Better cache locality for hot instance data
- Clear separation of type-level vs instance-level data
- No changes needed to actual shard implementations

See SHARD_METADATA_MIGRATION.md for detailed migration notes and testing checklist.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
