### PR TITLE
fix: handle TakeTable/TakeSeq replacements in template parameters

### DIFF
--- a/shards/lang/src/eval.rs
+++ b/shards/lang/src/eval.rs
@@ -1551,6 +1551,48 @@ fn create_take_table_chain(
   line: LineInfo,
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
+  // Check if var_name has a replacement that is a TakeTable or TakeSeq
+  // This allows templates to use x:key syntax where x is a template parameter
+  // that could be another TakeTable like outer:inner
+  if let Some(replacement) = find_replacement(var_name, e) {
+    match replacement {
+      Value::TakeTable(base_name, base_path) => {
+        // First, get the base variable and apply the base path
+        add_get_shard(base_name, line, e)?;
+        add_expect_table_shard(line, e)?;
+        for base_part in base_path {
+          let s = Var::ephemeral_string(base_part.as_str());
+          add_take_shard(base_name, &s, line, e)?;
+        }
+        // Then apply the additional path from this TakeTable
+        for path_part in path {
+          let s = Var::ephemeral_string(path_part.as_str());
+          add_take_shard(var_name, &s, line, e)?;
+        }
+        return Ok(());
+      }
+      Value::TakeSeq(base_name, base_path) => {
+        // First, get the base variable and apply the base indices
+        add_get_shard(base_name, line, e)?;
+        for idx in base_path {
+          let idx_var: Var = (*idx).try_into().unwrap();
+          add_take_shard(base_name, &idx_var, line, e)?;
+        }
+        // Then apply the additional path from this TakeTable (treating as table keys)
+        add_expect_table_shard(line, e)?;
+        for path_part in path {
+          let s = Var::ephemeral_string(path_part.as_str());
+          add_take_shard(var_name, &s, line, e)?;
+        }
+        return Ok(());
+      }
+      _ => {
+        // For other replacements (including Identifier), fall through to default handling
+      }
+    }
+  }
+
+  // Default handling - var_name is either not a replacement or is an Identifier replacement
   add_get_shard(var_name, line, e)?;
   add_expect_table_shard(line, e)?;
   for path_part in path {
@@ -1566,6 +1608,46 @@ fn create_take_seq_chain(
   line: LineInfo,
   e: &mut EvalEnv,
 ) -> Result<(), ShardsError> {
+  // Check if var_name has a replacement that is a TakeTable or TakeSeq
+  // This allows templates to use x:0 syntax where x is a template parameter
+  if let Some(replacement) = find_replacement(var_name, e) {
+    match replacement {
+      Value::TakeTable(base_name, base_path) => {
+        // First, get the base variable and apply the base path
+        add_get_shard(base_name, line, e)?;
+        add_expect_table_shard(line, e)?;
+        for base_part in base_path {
+          let s = Var::ephemeral_string(base_part.as_str());
+          add_take_shard(base_name, &s, line, e)?;
+        }
+        // Then apply the additional indices from this TakeSeq
+        for path_part in path {
+          let idx: Var = (*path_part).try_into().unwrap();
+          add_take_shard(var_name, &idx, line, e)?;
+        }
+        return Ok(());
+      }
+      Value::TakeSeq(base_name, base_path) => {
+        // First, get the base variable and apply the base indices
+        add_get_shard(base_name, line, e)?;
+        for idx in base_path {
+          let idx_var: Var = (*idx).try_into().unwrap();
+          add_take_shard(base_name, &idx_var, line, e)?;
+        }
+        // Then apply the additional indices from this TakeSeq
+        for path_part in path {
+          let idx: Var = (*path_part).try_into().unwrap();
+          add_take_shard(var_name, &idx, line, e)?;
+        }
+        return Ok(());
+      }
+      _ => {
+        // For other replacements (including Identifier), fall through to default handling
+      }
+    }
+  }
+
+  // Default handling
   add_get_shard(var_name, line, e)?;
   for path_part in path {
     let idx = (*path_part).try_into().unwrap(); // read should have caught this

--- a/shards/lang/src/eval.rs
+++ b/shards/lang/src/eval.rs
@@ -1557,12 +1557,15 @@ fn create_take_table_chain(
   if let Some(replacement) = find_replacement(var_name, e) {
     match replacement {
       Value::TakeTable(base_name, base_path) => {
+        // Clone the data to drop the immutable borrow before making mutable calls
+        let base_name = base_name.clone();
+        let base_path = base_path.clone();
         // First, get the base variable and apply the base path
-        add_get_shard(base_name, line, e)?;
+        add_get_shard(&base_name, line, e)?;
         add_expect_table_shard(line, e)?;
-        for base_part in base_path {
+        for base_part in &base_path {
           let s = Var::ephemeral_string(base_part.as_str());
-          add_take_shard(base_name, &s, line, e)?;
+          add_take_shard(&base_name, &s, line, e)?;
         }
         // Then apply the additional path from this TakeTable
         for path_part in path {
@@ -1572,11 +1575,14 @@ fn create_take_table_chain(
         return Ok(());
       }
       Value::TakeSeq(base_name, base_path) => {
+        // Clone the data to drop the immutable borrow before making mutable calls
+        let base_name = base_name.clone();
+        let base_path = base_path.clone();
         // First, get the base variable and apply the base indices
-        add_get_shard(base_name, line, e)?;
-        for idx in base_path {
+        add_get_shard(&base_name, line, e)?;
+        for idx in &base_path {
           let idx_var: Var = (*idx).try_into().unwrap();
-          add_take_shard(base_name, &idx_var, line, e)?;
+          add_take_shard(&base_name, &idx_var, line, e)?;
         }
         // Then apply the additional path from this TakeTable (treating as table keys)
         add_expect_table_shard(line, e)?;
@@ -1613,12 +1619,15 @@ fn create_take_seq_chain(
   if let Some(replacement) = find_replacement(var_name, e) {
     match replacement {
       Value::TakeTable(base_name, base_path) => {
+        // Clone the data to drop the immutable borrow before making mutable calls
+        let base_name = base_name.clone();
+        let base_path = base_path.clone();
         // First, get the base variable and apply the base path
-        add_get_shard(base_name, line, e)?;
+        add_get_shard(&base_name, line, e)?;
         add_expect_table_shard(line, e)?;
-        for base_part in base_path {
+        for base_part in &base_path {
           let s = Var::ephemeral_string(base_part.as_str());
-          add_take_shard(base_name, &s, line, e)?;
+          add_take_shard(&base_name, &s, line, e)?;
         }
         // Then apply the additional indices from this TakeSeq
         for path_part in path {
@@ -1628,11 +1637,14 @@ fn create_take_seq_chain(
         return Ok(());
       }
       Value::TakeSeq(base_name, base_path) => {
+        // Clone the data to drop the immutable borrow before making mutable calls
+        let base_name = base_name.clone();
+        let base_path = base_path.clone();
         // First, get the base variable and apply the base indices
-        add_get_shard(base_name, line, e)?;
-        for idx in base_path {
+        add_get_shard(&base_name, line, e)?;
+        for idx in &base_path {
           let idx_var: Var = (*idx).try_into().unwrap();
-          add_take_shard(base_name, &idx_var, line, e)?;
+          add_take_shard(&base_name, &idx_var, line, e)?;
         }
         // Then apply the additional indices from this TakeSeq
         for path_part in path {

--- a/shards/tests/template-take-bug.shs
+++ b/shards/tests/template-take-bug.shs
@@ -1,0 +1,66 @@
+; Test for issue #778: Semicolon ":" Take alias bug in template
+; This test verifies that the colon syntax works correctly inside templates
+
+; Setup test data
+{key1: 10 key2: 20 key3: {nested: 30}} | Set(outer-table)
+[[1 2 3] [4 5 6] [7 8 9]] | Set(outer-seq)
+
+; Test 1: Basic colon syntax outside of template (should work)
+outer-table:key1 | Assert.Is(10)
+
+; Test 2: Using explicit Take inside template (should work)
+@template(take-explicit [t] {
+  t | Take("key1") | Log("Explicit Take")
+})
+@take-explicit(outer-table)
+
+; Test 3: Using colon syntax inside template with simple identifier (this should already work)
+@template(take-colon [t] {
+  t:key1 | Log("Colon syntax") | Assert.Is(10)
+})
+@take-colon(outer-table)
+
+; Test 4: Nested colon access
+@template(take-nested [t] {
+  t:key3:nested | Log("Nested") | Assert.Is(30)
+})
+@take-nested(outer-table)
+
+; Test 5: Multiple uses of the same parameter with colon
+@template(take-multiple [t] {
+  t:key1 | Log("First")
+  t:key2 | Log("Second") | Assert.Is(20)
+})
+@take-multiple(outer-table)
+
+; Test 6: Template parameter is a TakeTable - this is the main bug scenario
+; When you pass outer-table:key3 as a parameter, and then use :nested inside template
+@template(take-chained-table [t] {
+  t:nested | Log("Chained table") | Assert.Is(30)
+})
+@take-chained-table(outer-table:key3)
+
+; Test 7: Template parameter is a TakeSeq, then use table key inside template
+@template(take-seq-then-table [t] {
+  ; After taking index 0, we get [1 2 3], which is a sequence
+  ; This test verifies TakeSeq replacement followed by index access
+  t:1 | Log("Seq then index") | Assert.Is(5)
+})
+@take-seq-then-table(outer-seq:1)
+
+; Test 8: Nested templates with TakeTable parameters
+@template(outer-template [t] {
+  @template(inner-template [x] {
+    x:key1 | Log("Inner template")
+  })
+  @inner-template(t)
+})
+@outer-template(outer-table)
+
+; Test 9: TakeSeq syntax with template parameter
+@template(take-seq-syntax [s] {
+  s:0 | Log("Seq index") | Assert.Is(1)
+})
+@take-seq-syntax(outer-seq:0)
+
+Msg("All template-take tests passed!")


### PR DESCRIPTION
Fixes issue #778 where the colon ":" alias for Take didn't work correctly in template contexts when the parameter was another TakeTable expression.

## Changes
- Modified `create_take_table_chain` and `create_take_seq_chain` in `eval.rs` to handle TakeTable/TakeSeq replacements
- Added comprehensive test file `template-take-bug.shs`

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `:` take syntax works in templates by resolving `TakeTable`/`TakeSeq` replacements and add tests covering nested/chained cases.
> 
> - **Lang/eval**:
>   - Update `create_take_table_chain` and `create_take_seq_chain` in `shards/lang/src/eval.rs` to resolve template parameter replacements of type `Value::TakeTable`/`Value::TakeSeq`.
>     - Apply base `Get` + `Take` chain from the replacement, then append additional keys/indices; insert `ExpectTable` where needed.
> - **Tests**:
>   - Add `shards/tests/template-take-bug.shs` with scenarios verifying `:` syntax inside templates, including nested, chained table/seq accesses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5065e99d0c51934483e3cbbb6a80f971b962fea9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->