### PR TITLE
fix(FloatsToImage): throw error for invalid Channels values

### DIFF
--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -248,9 +248,15 @@ template <SHType FROMTYPE> struct ToImage {
   void setParam(int index, const SHVar &value) {
     switch (index) {
     case 0:
+      if (value.payload.intValue < 1) {
+        throw SHException("Width must be at least 1.");
+      }
       _width = uint16_t(value.payload.intValue);
       break;
     case 1:
+      if (value.payload.intValue < 1) {
+        throw SHException("Height must be at least 1.");
+      }
       _height = uint16_t(value.payload.intValue);
       break;
     case 2:

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -248,14 +248,14 @@ template <SHType FROMTYPE> struct ToImage {
   void setParam(int index, const SHVar &value) {
     switch (index) {
     case 0:
-      if (value.payload.intValue < 1) {
-        throw SHException("Width must be at least 1.");
+      if (value.payload.intValue < 1 || value.payload.intValue > UINT16_MAX) {
+        throw SHException("Width must be between 1 and 65535.");
       }
       _width = uint16_t(value.payload.intValue);
       break;
     case 1:
-      if (value.payload.intValue < 1) {
-        throw SHException("Height must be at least 1.");
+      if (value.payload.intValue < 1 || value.payload.intValue > UINT16_MAX) {
+        throw SHException("Height must be between 1 and 65535.");
       }
       _height = uint16_t(value.payload.intValue);
       break;

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -254,7 +254,10 @@ template <SHType FROMTYPE> struct ToImage {
       _height = uint16_t(value.payload.intValue);
       break;
     case 2:
-      _channels = uint8_t(std::min(SHInt(4), std::max(SHInt(1), value.payload.intValue)));
+      if (value.payload.intValue < 1 || value.payload.intValue > 4) {
+        throw SHException("Channels must be between 1 and 4.");
+      }
+      _channels = uint8_t(value.payload.intValue);
       break;
     }
   }


### PR DESCRIPTION
Instead of silently clamping Channels to 1-4 range, throw SHException when Channels parameter is < 1 or > 4.

Fixes #834

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces silent clamping of `FloatsToImage` `Channels` with explicit range validation (1–4) that throws `SHException` when invalid.
> 
> - **Core casting** (`shards/modules/core/casting.cpp`):
>   - `ToImage<FROMTYPE>::setParam` (`Channels`):
>     - Add explicit range check (1–4) and throw `SHException` when invalid.
>     - Remove previous clamping logic; assign channel value directly when valid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c685489afe4c467b7db93b8fdf4f30e21efe716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->