### PR TITLE
Remove unnecessary SDL dependency for getenv calls

### DIFF
--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 
 #if SH_DEBUG_CONSISTENT_RESUMER
-#include <SDL3/SDL_stdinc.h>
+#include <cstdlib>
 #endif
 
 // Enable for verbose fiber logging
@@ -111,7 +111,7 @@ ThreadFiber::operator bool() const { return !finished; }
 #if SH_DEBUG_CONSISTENT_RESUMER
 static bool checkForConsistentResumer() {
   static bool check = []() {
-    if (SDL_getenv("SH_IGNORE_CONSISTENT_RESUMER"))
+    if (std::getenv("SH_IGNORE_CONSISTENT_RESUMER"))
       return false;
     return true;
   }();

--- a/shards/log/CMakeLists.txt
+++ b/shards/log/CMakeLists.txt
@@ -3,11 +3,6 @@ target_include_directories(shards-logging PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../..
 target_include_directories(shards-logging PRIVATE ${SHARDS_ROOT}/include)
 target_link_libraries(shards-logging spdlog magic_enum Boost::filesystem Boost::algorithm)
 
-if(NOT EMSCRIPTEN AND NOT WATCHOS)
-  target_link_libraries(shards-logging SDL3-static)
-  target_compile_definitions(shards-logging PRIVATE SHARDS_LOG_SDL=1)
-endif()
-
 # The compile-time filtered log level
 if(NOT SPDLOG_ACTIVE_LEVEL)
   if((CMAKE_BUILD_TYPE STREQUAL "Release") OR(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel"))

--- a/shards/log/log.cpp
+++ b/shards/log/log.cpp
@@ -7,9 +7,7 @@
 #include <iterator>
 #include <spdlog/spdlog.h>
 #include <vector>
-#if SHARDS_LOG_SDL
-#include <SDL3/SDL_stdinc.h>
-#endif
+#include <cstdlib>
 #include <magic_enum.hpp>
 #include <shared_mutex>
 #include <boost/filesystem.hpp>
@@ -78,10 +76,9 @@ std::optional<spdlog::level::level_enum> getLogLevelFromEnvVar(std::string inNam
   std::string varName;
   const char *val{};
 
-#if SHARDS_LOG_SDL
   auto tryReadEnvVar = [&]() {
     varName = inName;
-    val = SDL_getenv(varName.c_str());
+    val = std::getenv(varName.c_str());
   };
 
   tryReadEnvVar();
@@ -96,7 +93,6 @@ std::optional<spdlog::level::level_enum> getLogLevelFromEnvVar(std::string inNam
     boost::algorithm::to_upper(inName);
     tryReadEnvVar();
   }
-#endif
 
   if (val) {
     return magic_enum::enum_cast<spdlog::level::level_enum>(val);
@@ -105,12 +101,10 @@ std::optional<spdlog::level::level_enum> getLogLevelFromEnvVar(std::string inNam
 }
 
 static std::optional<spdlog::level::level_enum> getFlushLogLevel() {
-#if SHARDS_LOG_SDL
-  auto val = SDL_getenv("LOG_FLUSH_ON");
+  auto val = std::getenv("LOG_FLUSH_ON");
   if (val) {
     return magic_enum::enum_cast<spdlog::level::level_enum>(val);
   }
-#endif
   return std::nullopt;
 }
 
@@ -342,20 +336,14 @@ void initLogFormat(Logger logger) {
   auto formatter = std::make_unique<spdlog::pattern_formatter>();
   formatter->add_flag<ProcessTimeFlag>('P', getProcessTimeKeeper());
 
-#if SHARDS_LOG_SDL
-  if (const char *val = SDL_getenv(varName.c_str())) {
+  if (const char *val = std::getenv(varName.c_str())) {
     formatter->set_pattern(val);
-  } else
-#endif
-  {
+  } else {
     std::string logPattern;
-// Use global log format
-#if SHARDS_LOG_SDL
-    if (const char *val = SDL_getenv("LOG_FORMAT")) {
+    // Use global log format
+    if (const char *val = std::getenv("LOG_FORMAT")) {
       logPattern = val;
-    } else
-#endif
-    {
+    } else {
 #ifdef __ANDROID
       // Logcat already countains timestamps & log level
       logPattern = "[T-%t][%n][%s::%#] %v";

--- a/shards/modules/debugger/interface.cpp
+++ b/shards/modules/debugger/interface.cpp
@@ -6,7 +6,7 @@
 #include <shards/core/runtime.hpp>
 #include <shards/core/assert.hpp>
 #include <shards/utility.hpp>
-#include <SDL3/SDL_stdinc.h>
+#include <cstdlib>
 
 namespace shards::dbg {
 
@@ -146,7 +146,7 @@ struct State {
 
   State() : breakSema(1) {
 
-    if (const char *wait = SDL_getenv("SHARDS_DEBUGGER_WAIT")) {
+    if (const char *wait = std::getenv("SHARDS_DEBUGGER_WAIT")) {
       debuggerWaitMode = atoi(wait);
       if (debuggerWaitMode > 0) {
         // Break on startup


### PR DESCRIPTION
## Summary

- Replace `SDL_getenv` with `std::getenv` from `<cstdlib>` in debugger, coro, and logging modules
- Remove SDL3-static link from shards-logging module entirely (was only used for environment variable access)
- Reduces unnecessary dependencies when graphics modules are disabled

## Test plan

- [x] Build passes locally
- [ ] CI build passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces SDL environment access with std::getenv and drops the SDL link/guards from logging to reduce dependencies.
> 
> - **Build/Logging**:
>   - Remove SDL linkage and defines from `shards/log/CMakeLists.txt` (no more `SDL3-static`, `SHARDS_LOG_SDL`).
> - **Logging (`shards/log/log.cpp`)**:
>   - Use `std::getenv` for env reads (`getLogLevelFromEnvVar`, `getFlushLogLevel`, `initLogFormat`); include `<cstdlib>`.
>   - Remove SDL-conditional env handling paths.
> - **Core/Debugger**:
>   - Replace `SDL_getenv` with `std::getenv` in `shards/core/coro.cpp` and `shards/modules/debugger/interface.cpp`; include `<cstdlib>` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 911f06a3feb9a822f0cef04afe75430f7ea20e0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->