### PR TITLE
Make File parameter optional in fileops

### DIFF
--- a/shards/modules/fileops/src/lib.rs
+++ b/shards/modules/fileops/src/lib.rs
@@ -321,8 +321,11 @@ struct GrepShard {
   #[shard_required]
   required: ExposedTypes,
 
-  #[shard_param("File", "File path to search in", [common_type::string, common_type::string_var])]
+  #[shard_param("File", "File path to search in", [common_type::none, common_type::string, common_type::string_var])]
   file: ParamVar,
+
+  #[shard_param("String", "Pure text string to search in (alternative to File)", [common_type::none, common_type::string, common_type::string_var])]
+  string: ParamVar,
 
   #[shard_param("WorkDir", "Working directory for resolving relative paths", [common_type::none, common_type::string, common_type::string_var])]
   work_dir: ParamVar,
@@ -356,6 +359,7 @@ impl Default for GrepShard {
     Self {
       required: ExposedTypes::new(),
       file: ParamVar::default(),
+      string: ParamVar::default(),
       work_dir: ParamVar::default(),
       case_insensitive: ParamVar::new(false.into()),
       line_numbers: ParamVar::new(true.into()),
@@ -392,34 +396,61 @@ impl Shard for GrepShard {
 
   fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
     self.compose_helper(data)?;
+
+    // Validate that either File or String is provided
+    let has_file = !self.file.get().as_ref().is_none();
+    let has_string = !self.string.get().as_ref().is_none();
+
+    if !has_file && !has_string {
+      return Err("Either File or String parameter must be provided");
+    }
+
+    if has_file && has_string {
+      return Err("Cannot specify both File and String parameters - use only one");
+    }
+
     Ok(self.output_types()[0])
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
     let pattern: &str = input.try_into()?;
 
-    // Get file path
-    let file_path_str: &str = self.file.get().as_ref().try_into().map_err(|_| {
-      shlog_error!("File parameter must be a string");
-      "File parameter must be a string"
-    })?;
+    // Determine if using File or String mode
+    let use_file = !self.file.get().as_ref().is_none();
 
-    // Get working directory
-    let work_dir = if self.work_dir.get().as_ref().is_none() {
-      env::current_dir().map_err(|e| {
-        shlog_error!("Failed to get current directory: {}", e);
-        "Failed to get current directory"
-      })?
-    } else {
-      let work_dir_str: &str = self.work_dir.get().as_ref().try_into().map_err(|_| {
-        shlog_error!("WorkDir parameter must be a string");
-        "WorkDir parameter must be a string"
+    // Get file path or string content
+    let (file_path, string_content, source_name) = if use_file {
+      // File mode
+      let file_path_str: &str = self.file.get().as_ref().try_into().map_err(|_| {
+        shlog_error!("File parameter must be a string");
+        "File parameter must be a string"
       })?;
-      PathBuf::from(work_dir_str)
-    };
 
-    // Resolve file path
-    let file_path = resolve_path(file_path_str, &work_dir);
+      // Get working directory
+      let work_dir = if self.work_dir.get().as_ref().is_none() {
+        env::current_dir().map_err(|e| {
+          shlog_error!("Failed to get current directory: {}", e);
+          "Failed to get current directory"
+        })?
+      } else {
+        let work_dir_str: &str = self.work_dir.get().as_ref().try_into().map_err(|_| {
+          shlog_error!("WorkDir parameter must be a string");
+          "WorkDir parameter must be a string"
+        })?;
+        PathBuf::from(work_dir_str)
+      };
+
+      // Resolve file path
+      let file_path = resolve_path(file_path_str, &work_dir);
+      (Some(file_path.clone()), None, file_path.display().to_string())
+    } else {
+      // String mode
+      let string_content_str: &str = self.string.get().as_ref().try_into().map_err(|_| {
+        shlog_error!("String parameter must be a string");
+        "String parameter must be a string"
+      })?;
+      (None, Some(string_content_str.to_string()), "<string>".to_string())
+    };
 
     // Get parameters
     let case_insensitive: bool = self.case_insensitive.get().as_ref().try_into().map_err(|_| "CaseInsensitive must be a boolean")?;
@@ -523,14 +554,20 @@ impl Shard for GrepShard {
     let max = if max_matches == 0 { i64::MAX } else { max_matches };
     let mut sink = GrepSinkImpl {
       output: AutoSeqVar::new(),
-      file_path: file_path.display().to_string(),
+      file_path: source_name,
       line_numbers,
       match_count: 0,
       max_matches: max,
     };
 
-    // Search the file
-    let result = searcher.search_path(&matcher, &file_path, &mut sink);
+    // Search either file or string
+    let result = if let Some(ref path) = file_path {
+      searcher.search_path(&matcher, path, &mut sink)
+    } else if let Some(ref content) = string_content {
+      searcher.search_slice(&matcher, content.as_bytes(), &mut sink)
+    } else {
+      unreachable!("Either file_path or string_content must be set");
+    };
 
     // Handle search errors
     if let Err(e) = result {

--- a/shards/modules/fileops/src/lib.rs
+++ b/shards/modules/fileops/src/lib.rs
@@ -396,8 +396,13 @@ impl Shard for GrepShard {
 
   fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
     self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    // Validate that either File or String is provided
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let pattern: &str = input.try_into()?;
+
+    // Validate that either File or String is provided (but not both)
     let has_file = !self.file.get().as_ref().is_none();
     let has_string = !self.string.get().as_ref().is_none();
 
@@ -408,12 +413,6 @@ impl Shard for GrepShard {
     if has_file && has_string {
       return Err("Cannot specify both File and String parameters - use only one");
     }
-
-    Ok(self.output_types()[0])
-  }
-
-  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-    let pattern: &str = input.try_into()?;
 
     // Get parameters
     let case_insensitive: bool = self.case_insensitive.get().as_ref().try_into().map_err(|_| "CaseInsensitive must be a boolean")?;

--- a/shards/modules/fileops/src/lib.rs
+++ b/shards/modules/fileops/src/lib.rs
@@ -415,43 +415,6 @@ impl Shard for GrepShard {
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
     let pattern: &str = input.try_into()?;
 
-    // Determine if using File or String mode
-    let use_file = !self.file.get().as_ref().is_none();
-
-    // Get file path or string content
-    let (file_path, string_content, source_name) = if use_file {
-      // File mode
-      let file_path_str: &str = self.file.get().as_ref().try_into().map_err(|_| {
-        shlog_error!("File parameter must be a string");
-        "File parameter must be a string"
-      })?;
-
-      // Get working directory
-      let work_dir = if self.work_dir.get().as_ref().is_none() {
-        env::current_dir().map_err(|e| {
-          shlog_error!("Failed to get current directory: {}", e);
-          "Failed to get current directory"
-        })?
-      } else {
-        let work_dir_str: &str = self.work_dir.get().as_ref().try_into().map_err(|_| {
-          shlog_error!("WorkDir parameter must be a string");
-          "WorkDir parameter must be a string"
-        })?;
-        PathBuf::from(work_dir_str)
-      };
-
-      // Resolve file path
-      let file_path = resolve_path(file_path_str, &work_dir);
-      (Some(file_path.clone()), None, file_path.display().to_string())
-    } else {
-      // String mode
-      let string_content_str: &str = self.string.get().as_ref().try_into().map_err(|_| {
-        shlog_error!("String parameter must be a string");
-        "String parameter must be a string"
-      })?;
-      (None, Some(string_content_str.to_string()), "<string>".to_string())
-    };
-
     // Get parameters
     let case_insensitive: bool = self.case_insensitive.get().as_ref().try_into().map_err(|_| "CaseInsensitive must be a boolean")?;
     let line_numbers: bool = self.line_numbers.get().as_ref().try_into().map_err(|_| "LineNumbers must be a boolean")?;
@@ -497,7 +460,7 @@ impl Shard for GrepShard {
     // Custom sink to properly count only matches, not context lines
     struct GrepSinkImpl {
       output: AutoSeqVar,
-      file_path: String,
+      source_name: String,
       line_numbers: bool,
       match_count: i64,
       max_matches: i64,
@@ -521,7 +484,7 @@ impl Shard for GrepShard {
         }
 
         match_table.0.insert_fast_static("line", &Var::ephemeral_string(&line));
-        match_table.0.insert_fast_static("file", &Var::ephemeral_string(&self.file_path));
+        match_table.0.insert_fast_static("file", &Var::ephemeral_string(&self.source_name));
         match_table.0.insert_fast_static("is_match", &true.into());
 
         self.output.0.push(&match_table.0.0);
@@ -542,7 +505,7 @@ impl Shard for GrepShard {
         }
 
         context_table.0.insert_fast_static("line", &Var::ephemeral_string(&line));
-        context_table.0.insert_fast_static("file", &Var::ephemeral_string(&self.file_path));
+        context_table.0.insert_fast_static("file", &Var::ephemeral_string(&self.source_name));
         context_table.0.insert_fast_static("is_match", &false.into());
 
         self.output.0.push(&context_table.0.0);
@@ -551,22 +514,65 @@ impl Shard for GrepShard {
       }
     }
 
-    let max = if max_matches == 0 { i64::MAX } else { max_matches };
-    let mut sink = GrepSinkImpl {
-      output: AutoSeqVar::new(),
-      file_path: source_name,
-      line_numbers,
-      match_count: 0,
-      max_matches: max,
-    };
+    // Determine if using File or String mode and perform search
+    let use_file = !self.file.get().as_ref().is_none();
 
-    // Search either file or string
-    let result = if let Some(ref path) = file_path {
-      searcher.search_path(&matcher, path, &mut sink)
-    } else if let Some(ref content) = string_content {
-      searcher.search_slice(&matcher, content.as_bytes(), &mut sink)
+    let max = if max_matches == 0 { i64::MAX } else { max_matches };
+
+    let result = if use_file {
+      // File mode
+      let file_path_str: &str = self.file.get().as_ref().try_into().map_err(|_| {
+        shlog_error!("File parameter must be a string");
+        "File parameter must be a string"
+      })?;
+
+      // Get working directory
+      let work_dir = if self.work_dir.get().as_ref().is_none() {
+        env::current_dir().map_err(|e| {
+          shlog_error!("Failed to get current directory: {}", e);
+          "Failed to get current directory"
+        })?
+      } else {
+        let work_dir_str: &str = self.work_dir.get().as_ref().try_into().map_err(|_| {
+          shlog_error!("WorkDir parameter must be a string");
+          "WorkDir parameter must be a string"
+        })?;
+        PathBuf::from(work_dir_str)
+      };
+
+      // Resolve file path
+      let file_path = resolve_path(file_path_str, &work_dir);
+      let source_name = file_path.display().to_string();
+
+      let mut sink = GrepSinkImpl {
+        output: AutoSeqVar::new(),
+        source_name,
+        line_numbers,
+        match_count: 0,
+        max_matches: max,
+      };
+
+      let result = searcher.search_path(&matcher, &file_path, &mut sink);
+      self.output = sink.output;
+      result
     } else {
-      unreachable!("Either file_path or string_content must be set");
+      // String mode
+      let string_content: &str = self.string.get().as_ref().try_into().map_err(|_| {
+        shlog_error!("String parameter must be a string");
+        "String parameter must be a string"
+      })?;
+
+      let mut sink = GrepSinkImpl {
+        output: AutoSeqVar::new(),
+        source_name: "<string>".to_string(),
+        line_numbers,
+        match_count: 0,
+        max_matches: max,
+      };
+
+      let result = searcher.search_slice(&matcher, string_content.as_bytes(), &mut sink);
+      self.output = sink.output;
+      result
     };
 
     // Handle search errors
@@ -574,9 +580,6 @@ impl Shard for GrepShard {
       shlog_error!("Grep search failed: {}", e);
       return Err("Grep search failed");
     }
-
-    // Transfer results to self.output
-    self.output = sink.output;
 
     Ok(Some(self.output.0.0))
   }

--- a/shards/tests/fileops.shs
+++ b/shards/tests/fileops.shs
@@ -275,6 +275,137 @@ This file is accessed using a relative path.""" = relative-content
 "test-fileops/relative-test.txt" | FileOps.ViewFile | Log("Verify relative path edit")
 
 // ============================================================================
+// Test 16: Grep with String parameter - Basic search
+// ============================================================================
+"""The quick brown fox jumps over the lazy dog.
+The QUICK brown FOX jumps again.
+Lorem ipsum dolor sit amet.
+Another line with FOX in it.
+Quick thinking saves the day.
+This is line six.
+This is line seven.
+Final line with nothing special.""" = string-grep-content
+
+// Basic pattern search in string
+"fox" | Grep(String: string-grep-content) = string-matches
+string-matches | Log("Grep String: basic search for 'fox'")
+
+// Verify it found the match
+string-matches | Count | ExpectEq(1) | Assert("Should find 1 match for 'fox'")
+
+// ============================================================================
+// Test 17: Grep with String parameter - Case insensitive search
+// ============================================================================
+"fox" | Grep(
+  String: string-grep-content
+  CaseInsensitive: true
+) = case-insensitive-matches
+case-insensitive-matches | Log("Grep String: case insensitive 'fox'")
+
+// Should find 3 matches (fox, FOX, FOX)
+case-insensitive-matches | Count | ExpectEq(3) | Assert("Should find 3 matches case-insensitive")
+
+// ============================================================================
+// Test 18: Grep with String parameter - With context lines
+// ============================================================================
+"Lorem" | Grep(
+  String: string-grep-content
+  BeforeContext: 1
+  AfterContext: 1
+) = context-matches
+context-matches | Log("Grep String: 'Lorem' with context")
+
+// Should return 3 lines (1 match + 1 before + 1 after)
+context-matches | Count | ExpectEq(3) | Assert("Should return 3 lines with context")
+
+// ============================================================================
+// Test 19: Grep with String parameter - Max matches limit
+// ============================================================================
+"line|quick" | Grep(
+  String: string-grep-content
+  CaseInsensitive: true
+  MaxMatches: 2
+) = limited-matches
+limited-matches | Log("Grep String: limited to 2 matches")
+
+// Should only return 2 matches even though more exist
+limited-matches | Count | ExpectEq(2) | Assert("Should limit to 2 matches")
+
+// ============================================================================
+// Test 20: Grep with String parameter - Multi-line search
+// ============================================================================
+"""This is a test
+with multiple lines
+that spans across
+several rows""" = multiline-content
+
+// Search for pattern across lines
+"test\nwith" | Grep(
+  String: multiline-content
+  MultiLine: true
+) = multiline-matches
+multiline-matches | Log("Grep String: multi-line pattern")
+
+// ============================================================================
+// Test 21: Grep with String parameter - Invert match
+// ============================================================================
+"fox|FOX" | Grep(
+  String: string-grep-content
+  InvertMatch: true
+) = inverted-matches
+inverted-matches | Log("Grep String: lines without fox/FOX")
+
+// Should return 5 lines (8 total - 3 with fox/FOX)
+inverted-matches | Count | ExpectEq(5) | Assert("Should find 5 lines without fox/FOX")
+
+// ============================================================================
+// Test 22: Grep with String parameter - Line numbers disabled
+// ============================================================================
+"quick" | Grep(
+  String: string-grep-content
+  CaseInsensitive: true
+  LineNumbers: false
+) = no-linenum-matches
+no-linenum-matches | Log("Grep String: without line numbers")
+
+// ============================================================================
+// Test 23: Grep with String parameter - Complex regex pattern
+// ============================================================================
+"[Qq]uick.*[a-z]+" | Grep(
+  String: string-grep-content
+) = regex-matches
+regex-matches | Log("Grep String: complex regex pattern")
+
+// Should find 2 matches
+regex-matches | Count | ExpectEq(2) | Assert("Should find 2 regex matches")
+
+// ============================================================================
+// Test 24: Grep with String parameter - Empty string content
+// ============================================================================
+"" = empty-string
+
+"anything" | Grep(
+  String: empty-string
+) = empty-matches
+empty-matches | Log("Grep String: search in empty string")
+
+// Should return no matches
+empty-matches | Count | ExpectEq(0) | Assert("Should find 0 matches in empty string")
+
+// ============================================================================
+// Test 25: Grep with String parameter - Single line content
+// ============================================================================
+"Just one line with some words" = single-line
+
+"words" | Grep(
+  String: single-line
+) = single-line-matches
+single-line-matches | Log("Grep String: single line search")
+
+// Should find 1 match
+single-line-matches | Count | ExpectEq(1) | Assert("Should find 1 match in single line")
+
+// ============================================================================
 // Cleanup
 // ============================================================================
 "test-fileops" | FS.RemoveAll

--- a/shards/tests/fileops.shs
+++ b/shards/tests/fileops.shs
@@ -291,7 +291,7 @@ Final line with nothing special.""" = string-grep-content
 string-matches | Log("Grep String: basic search for 'fox'")
 
 // Verify it found the match
-string-matches | Count | ExpectEq(1) | Assert("Should find 1 match for 'fox'")
+string-matches | Count | Assert.Is(1 true)
 
 // ============================================================================
 // Test 17: Grep with String parameter - Case insensitive search
@@ -303,7 +303,7 @@ string-matches | Count | ExpectEq(1) | Assert("Should find 1 match for 'fox'")
 case-insensitive-matches | Log("Grep String: case insensitive 'fox'")
 
 // Should find 3 matches (fox, FOX, FOX)
-case-insensitive-matches | Count | ExpectEq(3) | Assert("Should find 3 matches case-insensitive")
+case-insensitive-matches | Count | Assert.Is(3 true)
 
 // ============================================================================
 // Test 18: Grep with String parameter - With context lines
@@ -316,7 +316,7 @@ case-insensitive-matches | Count | ExpectEq(3) | Assert("Should find 3 matches c
 context-matches | Log("Grep String: 'Lorem' with context")
 
 // Should return 3 lines (1 match + 1 before + 1 after)
-context-matches | Count | ExpectEq(3) | Assert("Should return 3 lines with context")
+context-matches | Count | Assert.Is(3 true)
 
 // ============================================================================
 // Test 19: Grep with String parameter - Max matches limit
@@ -329,7 +329,7 @@ context-matches | Count | ExpectEq(3) | Assert("Should return 3 lines with conte
 limited-matches | Log("Grep String: limited to 2 matches")
 
 // Should only return 2 matches even though more exist
-limited-matches | Count | ExpectEq(2) | Assert("Should limit to 2 matches")
+limited-matches | Count | Assert.Is(2 true)
 
 // ============================================================================
 // Test 20: Grep with String parameter - Multi-line search
@@ -356,7 +356,7 @@ multiline-matches | Log("Grep String: multi-line pattern")
 inverted-matches | Log("Grep String: lines without fox/FOX")
 
 // Should return 5 lines (8 total - 3 with fox/FOX)
-inverted-matches | Count | ExpectEq(5) | Assert("Should find 5 lines without fox/FOX")
+inverted-matches | Count | Assert.Is(5 true)
 
 // ============================================================================
 // Test 22: Grep with String parameter - Line numbers disabled
@@ -377,7 +377,7 @@ no-linenum-matches | Log("Grep String: without line numbers")
 regex-matches | Log("Grep String: complex regex pattern")
 
 // Should find 2 matches
-regex-matches | Count | ExpectEq(2) | Assert("Should find 2 regex matches")
+regex-matches | Count | Assert.Is(2 true)
 
 // ============================================================================
 // Test 24: Grep with String parameter - Empty string content
@@ -390,7 +390,7 @@ regex-matches | Count | ExpectEq(2) | Assert("Should find 2 regex matches")
 empty-matches | Log("Grep String: search in empty string")
 
 // Should return no matches
-empty-matches | Count | ExpectEq(0) | Assert("Should find 0 matches in empty string")
+empty-matches | Count | Assert.Is(0 true)
 
 // ============================================================================
 // Test 25: Grep with String parameter - Single line content
@@ -403,7 +403,7 @@ empty-matches | Count | ExpectEq(0) | Assert("Should find 0 matches in empty str
 single-line-matches | Log("Grep String: single line search")
 
 // Should find 1 match
-single-line-matches | Count | ExpectEq(1) | Assert("Should find 1 match in single line")
+single-line-matches | Count | Assert.Is(1 true)
 
 // ============================================================================
 // Cleanup


### PR DESCRIPTION
- Made File parameter optional by adding common_type::none
- Added new String parameter for searching in direct text content
- Added compose-time validation to ensure either File or String is provided
- Updated activate method to handle both file-based and string-based search
- String mode uses search_slice instead of search_path for in-memory search

This allows the Grep shard to be used both for file searching and for searching in pure text strings evaluated at compose time.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
