### PR TITLE
Convert SHAudio to planar format

### DIFF
--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -260,11 +260,19 @@ struct SHImage {
   SHImageFreeProc free;
 } SH_STRUCT16;
 
+// Sample rate encoding: stored as actual_rate / 25 to fit in uint16_t
+// All common rates (11025, 22050, 44100, 48000, 96000, 192000) divide evenly by 25
+#define SHAUDIO_SAMPLE_RATE_DIVISOR 25
+#define SHAUDIO_ENCODE_SAMPLE_RATE(rate) ((uint16_t)((rate) / SHAUDIO_SAMPLE_RATE_DIVISOR))
+#define SHAUDIO_DECODE_SAMPLE_RATE(encoded) ((uint32_t)(encoded) * SHAUDIO_SAMPLE_RATE_DIVISOR)
+
+// Audio is always in planar format: channel N at samples + N * nsamples
 struct SHAudio {
-  uint32_t sampleRate; // set to 0 if unknown/not relevant
-  uint16_t nsamples;
-  uint16_t channels;
-  float *samples;
+  float *samples;      // Planar layout: [ch0_s0, ch0_s1, ...][ch1_s0, ch1_s1, ...]
+  uint32_t nsamples;   // Samples per channel
+  uint16_t sampleRate; // Encoded: actual_rate / 25 (use SHAUDIO_ENCODE/DECODE macros)
+  uint8_t channels;    // Number of channels (max 255)
+  uint8_t reserved;    // Reserved for future use
 };
 
 #define SH_FLOW_CONTINUE (0)

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -1068,7 +1068,10 @@ template <typename TGenericArray, class Function> inline void ForEach(const TGen
 // ============================================================================
 
 // Create a planar SHAudio struct with proper sample rate encoding
+// Note: sampleRate must be divisible by 25 (all common rates: 11025, 22050, 44100, 48000, 96000, 192000)
+// Non-divisible rates will be truncated (e.g., 44099 -> 44075)
 inline SHAudio makeAudio(float *samples, uint32_t nsamples, uint32_t sampleRate, uint8_t channels) {
+  shassert((sampleRate % SHAUDIO_SAMPLE_RATE_DIVISOR) == 0 && "Sample rate must be divisible by 25");
   return SHAudio{samples, nsamples, SHAUDIO_ENCODE_SAMPLE_RATE(sampleRate), channels, 0};
 }
 
@@ -1076,8 +1079,15 @@ inline SHAudio makeAudio(float *samples, uint32_t nsamples, uint32_t sampleRate,
 inline uint32_t audioGetSampleRate(const SHAudio &audio) { return SHAUDIO_DECODE_SAMPLE_RATE(audio.sampleRate); }
 
 // Get pointer to a specific channel in planar audio
-inline float *audioGetChannel(SHAudio &audio, uint8_t channel) { return audio.samples + channel * audio.nsamples; }
-inline const float *audioGetChannel(const SHAudio &audio, uint8_t channel) { return audio.samples + channel * audio.nsamples; }
+// Note: channel must be < audio.channels, otherwise returns invalid pointer
+inline float *audioGetChannel(SHAudio &audio, uint8_t channel) {
+  shassert(channel < audio.channels && "Channel index out of bounds");
+  return audio.samples + channel * audio.nsamples;
+}
+inline const float *audioGetChannel(const SHAudio &audio, uint8_t channel) {
+  shassert(channel < audio.channels && "Channel index out of bounds");
+  return audio.samples + channel * audio.nsamples;
+}
 
 // Deinterleave audio: convert interleaved [L0,R0,L1,R1,...] to planar [L0,L1,...,R0,R1,...]
 // Output buffer must have space for nsamples * channels floats

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -1063,6 +1063,46 @@ template <typename TGenericArray, class Function> inline void ForEach(const TGen
     f(seq.elements[i]);
 }
 
+// ============================================================================
+// Audio utilities for SHAudio
+// ============================================================================
+
+// Create a planar SHAudio struct with proper sample rate encoding
+inline SHAudio makeAudio(float *samples, uint32_t nsamples, uint32_t sampleRate, uint8_t channels) {
+  return SHAudio{samples, nsamples, SHAUDIO_ENCODE_SAMPLE_RATE(sampleRate), channels, 0};
+}
+
+// Get decoded sample rate from SHAudio
+inline uint32_t audioGetSampleRate(const SHAudio &audio) { return SHAUDIO_DECODE_SAMPLE_RATE(audio.sampleRate); }
+
+// Get pointer to a specific channel in planar audio
+inline float *audioGetChannel(SHAudio &audio, uint8_t channel) { return audio.samples + channel * audio.nsamples; }
+inline const float *audioGetChannel(const SHAudio &audio, uint8_t channel) { return audio.samples + channel * audio.nsamples; }
+
+// Deinterleave audio: convert interleaved [L0,R0,L1,R1,...] to planar [L0,L1,...,R0,R1,...]
+// Output buffer must have space for nsamples * channels floats
+inline void audioDeinterleave(const float *interleaved, float *planar, uint32_t nsamples, uint8_t channels) {
+  for (uint32_t ch = 0; ch < channels; ch++) {
+    float *dst = planar + ch * nsamples;
+    for (uint32_t i = 0; i < nsamples; i++) {
+      dst[i] = interleaved[i * channels + ch];
+    }
+  }
+}
+
+// Interleave audio: convert planar [L0,L1,...,R0,R1,...] to interleaved [L0,R0,L1,R1,...]
+// Output buffer must have space for nsamples * channels floats
+inline void audioInterleave(const float *planar, float *interleaved, uint32_t nsamples, uint8_t channels) {
+  for (uint32_t ch = 0; ch < channels; ch++) {
+    const float *src = planar + ch * nsamples;
+    for (uint32_t i = 0; i < nsamples; i++) {
+      interleaved[i * channels + ch] = src[i];
+    }
+  }
+}
+
+// ============================================================================
+
 class WireProvider {
   // used specially for live editing wires, from host languages
 public:

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -16,6 +16,13 @@
 #include <cstdint>
 #include <stdexcept>
 
+// SIMD headers for audio interleave/deinterleave
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#include <arm_neon.h>
+#elif defined(__AVX2__) || defined(__SSE__)
+#include <immintrin.h>
+#endif
+
 #define ENTT_ID_TYPE std::uint64_t
 #ifdef SHARDS_WITH_ENTT
 // entt\meta\meta.hpp:768:10: note: 'meta_prop' has been explicitly marked deprecated here
@@ -1091,24 +1098,235 @@ inline const float *audioGetChannel(const SHAudio &audio, uint8_t channel) {
 
 // Deinterleave audio: convert interleaved [L0,R0,L1,R1,...] to planar [L0,L1,...,R0,R1,...]
 // Output buffer must have space for nsamples * channels floats
-inline void audioDeinterleave(const float *interleaved, float *planar, uint32_t nsamples, uint8_t channels) {
-  for (uint32_t ch = 0; ch < channels; ch++) {
-    float *dst = planar + ch * nsamples;
+// SIMD optimized: AVX2 gather (x86), NEON vld2-4 (ARM 2-4 channels)
+inline void audioDeinterleave(const float *__restrict interleaved, float *__restrict planar, uint32_t nsamples,
+                              uint8_t channels) {
+  if (channels == 1) {
+    memcpy(planar, interleaved, nsamples * sizeof(float));
+    return;
+  }
+
+#if defined(__AVX2__)
+  // AVX2: use gather for any channel count - single elegant path
+  const __m256i indices =
+      _mm256_mullo_epi32(_mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7), _mm256_set1_epi32(channels));
+
+  for (uint8_t ch = 0; ch < channels; ch++) {
+    const float *__restrict src = interleaved + ch;
+    float *__restrict dst = planar + ch * nsamples;
+    uint32_t i = 0;
+
+    for (; i + 8 <= nsamples; i += 8) {
+      __m256 samples = _mm256_i32gather_ps(src + i * channels, indices, sizeof(float));
+      _mm256_storeu_ps(dst + i, samples);
+    }
+
+    for (; i < nsamples; i++) {
+      dst[i] = src[i * channels];
+    }
+  }
+
+#elif defined(__ARM_NEON) || defined(__ARM_NEON__)
+  // NEON: native deinterleave for 2/3/4 channels
+  uint32_t i = 0;
+
+  if (channels == 2) {
+    float *__restrict ch0 = planar;
+    float *__restrict ch1 = planar + nsamples;
+    for (; i + 4 <= nsamples; i += 4) {
+      float32x4x2_t v = vld2q_f32(interleaved + i * 2);
+      vst1q_f32(ch0 + i, v.val[0]);
+      vst1q_f32(ch1 + i, v.val[1]);
+    }
+    for (; i < nsamples; i++) {
+      ch0[i] = interleaved[i * 2];
+      ch1[i] = interleaved[i * 2 + 1];
+    }
+    return;
+  }
+
+  if (channels == 3) {
+    float *__restrict ch0 = planar;
+    float *__restrict ch1 = planar + nsamples;
+    float *__restrict ch2 = planar + nsamples * 2;
+    for (; i + 4 <= nsamples; i += 4) {
+      float32x4x3_t v = vld3q_f32(interleaved + i * 3);
+      vst1q_f32(ch0 + i, v.val[0]);
+      vst1q_f32(ch1 + i, v.val[1]);
+      vst1q_f32(ch2 + i, v.val[2]);
+    }
+    for (; i < nsamples; i++) {
+      ch0[i] = interleaved[i * 3];
+      ch1[i] = interleaved[i * 3 + 1];
+      ch2[i] = interleaved[i * 3 + 2];
+    }
+    return;
+  }
+
+  if (channels == 4) {
+    float *__restrict ch0 = planar;
+    float *__restrict ch1 = planar + nsamples;
+    float *__restrict ch2 = planar + nsamples * 2;
+    float *__restrict ch3 = planar + nsamples * 3;
+    for (; i + 4 <= nsamples; i += 4) {
+      float32x4x4_t v = vld4q_f32(interleaved + i * 4);
+      vst1q_f32(ch0 + i, v.val[0]);
+      vst1q_f32(ch1 + i, v.val[1]);
+      vst1q_f32(ch2 + i, v.val[2]);
+      vst1q_f32(ch3 + i, v.val[3]);
+    }
+    for (; i < nsamples; i++) {
+      ch0[i] = interleaved[i * 4];
+      ch1[i] = interleaved[i * 4 + 1];
+      ch2[i] = interleaved[i * 4 + 2];
+      ch3[i] = interleaved[i * 4 + 3];
+    }
+    return;
+  }
+
+  // NEON fallback for 5+ channels
+  for (uint8_t ch = 0; ch < channels; ch++) {
+    float *__restrict dst = planar + ch * nsamples;
+    for (uint32_t j = 0; j < nsamples; j++) {
+      dst[j] = interleaved[j * channels + ch];
+    }
+  }
+
+#else
+  // Scalar fallback
+  for (uint8_t ch = 0; ch < channels; ch++) {
+    float *__restrict dst = planar + ch * nsamples;
     for (uint32_t i = 0; i < nsamples; i++) {
       dst[i] = interleaved[i * channels + ch];
     }
   }
+#endif
 }
 
 // Interleave audio: convert planar [L0,L1,...,R0,R1,...] to interleaved [L0,R0,L1,R1,...]
 // Output buffer must have space for nsamples * channels floats
-inline void audioInterleave(const float *planar, float *interleaved, uint32_t nsamples, uint8_t channels) {
-  for (uint32_t ch = 0; ch < channels; ch++) {
-    const float *src = planar + ch * nsamples;
+// SIMD optimized: AVX2 shuffles for stereo (x86), NEON vst2-4 (ARM 2-4 channels)
+inline void audioInterleave(const float *__restrict planar, float *__restrict interleaved, uint32_t nsamples,
+                            uint8_t channels) {
+  if (channels == 1) {
+    memcpy(interleaved, planar, nsamples * sizeof(float));
+    return;
+  }
+
+#if defined(__AVX2__)
+  // AVX2: optimized for stereo (most common), scalar for others (no scatter until AVX-512)
+  if (channels == 2) {
+    const float *__restrict ch0 = planar;
+    const float *__restrict ch1 = planar + nsamples;
+    uint32_t i = 0;
+
+    for (; i + 8 <= nsamples; i += 8) {
+      __m256 l = _mm256_loadu_ps(ch0 + i); // L0 L1 L2 L3 L4 L5 L6 L7
+      __m256 r = _mm256_loadu_ps(ch1 + i); // R0 R1 R2 R3 R4 R5 R6 R7
+
+      __m256 lo = _mm256_unpacklo_ps(l, r); // L0 R0 L1 R1 | L4 R4 L5 R5
+      __m256 hi = _mm256_unpackhi_ps(l, r); // L2 R2 L3 R3 | L6 R6 L7 R7
+
+      __m256 out0 = _mm256_permute2f128_ps(lo, hi, 0x20); // L0 R0 L1 R1 L2 R2 L3 R3
+      __m256 out1 = _mm256_permute2f128_ps(lo, hi, 0x31); // L4 R4 L5 R5 L6 R6 L7 R7
+
+      _mm256_storeu_ps(interleaved + i * 2, out0);
+      _mm256_storeu_ps(interleaved + i * 2 + 8, out1);
+    }
+
+    for (; i < nsamples; i++) {
+      interleaved[i * 2] = ch0[i];
+      interleaved[i * 2 + 1] = ch1[i];
+    }
+    return;
+  }
+
+  // AVX2 scalar fallback for non-stereo (no scatter instruction)
+  for (uint8_t ch = 0; ch < channels; ch++) {
+    const float *__restrict src = planar + ch * nsamples;
     for (uint32_t i = 0; i < nsamples; i++) {
       interleaved[i * channels + ch] = src[i];
     }
   }
+
+#elif defined(__ARM_NEON) || defined(__ARM_NEON__)
+  // NEON: native interleave for 2/3/4 channels
+  uint32_t i = 0;
+
+  if (channels == 2) {
+    const float *__restrict ch0 = planar;
+    const float *__restrict ch1 = planar + nsamples;
+    for (; i + 4 <= nsamples; i += 4) {
+      float32x4x2_t v;
+      v.val[0] = vld1q_f32(ch0 + i);
+      v.val[1] = vld1q_f32(ch1 + i);
+      vst2q_f32(interleaved + i * 2, v);
+    }
+    for (; i < nsamples; i++) {
+      interleaved[i * 2] = ch0[i];
+      interleaved[i * 2 + 1] = ch1[i];
+    }
+    return;
+  }
+
+  if (channels == 3) {
+    const float *__restrict ch0 = planar;
+    const float *__restrict ch1 = planar + nsamples;
+    const float *__restrict ch2 = planar + nsamples * 2;
+    for (; i + 4 <= nsamples; i += 4) {
+      float32x4x3_t v;
+      v.val[0] = vld1q_f32(ch0 + i);
+      v.val[1] = vld1q_f32(ch1 + i);
+      v.val[2] = vld1q_f32(ch2 + i);
+      vst3q_f32(interleaved + i * 3, v);
+    }
+    for (; i < nsamples; i++) {
+      interleaved[i * 3] = ch0[i];
+      interleaved[i * 3 + 1] = ch1[i];
+      interleaved[i * 3 + 2] = ch2[i];
+    }
+    return;
+  }
+
+  if (channels == 4) {
+    const float *__restrict ch0 = planar;
+    const float *__restrict ch1 = planar + nsamples;
+    const float *__restrict ch2 = planar + nsamples * 2;
+    const float *__restrict ch3 = planar + nsamples * 3;
+    for (; i + 4 <= nsamples; i += 4) {
+      float32x4x4_t v;
+      v.val[0] = vld1q_f32(ch0 + i);
+      v.val[1] = vld1q_f32(ch1 + i);
+      v.val[2] = vld1q_f32(ch2 + i);
+      v.val[3] = vld1q_f32(ch3 + i);
+      vst4q_f32(interleaved + i * 4, v);
+    }
+    for (; i < nsamples; i++) {
+      interleaved[i * 4] = ch0[i];
+      interleaved[i * 4 + 1] = ch1[i];
+      interleaved[i * 4 + 2] = ch2[i];
+      interleaved[i * 4 + 3] = ch3[i];
+    }
+    return;
+  }
+
+  // NEON fallback for 5+ channels
+  for (uint8_t ch = 0; ch < channels; ch++) {
+    const float *__restrict src = planar + ch * nsamples;
+    for (uint32_t j = 0; j < nsamples; j++) {
+      interleaved[j * channels + ch] = src[j];
+    }
+  }
+
+#else
+  // Scalar fallback
+  for (uint8_t ch = 0; ch < channels; ch++) {
+    const float *__restrict src = planar + ch * nsamples;
+    for (uint32_t i = 0; i < nsamples; i++) {
+      interleaved[i * channels + ch] = src[i];
+    }
+  }
+#endif
 }
 
 // ============================================================================

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -1100,7 +1100,7 @@ inline const float *audioGetChannel(const SHAudio &audio, uint8_t channel) {
 // Output buffer must have space for nsamples * channels floats
 // SIMD optimized: AVX2 gather (x86), NEON vld2-4 (ARM 2-4 channels)
 inline void audioDeinterleave(const float *__restrict interleaved, float *__restrict planar, uint32_t nsamples,
-                              uint8_t channels) {
+                              uint8_t channels) noexcept {
   if (channels == 1) {
     memcpy(planar, interleaved, nsamples * sizeof(float));
     return;
@@ -1207,7 +1207,7 @@ inline void audioDeinterleave(const float *__restrict interleaved, float *__rest
 // Output buffer must have space for nsamples * channels floats
 // SIMD optimized: AVX2 shuffles for stereo (x86), NEON vst2-4 (ARM 2-4 channels)
 inline void audioInterleave(const float *__restrict planar, float *__restrict interleaved, uint32_t nsamples,
-                            uint8_t channels) {
+                            uint8_t channels) noexcept {
   if (channels == 1) {
     memcpy(interleaved, planar, nsamples * sizeof(float));
     return;

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -1108,8 +1108,7 @@ inline void audioDeinterleave(const float *__restrict interleaved, float *__rest
 
 #if defined(__AVX2__)
   // AVX2: use gather for any channel count - single elegant path
-  const __m256i indices =
-      _mm256_mullo_epi32(_mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7), _mm256_set1_epi32(channels));
+  const __m256i indices = _mm256_mullo_epi32(_mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7), _mm256_set1_epi32(channels));
 
   for (uint8_t ch = 0; ch < channels; ch++) {
     const float *__restrict src = interleaved + ch;

--- a/include/shards/shards.swift
+++ b/include/shards/shards.swift
@@ -301,7 +301,8 @@ extension SHVar: CustomStringConvertible, Hashable, Equatable {
         case .Enum:
             return "Enum(vendor:\(payload.enumVendorId), type:\(payload.enumTypeId), value:\(payload.enumValue))"
         case .Audio:
-            return "Audio(\(payload.audioValue.nsamples) samples, channels:\(payload.audioValue.channels), rate:\(payload.audioValue.sampleRate))"
+            let decodedSampleRate = UInt32(payload.audioValue.sampleRate) * 25  // SHAUDIO_DECODE_SAMPLE_RATE
+            return "Audio(\(payload.audioValue.nsamples) samples, channels:\(payload.audioValue.channels), rate:\(decodedSampleRate))"
         case .TypeInfo:
             return "TypeInfo"
         case .Trait:

--- a/include/shards/shards.swift
+++ b/include/shards/shards.swift
@@ -3,6 +3,9 @@
 
 // WIP: This is a work in progress
 
+// Audio sample rate encoding divisor (must match SHAUDIO_SAMPLE_RATE_DIVISOR in shards.h)
+private let kAudioSampleRateDivisor: UInt32 = 25
+
 /*
  final class MyShard1 : IShard {
      static var name: StaticString = "MyShard1"
@@ -301,7 +304,7 @@ extension SHVar: CustomStringConvertible, Hashable, Equatable {
         case .Enum:
             return "Enum(vendor:\(payload.enumVendorId), type:\(payload.enumTypeId), value:\(payload.enumValue))"
         case .Audio:
-            let decodedSampleRate = UInt32(payload.audioValue.sampleRate) * 25  // SHAUDIO_DECODE_SAMPLE_RATE
+            let decodedSampleRate = UInt32(payload.audioValue.sampleRate) * kAudioSampleRateDivisor
             return "Audio(\(payload.audioValue.nsamples) samples, channels:\(payload.audioValue.channels), rate:\(decodedSampleRate))"
         case .TypeInfo:
             return "TypeInfo"

--- a/shards/core/ops_internal.cpp
+++ b/shards/core/ops_internal.cpp
@@ -186,9 +186,9 @@ std::ostream &DocsFriendlyFormatter::format(std::ostream &os, const SHVar &var) 
     break;
   case SHType::Audio:
     os << "Audio";
-    os << " SampleRate: " << var.payload.audioValue.sampleRate;
+    os << " SampleRate: " << SHAUDIO_DECODE_SAMPLE_RATE(var.payload.audioValue.sampleRate);
     os << " Samples: " << var.payload.audioValue.nsamples;
-    os << " Channels: " << var.payload.audioValue.channels;
+    os << " Channels: " << (int)var.payload.audioValue.channels;
     break;
   case SHType::Seq:
     os << "[";

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -2183,6 +2183,7 @@ NO_INLINE void _cloneVarSlow(SHVar &dst, const SHVar &src) {
     dst.payload.audioValue.sampleRate = src.payload.audioValue.sampleRate;
     dst.payload.audioValue.nsamples = src.payload.audioValue.nsamples;
     dst.payload.audioValue.channels = src.payload.audioValue.channels;
+    dst.payload.audioValue.reserved = src.payload.audioValue.reserved;
 
     if (src.payload.audioValue.samples == dst.payload.audioValue.samples)
       return;

--- a/shards/core/serialization.hpp
+++ b/shards/core/serialization.hpp
@@ -314,6 +314,7 @@ struct Serialization {
       read((uint8_t *)&output.payload.audioValue.nsamples, sizeof(output.payload.audioValue.nsamples));
       read((uint8_t *)&output.payload.audioValue.channels, sizeof(output.payload.audioValue.channels));
       read((uint8_t *)&output.payload.audioValue.sampleRate, sizeof(output.payload.audioValue.sampleRate));
+      read((uint8_t *)&output.payload.audioValue.reserved, sizeof(output.payload.audioValue.reserved));
 
       size_t size = output.payload.audioValue.nsamples * output.payload.audioValue.channels * sizeof(float);
 
@@ -626,6 +627,9 @@ struct Serialization {
 
       write((const uint8_t *)&input.payload.audioValue.sampleRate, sizeof(input.payload.audioValue.sampleRate));
       total += sizeof(input.payload.audioValue.sampleRate);
+
+      write((const uint8_t *)&input.payload.audioValue.reserved, sizeof(input.payload.audioValue.reserved));
+      total += sizeof(input.payload.audioValue.reserved);
 
       auto size = input.payload.audioValue.nsamples * input.payload.audioValue.channels * sizeof(float);
 

--- a/shards/modules/audio/audio.cpp
+++ b/shards/modules/audio/audio.cpp
@@ -201,8 +201,8 @@ struct Device {
       // Inside here, if happens, there might be syscalls
       // Allocations and such... we need to refactor if we start
       // Noticing audio cracks
-      SHLOG_TRACE("Audio: Adding channel inBus={} inHash={} outBus={} outHash={} outChannels={} inChannels={}",
-                  c.inBus, c.inHash, c.outBus, c.outHash, c.outChannels, c.data->inChannels.size());
+      SHLOG_TRACE("Audio: Adding channel inBus={} inHash={} outBus={} outHash={} outChannels={} inChannels={}", c.inBus, c.inHash,
+                  c.outBus, c.outHash, c.outChannels, c.data->inChannels.size());
       {
         auto &bus = device->channels[c.inBus];
         bus[c.inHash].emplace_back(c.data);
@@ -277,8 +277,8 @@ struct Device {
           }
         }
 
-        SHAudio inputPacket = makeAudio(device->inputScratch.data(), frameCount,
-                                        uint32_t(device->_sampleRate.payload.intValue), uint8_t(nChannels));
+        SHAudio inputPacket = makeAudio(device->inputScratch.data(), frameCount, uint32_t(device->_sampleRate.payload.intValue),
+                                        uint8_t(nChannels));
         Var inputVar(inputPacket);
 
         // run activations of all channels that need such input
@@ -333,7 +333,7 @@ struct Device {
         // Map [0.9..inf] to [0.9..1.0] using tanh
         float sign = x > 0.0f ? 1.0f : -1.0f;
         float excess = (std::abs(x) - threshold) / (1.0f - threshold); // 0..inf
-        float compressed = std::tanh(excess); // 0..1
+        float compressed = std::tanh(excess);                          // 0..1
         return sign * (threshold + compressed * (1.0f - threshold));
       }
     };
@@ -341,15 +341,19 @@ struct Device {
     // Compose device output from all channel outputs on bus 0
     // Channel outputs are planar, device output is interleaved (for miniaudio)
     for (auto &[nbus, channelKinds] : device->channels) {
-      if (nbus != 0) continue; // Only device output bus
+      if (nbus != 0)
+        continue; // Only device output bus
       for (auto &[kind, channels] : channelKinds) {
-        if (channels.empty()) continue;
+        if (channels.empty())
+          continue;
         auto *channelData = channels[0];
-        if (channelData->outChannels.empty()) continue;
+        if (channelData->outChannels.empty())
+          continue;
 
         // Get the output buffer for this channel configuration (planar layout)
         auto &channelOutput = channelData->outputBuffer;
-        if (!channelOutput) continue;
+        if (!channelOutput)
+          continue;
 
         auto channelOutCount = channelData->outChannels.size();
         auto requiredBufferSize = channelOutCount * frameCount;
@@ -361,7 +365,8 @@ struct Device {
         // Map each channel's planar output to the correct interleaved device output channel
         for (size_t c = 0; c < channelOutCount; c++) {
           auto deviceChannel = channelData->outChannels[c];
-          if (deviceChannel >= outChannels) continue;
+          if (deviceChannel >= outChannels)
+            continue;
 
           // Source is planar: channel c data is at channelOutput + c * frameCount
           const float *src = channelOutput + c * frameCount;
@@ -806,8 +811,8 @@ struct Oscillator {
   ma_uint64 _nsamples{1024};
   ma_uint32 _sampleRate{44100};
 
-  std::vector<float> _buffer;          // Planar output buffer
-  std::vector<float> _interleavedBuf;  // Scratch for miniaudio interleaved output
+  std::vector<float> _buffer;         // Planar output buffer
+  std::vector<float> _interleavedBuf; // Scratch for miniaudio interleaved output
 
   SHVar *_device{nullptr};
   Device *d{nullptr};
@@ -961,8 +966,8 @@ struct ReadFile {
 
   ma_uint64 _progress{0};
 
-  std::vector<float> _buffer;          // Planar output buffer
-  std::vector<float> _interleavedBuf;  // Scratch for miniaudio interleaved output
+  std::vector<float> _buffer;         // Planar output buffer
+  std::vector<float> _interleavedBuf; // Scratch for miniaudio interleaved output
   bool _done{false};
 
   SHVar *_device{nullptr};
@@ -1271,7 +1276,7 @@ struct WriteFile {
   ma_uint32 _sampleRate{44100};
   ma_uint64 _progress{0};
   ParamVar _filename;
-  std::vector<float> _interleavedBuf;  // Scratch for interleaving planar input
+  std::vector<float> _interleavedBuf; // Scratch for interleaving planar input
 
   static SHOptionalString help() { return SHCCSTR("This shard writes audio data to WAV format file."); }
 
@@ -1416,10 +1421,10 @@ struct Resample {
     PARAM_CLEANUP(context);
   }
 
-  std::vector<float> _buffer;           // Planar output buffer
-  std::vector<float> _interleavedIn;    // Interleaved input for resampler (includes leftovers)
-  std::vector<float> _interleavedOut;   // Interleaved output from resampler
-  std::vector<float> _leftoverSamples;  // Interleaved leftovers
+  std::vector<float> _buffer;          // Planar output buffer
+  std::vector<float> _interleavedIn;   // Interleaved input for resampler (includes leftovers)
+  std::vector<float> _interleavedOut;  // Interleaved output from resampler
+  std::vector<float> _leftoverSamples; // Interleaved leftovers
   ma_uint32 _inSampleRate{0};
   ma_uint32 _outSampleRate{0};
   ma_uint32 _channels{0};
@@ -1429,9 +1434,8 @@ struct Resample {
     uint32_t inSampleRate = audioGetSampleRate(audio);
 
     if (!_initialized) {
-      ma_resampler_config config =
-          ma_resampler_config_init(ma_format_f32, audio.channels, inSampleRate,
-                                   _outRate.get().payload.intValue, ma_resample_algorithm_linear);
+      ma_resampler_config config = ma_resampler_config_init(ma_format_f32, audio.channels, inSampleRate,
+                                                            _outRate.get().payload.intValue, ma_resample_algorithm_linear);
       ma_result res = ma_resampler_init(&config, NULL, &_resampler);
       if (res != MA_SUCCESS) {
         throw ActivationError("Failed to initialize resampler");
@@ -1472,7 +1476,8 @@ struct Resample {
     }
 
     _interleavedOut.resize(frameCountOut * _channels);
-    res = ma_resampler_process_pcm_frames(&_resampler, _interleavedIn.data(), &frameCountIn, _interleavedOut.data(), &frameCountOut);
+    res = ma_resampler_process_pcm_frames(&_resampler, _interleavedIn.data(), &frameCountIn, _interleavedOut.data(),
+                                          &frameCountOut);
 
     if (res != MA_SUCCESS) {
       SHLOG_ERROR("Failed to resample audio: {} {}", res, frameCountIn);

--- a/shards/modules/audio/audio.cpp
+++ b/shards/modules/audio/audio.cpp
@@ -56,6 +56,7 @@ struct AudioDefaultHelpText {
 
 struct ChannelData {
   float *outputBuffer;
+  size_t outputBufferSize;
   std::vector<uint32_t> inChannels;
   std::vector<uint32_t> outChannels;
   ShardsVar shards;
@@ -212,8 +213,10 @@ struct Device {
           auto &buffer = bus[c.outHash];
           buffer.resize(frameCount * c.outChannels);
           c.data->outputBuffer = buffer.data();
+          c.data->outputBufferSize = buffer.size();
         } else {
           c.data->outputBuffer = nullptr;
+          c.data->outputBufferSize = 0;
         }
       }
 
@@ -349,6 +352,11 @@ struct Device {
         if (!channelOutput) continue;
 
         auto channelOutCount = channelData->outChannels.size();
+        auto requiredBufferSize = channelOutCount * frameCount;
+        if (channelData->outputBufferSize < requiredBufferSize) {
+          SHLOG_ERROR("Channel output buffer too small: {} < {}", channelData->outputBufferSize, requiredBufferSize);
+          continue;
+        }
 
         // Map each channel's planar output to the correct interleaved device output channel
         for (size_t c = 0; c < channelOutCount; c++) {

--- a/shards/modules/audio/audio.cpp
+++ b/shards/modules/audio/audio.cpp
@@ -249,19 +249,23 @@ struct Device {
         device->inputScratch.resize(frameCount * nChannels);
 
         if (nbus == 0) {
-          if (kind == device->inputHash) {
-            // this is the full device input, just copy it
-            memcpy(device->inputScratch.data(), pInput, sizeof(float) * nChannels * frameCount);
+          // Device input - deinterleave from miniaudio's interleaved format to planar
+          auto *finput = reinterpret_cast<const float *>(pInput);
+          if (kind == device->inputHash && inChannels == nChannels) {
+            // Full device input, deinterleave all channels
+            audioDeinterleave(finput, device->inputScratch.data(), frameCount, uint8_t(nChannels));
           } else {
-            auto *finput = reinterpret_cast<const float *>(pInput);
-            // need to properly compose the input
-            for (uint32_t c = 0; c < nChannels; c++) {
+            // Selective channels - deinterleave only the channels we need
+            for (uint32_t c = 0; c < uint32_t(nChannels); c++) {
+              float *dst = device->inputScratch.data() + c * frameCount;
+              uint32_t srcChannel = channels[0]->inChannels[c];
               for (ma_uint32 i = 0; i < frameCount; i++) {
-                device->inputScratch[(i * nChannels) + c] = finput[(i * inChannels) + channels[0]->inChannels[c]];
+                dst[i] = finput[i * inChannels + srcChannel];
               }
             }
           }
         } else {
+          // Input from another bus - already planar
           const auto inputBuffer = device->outputBuffers[nbus][kind];
           if (inputBuffer.size() != 0) {
             std::copy(inputBuffer.begin(), inputBuffer.end(), device->inputScratch.begin());
@@ -270,10 +274,8 @@ struct Device {
           }
         }
 
-        SHAudio inputPacket{uint32_t(device->_sampleRate.payload.intValue), //
-                            uint16_t(frameCount),                           //
-                            uint16_t(nChannels),                            //
-                            device->inputScratch.data()};
+        SHAudio inputPacket = makeAudio(device->inputScratch.data(), frameCount,
+                                        uint32_t(device->_sampleRate.payload.intValue), uint8_t(nChannels));
         Var inputVar(inputPacket);
 
         // run activations of all channels that need such input
@@ -334,7 +336,7 @@ struct Device {
     };
 
     // Compose device output from all channel outputs on bus 0
-    // Each channel writes to specific output channels, we need to map them correctly
+    // Channel outputs are planar, device output is interleaved (for miniaudio)
     for (auto &[nbus, channelKinds] : device->channels) {
       if (nbus != 0) continue; // Only device output bus
       for (auto &[kind, channels] : channelKinds) {
@@ -342,20 +344,22 @@ struct Device {
         auto *channelData = channels[0];
         if (channelData->outChannels.empty()) continue;
 
-        // Get the output buffer for this channel configuration
+        // Get the output buffer for this channel configuration (planar layout)
         auto &channelOutput = channelData->outputBuffer;
         if (!channelOutput) continue;
 
         auto channelOutCount = channelData->outChannels.size();
 
-        // Map each channel's output to the correct device output channel
+        // Map each channel's planar output to the correct interleaved device output channel
         for (size_t c = 0; c < channelOutCount; c++) {
           auto deviceChannel = channelData->outChannels[c];
           if (deviceChannel >= outChannels) continue;
 
+          // Source is planar: channel c data is at channelOutput + c * frameCount
+          const float *src = channelOutput + c * frameCount;
           for (ma_uint32 i = 0; i < frameCount; i++) {
-            // Add to device output (mixing)
-            fOutput[i * outChannels + deviceChannel] += channelOutput[i * channelOutCount + c];
+            // Add to interleaved device output (mixing)
+            fOutput[i * outChannels + deviceChannel] += src[i];
           }
         }
       }
@@ -794,7 +798,8 @@ struct Oscillator {
   ma_uint64 _nsamples{1024};
   ma_uint32 _sampleRate{44100};
 
-  std::vector<float> _buffer;
+  std::vector<float> _buffer;          // Planar output buffer
+  std::vector<float> _interleavedBuf;  // Scratch for miniaudio interleaved output
 
   SHVar *_device{nullptr};
   Device *d{nullptr};
@@ -923,15 +928,22 @@ struct Oscillator {
     if (d) {
       // if a device is connected override this value
       _nsamples = d->actualBufferSize;
-      _buffer.resize(_channels * _nsamples);
     }
+
+    auto totalSamples = _channels * _nsamples;
+    _buffer.resize(totalSamples);
+    _interleavedBuf.resize(totalSamples);
 
     ma_waveform_set_amplitude(&_wave, _amplitude.get().payload.floatValue);
     ma_waveform_set_frequency(&_wave, input.payload.floatValue);
 
-    ma_waveform_read_pcm_frames(&_wave, _buffer.data(), _nsamples, NULL);
+    // miniaudio outputs interleaved, read into scratch buffer
+    ma_waveform_read_pcm_frames(&_wave, _interleavedBuf.data(), _nsamples, NULL);
 
-    return Var(SHAudio{_sampleRate, uint16_t(_nsamples), uint16_t(_channels), _buffer.data()});
+    // Deinterleave to planar output
+    audioDeinterleave(_interleavedBuf.data(), _buffer.data(), uint32_t(_nsamples), uint8_t(_channels));
+
+    return Var(makeAudio(_buffer.data(), uint32_t(_nsamples), _sampleRate, uint8_t(_channels)));
   }
 };
 
@@ -941,15 +953,8 @@ struct ReadFile {
 
   ma_uint64 _progress{0};
 
-  // ma_uint32 _channels{2};
-  // ma_uint64 _nsamples{1024};
-  // ma_uint32 _sampleRate{44100};
-  // what to do when not looped ends? throw?
-  // bool _looped{false};
-  // ParamVar _fromSample;
-  // ParamVar _toSample;
-
-  std::vector<float> _buffer;
+  std::vector<float> _buffer;          // Planar output buffer
+  std::vector<float> _interleavedBuf;  // Scratch for miniaudio interleaved output
   bool _done{false};
 
   SHVar *_device{nullptr};
@@ -1070,14 +1075,18 @@ struct ReadFile {
       ma_uint64 totalSamples;
       ma_decoder_get_length_in_pcm_frames(&_decoder, &totalSamples);
 
-      _buffer.resize(size_t(channels) * size_t(nsamples));
+      auto bufSize = size_t(channels) * size_t(nsamples);
+      _buffer.resize(bufSize);
+      _interleavedBuf.resize(bufSize);
       _initialized = true;
     }
 
     if (d) {
       // if a device is connected override this value
       nsamples = d->actualBufferSize;
-      _buffer.resize(size_t(channels) * size_t(nsamples));
+      auto bufSize = size_t(channels) * size_t(nsamples);
+      _buffer.resize(bufSize);
+      _interleavedBuf.resize(bufSize);
     }
 
     if (unlikely(_done)) {
@@ -1114,10 +1123,10 @@ struct ReadFile {
       }
     }
 
-    // read pcm data every iteration
+    // read pcm data every iteration (miniaudio outputs interleaved)
     ma_uint64 framesRead = 0;
     if (reading > 0) {
-      ma_result res = ma_decoder_read_pcm_frames(&_decoder, _buffer.data(), reading, &framesRead);
+      ma_result res = ma_decoder_read_pcm_frames(&_decoder, _interleavedBuf.data(), reading, &framesRead);
       if (res != MA_SUCCESS) {
         throw ActivationError("Failed to read");
       }
@@ -1127,17 +1136,20 @@ struct ReadFile {
     if (framesRead < nsamples) {
       // Reached the end.
       _done = true;
-      // zero anything that was not used
+      // zero anything that was not used in interleaved buffer
       const auto remains = nsamples - framesRead;
-      if (remains <= _buffer.size()) {
-        memset(_buffer.data() + framesRead * channels, 0, sizeof(float) * remains * channels);
+      if (remains * channels <= _interleavedBuf.size()) {
+        memset(_interleavedBuf.data() + framesRead * channels, 0, sizeof(float) * remains * channels);
       } else {
         // Handle error: buffer is smaller than expected
         throw ActivationError("Buffer size mismatch");
       }
     }
 
-    return Var(SHAudio{sampleRate, uint16_t(nsamples), uint16_t(channels), _buffer.data()});
+    // Deinterleave to planar output
+    audioDeinterleave(_interleavedBuf.data(), _buffer.data(), uint32_t(nsamples), uint8_t(channels));
+
+    return Var(makeAudio(_buffer.data(), uint32_t(nsamples), sampleRate, uint8_t(channels)));
   }
 };
 
@@ -1249,6 +1261,7 @@ struct WriteFile {
   ma_uint32 _sampleRate{44100};
   ma_uint64 _progress{0};
   ParamVar _filename;
+  std::vector<float> _interleavedBuf;  // Scratch for interleaving planar input
 
   static SHOptionalString help() { return SHCCSTR("This shard writes audio data to WAV format file."); }
 
@@ -1333,7 +1346,8 @@ struct WriteFile {
   }
 
   SHVar activate(SHContext *context, const SHVar &input) {
-    if (input.payload.audioValue.channels != _channels) {
+    auto &audio = input.payload.audioValue;
+    if (audio.channels != _channels) {
       throw ActivationError("Input has an invalid number of audio channels");
     }
     if (!_initialized) {
@@ -1341,7 +1355,13 @@ struct WriteFile {
       initFile(fname);
       _initialized = true;
     }
-    ma_encoder_write_pcm_frames(&_encoder, input.payload.audioValue.samples, input.payload.audioValue.nsamples, NULL);
+
+    // miniaudio encoder expects interleaved format
+    // Interleave planar input before writing
+    _interleavedBuf.resize(audio.nsamples * audio.channels);
+    audioInterleave(audio.samples, _interleavedBuf.data(), audio.nsamples, audio.channels);
+
+    ma_encoder_write_pcm_frames(&_encoder, _interleavedBuf.data(), audio.nsamples, NULL);
     return input;
   }
 };
@@ -1386,31 +1406,40 @@ struct Resample {
     PARAM_CLEANUP(context);
   }
 
-  std::vector<float> _buffer;
-  std::vector<float> _leftoverSamples;
-  std::vector<float> _combinedInput;
+  std::vector<float> _buffer;           // Planar output buffer
+  std::vector<float> _interleavedIn;    // Interleaved input for resampler
+  std::vector<float> _interleavedOut;   // Interleaved output from resampler
+  std::vector<float> _leftoverSamples;  // Interleaved leftovers
+  std::vector<float> _combinedInput;    // Combined interleaved input
   ma_uint32 _inSampleRate{0};
   ma_uint32 _outSampleRate{0};
   ma_uint32 _channels{0};
 
   SHVar activate(SHContext *context, const SHVar &input) {
+    auto &audio = input.payload.audioValue;
+    uint32_t inSampleRate = audioGetSampleRate(audio);
+
     if (!_initialized) {
       ma_resampler_config config =
-          ma_resampler_config_init(ma_format_f32, input.payload.audioValue.channels, input.payload.audioValue.sampleRate,
+          ma_resampler_config_init(ma_format_f32, audio.channels, inSampleRate,
                                    _outRate.get().payload.intValue, ma_resample_algorithm_linear);
       ma_result res = ma_resampler_init(&config, NULL, &_resampler);
       if (res != MA_SUCCESS) {
         throw ActivationError("Failed to initialize resampler");
       }
       _initialized = true;
-      _inSampleRate = input.payload.audioValue.sampleRate;
+      _inSampleRate = inSampleRate;
       _outSampleRate = _outRate.get().payload.intValue;
-      _channels = input.payload.audioValue.channels;
+      _channels = audio.channels;
     }
 
-    if (input.payload.audioValue.sampleRate != _inSampleRate) {
+    if (inSampleRate != _inSampleRate) {
       throw ActivationError("Input sample rate does not match initialized sample rate");
     }
+
+    // Convert planar input to interleaved for miniaudio resampler
+    _interleavedIn.resize(audio.nsamples * _channels);
+    audioInterleave(audio.samples, _interleavedIn.data(), audio.nsamples, uint8_t(_channels));
 
     // Prepare combined input buffer with leftover samples and new input
     _combinedInput.clear();
@@ -1418,9 +1447,8 @@ struct Resample {
       _combinedInput.insert(_combinedInput.end(), _leftoverSamples.begin(), _leftoverSamples.end());
     }
 
-    // Add new input samples
-    _combinedInput.insert(_combinedInput.end(), input.payload.audioValue.samples,
-                          input.payload.audioValue.samples + (input.payload.audioValue.nsamples * _channels));
+    // Add new interleaved input samples
+    _combinedInput.insert(_combinedInput.end(), _interleavedIn.begin(), _interleavedIn.end());
 
     ma_uint64 totalFramesIn = _combinedInput.size() / _channels;
     ma_uint64 frameCountIn = totalFramesIn;
@@ -1432,15 +1460,15 @@ struct Resample {
       throw ActivationError("Failed to get expected output frame count");
     }
 
-    _buffer.resize(frameCountOut * _channels);
-    res = ma_resampler_process_pcm_frames(&_resampler, _combinedInput.data(), &frameCountIn, _buffer.data(), &frameCountOut);
+    _interleavedOut.resize(frameCountOut * _channels);
+    res = ma_resampler_process_pcm_frames(&_resampler, _combinedInput.data(), &frameCountIn, _interleavedOut.data(), &frameCountOut);
 
     if (res != MA_SUCCESS) {
       SHLOG_ERROR("Failed to resample audio: {} {}", res, frameCountIn);
       throw ActivationError("Failed to resample audio");
     }
 
-    // Store unconsumed samples for next iteration
+    // Store unconsumed samples for next iteration (in interleaved format)
     if (frameCountIn < totalFramesIn) {
       size_t unconsumedSamples = (totalFramesIn - frameCountIn) * _channels;
       _leftoverSamples.assign(_combinedInput.end() - unconsumedSamples, _combinedInput.end());
@@ -1448,12 +1476,11 @@ struct Resample {
       _leftoverSamples.clear();
     }
 
-    SHVar output = input;
-    output.payload.audioValue.nsamples = frameCountOut;
-    output.payload.audioValue.samples = _buffer.data();
-    output.payload.audioValue.sampleRate = _outSampleRate;
+    // Convert interleaved output back to planar
+    _buffer.resize(frameCountOut * _channels);
+    audioDeinterleave(_interleavedOut.data(), _buffer.data(), uint32_t(frameCountOut), uint8_t(_channels));
 
-    return output;
+    return Var(makeAudio(_buffer.data(), uint32_t(frameCountOut), _outSampleRate, uint8_t(_channels)));
   }
 };
 

--- a/shards/modules/audio/audio.cpp
+++ b/shards/modules/audio/audio.cpp
@@ -1417,10 +1417,9 @@ struct Resample {
   }
 
   std::vector<float> _buffer;           // Planar output buffer
-  std::vector<float> _interleavedIn;    // Interleaved input for resampler
+  std::vector<float> _interleavedIn;    // Interleaved input for resampler (includes leftovers)
   std::vector<float> _interleavedOut;   // Interleaved output from resampler
   std::vector<float> _leftoverSamples;  // Interleaved leftovers
-  std::vector<float> _combinedInput;    // Combined interleaved input
   ma_uint32 _inSampleRate{0};
   ma_uint32 _outSampleRate{0};
   ma_uint32 _channels{0};
@@ -1447,20 +1446,22 @@ struct Resample {
       throw ActivationError("Input sample rate does not match initialized sample rate");
     }
 
-    // Convert planar input to interleaved for miniaudio resampler
-    _interleavedIn.resize(audio.nsamples * _channels);
-    audioInterleave(audio.samples, _interleavedIn.data(), audio.nsamples, uint8_t(_channels));
+    // Build interleaved input: leftovers + new samples (single buffer, no intermediate copy)
+    const size_t newSamplesInterleaved = audio.nsamples * _channels;
+    const size_t leftoverSamplesInterleaved = _leftoverSamples.size();
+    const size_t totalSamplesInterleaved = leftoverSamplesInterleaved + newSamplesInterleaved;
 
-    // Prepare combined input buffer with leftover samples and new input
-    _combinedInput.clear();
-    if (!_leftoverSamples.empty()) {
-      _combinedInput.insert(_combinedInput.end(), _leftoverSamples.begin(), _leftoverSamples.end());
+    _interleavedIn.resize(totalSamplesInterleaved);
+
+    // Copy leftovers to front (if any)
+    if (leftoverSamplesInterleaved > 0) {
+      memcpy(_interleavedIn.data(), _leftoverSamples.data(), leftoverSamplesInterleaved * sizeof(float));
     }
 
-    // Add new interleaved input samples
-    _combinedInput.insert(_combinedInput.end(), _interleavedIn.begin(), _interleavedIn.end());
+    // Interleave new planar samples directly after leftovers
+    audioInterleave(audio.samples, _interleavedIn.data() + leftoverSamplesInterleaved, audio.nsamples, uint8_t(_channels));
 
-    ma_uint64 totalFramesIn = _combinedInput.size() / _channels;
+    ma_uint64 totalFramesIn = totalSamplesInterleaved / _channels;
     ma_uint64 frameCountIn = totalFramesIn;
     ma_uint64 frameCountOut = 0;
 
@@ -1471,7 +1472,7 @@ struct Resample {
     }
 
     _interleavedOut.resize(frameCountOut * _channels);
-    res = ma_resampler_process_pcm_frames(&_resampler, _combinedInput.data(), &frameCountIn, _interleavedOut.data(), &frameCountOut);
+    res = ma_resampler_process_pcm_frames(&_resampler, _interleavedIn.data(), &frameCountIn, _interleavedOut.data(), &frameCountOut);
 
     if (res != MA_SUCCESS) {
       SHLOG_ERROR("Failed to resample audio: {} {}", res, frameCountIn);
@@ -1480,8 +1481,8 @@ struct Resample {
 
     // Store unconsumed samples for next iteration (in interleaved format)
     if (frameCountIn < totalFramesIn) {
-      size_t unconsumedSamples = (totalFramesIn - frameCountIn) * _channels;
-      _leftoverSamples.assign(_combinedInput.end() - unconsumedSamples, _combinedInput.end());
+      size_t consumedSamples = frameCountIn * _channels;
+      _leftoverSamples.assign(_interleavedIn.begin() + consumedSamples, _interleavedIn.end());
     } else {
       _leftoverSamples.clear();
     }

--- a/shards/modules/audio/audio.cpp
+++ b/shards/modules/audio/audio.cpp
@@ -1146,8 +1146,10 @@ struct ReadFile {
       _done = true;
       // zero anything that was not used in interleaved buffer
       const auto remains = nsamples - framesRead;
-      if (remains * channels <= _interleavedBuf.size()) {
-        memset(_interleavedBuf.data() + framesRead * channels, 0, sizeof(float) * remains * channels);
+      const size_t zeroStart = framesRead * channels;
+      const size_t zeroSize = remains * channels;
+      if (zeroStart + zeroSize <= _interleavedBuf.size()) {
+        memset(_interleavedBuf.data() + zeroStart, 0, sizeof(float) * zeroSize);
       } else {
         // Handle error: buffer is smaller than expected
         throw ActivationError("Buffer size mismatch");

--- a/shards/modules/audio/codec.cpp
+++ b/shards/modules/audio/codec.cpp
@@ -235,9 +235,11 @@ struct Compress {
   std::vector<unsigned char> _encodedBuffer;  // Buffer for encoded data
   std::vector<SHVar> _outputPackets;          // Sequence of encoded packets
 
+  std::vector<float> _interleavedInput;  // Buffer for interleaved audio (Opus expects interleaved)
+
   SHVar activate(SHContext *context, const SHVar &input) {
     const auto &audio = input.payload.audioValue;
-    int sampleRate = static_cast<int>(audio.sampleRate);
+    int sampleRate = static_cast<int>(audioGetSampleRate(audio));
     int numChannels = static_cast<int>(audio.channels);
     int numSamples = static_cast<int>(audio.nsamples);
 
@@ -277,10 +279,14 @@ struct Compress {
       throw ActivationError(msg);
     }
 
+    // Opus expects interleaved audio, so convert planar to interleaved
+    _interleavedInput.resize(numSamples * numChannels);
+    audioInterleave(audio.samples, _interleavedInput.data(), uint32_t(numSamples), uint8_t(numChannels));
+
     // Append new audio data to our input buffer
     size_t oldSize = _inputBuffer.size();
     _inputBuffer.resize(oldSize + numSamples * numChannels);
-    std::memcpy(_inputBuffer.data() + oldSize, audio.samples, numSamples * numChannels * sizeof(float));
+    std::memcpy(_inputBuffer.data() + oldSize, _interleavedInput.data(), numSamples * numChannels * sizeof(float));
 
     // Clear output packets for this activation
     _outputPackets.clear();
@@ -439,7 +445,8 @@ struct Decompress {
   bool _decoderInitialized = false;
   int _lastSampleRate = 0;
   int _lastChannels = 0;
-  std::vector<float> _outputBuffer;
+  std::vector<float> _interleavedOutput;  // Opus outputs interleaved
+  std::vector<float> _outputBuffer;        // Planar output
 
   SHVar activate(SHContext *context, const SHVar &input) {
     const auto &binaryData = input.payload.bytesValue;
@@ -493,21 +500,24 @@ struct Decompress {
       throw ActivationError(msg);
     }
 
-    // Resize output buffer to hold the decoded frame
-    _outputBuffer.resize(frameSizeSamples * channels);
+    // Resize output buffer to hold the decoded frame (Opus outputs interleaved)
+    _interleavedOutput.resize(frameSizeSamples * channels);
 
     // Decode the Opus packet
     int samplesDecoded =
-        opus_decode_float(_decoder, binaryData, static_cast<opus_int32>(binarySize), _outputBuffer.data(), frameSizeSamples, 0);
+        opus_decode_float(_decoder, binaryData, static_cast<opus_int32>(binarySize), _interleavedOutput.data(), frameSizeSamples, 0);
 
     if (samplesDecoded < 0) {
       auto msg = fmt::format("Opus decoding failed: {}", opus_strerror(samplesDecoded));
       throw ActivationError(msg);
     }
 
-    // Create output audio with decompressed samples
-    return Var(SHAudio{static_cast<uint32_t>(sampleRate), static_cast<uint16_t>(samplesDecoded), static_cast<uint16_t>(channels),
-                       _outputBuffer.data()});
+    // Convert interleaved output to planar
+    _outputBuffer.resize(samplesDecoded * channels);
+    audioDeinterleave(_interleavedOutput.data(), _outputBuffer.data(), uint32_t(samplesDecoded), uint8_t(channels));
+
+    // Create output audio with decompressed samples (planar format)
+    return Var(makeAudio(_outputBuffer.data(), uint32_t(samplesDecoded), uint32_t(sampleRate), uint8_t(channels)));
   }
 };
 

--- a/shards/modules/audio/codec.cpp
+++ b/shards/modules/audio/codec.cpp
@@ -235,7 +235,7 @@ struct Compress {
   std::vector<unsigned char> _encodedBuffer;  // Buffer for encoded data
   std::vector<SHVar> _outputPackets;          // Sequence of encoded packets
 
-  std::vector<float> _interleavedInput;  // Buffer for interleaved audio (Opus expects interleaved)
+  std::vector<float> _interleavedInput; // Buffer for interleaved audio (Opus expects interleaved)
 
   SHVar activate(SHContext *context, const SHVar &input) {
     const auto &audio = input.payload.audioValue;
@@ -445,8 +445,8 @@ struct Decompress {
   bool _decoderInitialized = false;
   int _lastSampleRate = 0;
   int _lastChannels = 0;
-  std::vector<float> _interleavedOutput;  // Opus outputs interleaved
-  std::vector<float> _outputBuffer;        // Planar output
+  std::vector<float> _interleavedOutput; // Opus outputs interleaved
+  std::vector<float> _outputBuffer;      // Planar output
 
   SHVar activate(SHContext *context, const SHVar &input) {
     const auto &binaryData = input.payload.bytesValue;
@@ -504,8 +504,8 @@ struct Decompress {
     _interleavedOutput.resize(frameSizeSamples * channels);
 
     // Decode the Opus packet
-    int samplesDecoded =
-        opus_decode_float(_decoder, binaryData, static_cast<opus_int32>(binarySize), _interleavedOutput.data(), frameSizeSamples, 0);
+    int samplesDecoded = opus_decode_float(_decoder, binaryData, static_cast<opus_int32>(binarySize), _interleavedOutput.data(),
+                                           frameSizeSamples, 0);
 
     if (samplesDecoded < 0) {
       auto msg = fmt::format("Opus decoding failed: {}", opus_strerror(samplesDecoded));

--- a/shards/modules/audio/compressor.cpp
+++ b/shards/modules/audio/compressor.cpp
@@ -99,6 +99,11 @@ struct Compressor {
     const auto &audio = input.payload.audioValue;
     uint32_t numSamples = audio.nsamples;
     uint32_t numChannels = audio.channels;
+
+    // Check for overflow before multiplication
+    if (numChannels > 0 && numSamples > UINT32_MAX / numChannels) {
+      throw ActivationError("Audio buffer size overflow");
+    }
     uint32_t totalSamples = numSamples * numChannels;
     float sampleRate = static_cast<float>(audioGetSampleRate(audio));
 

--- a/shards/modules/audio/compressor.cpp
+++ b/shards/modules/audio/compressor.cpp
@@ -100,7 +100,7 @@ struct Compressor {
     uint32_t numSamples = audio.nsamples;
     uint32_t numChannels = audio.channels;
     uint32_t totalSamples = numSamples * numChannels;
-    float sampleRate = static_cast<float>(audio.sampleRate);
+    float sampleRate = static_cast<float>(audioGetSampleRate(audio));
 
     // Get parameter values
     float threshold = _threshold.get().payload.floatValue;
@@ -116,15 +116,16 @@ struct Compressor {
     float releaseCoeff = timeToCoeff(release, sampleRate);
     float slope = 1.0f - (1.0f / ratio);
 
-    // Resize buffer if needed
+    // Resize buffer if needed (planar format)
     _buffer.resize(totalSamples);
 
-    // Process each sample
+    // Process each sample (audio is in planar format: [ch0_samples...][ch1_samples...])
     for (uint32_t i = 0; i < numSamples; ++i) {
       // Find the maximum absolute value across all channels for this sample
       float maxSample = 0.0f;
       for (uint32_t c = 0; c < numChannels; ++c) {
-        float sample = std::abs(audio.samples[i * numChannels + c]);
+        // Planar: channel c sample i is at samples[c * numSamples + i]
+        float sample = std::abs(audio.samples[c * numSamples + i]);
         maxSample = std::max(maxSample, sample);
       }
 
@@ -143,15 +144,15 @@ struct Compressor {
         gainReduction = dbToLinear(dbGainReduction);
       }
 
-      // Apply gain reduction and makeup gain to all channels
+      // Apply gain reduction and makeup gain to all channels (planar format)
       for (uint32_t c = 0; c < numChannels; ++c) {
-        uint32_t index = i * numChannels + c;
+        uint32_t index = c * numSamples + i;
         _buffer[index] = audio.samples[index] * gainReduction * makeupGainLinear;
       }
     }
 
-    // Create output audio with compressed samples
-    return Var(SHAudio{audio.sampleRate, audio.nsamples, audio.channels, _buffer.data()});
+    // Create output audio with compressed samples (planar format)
+    return Var(makeAudio(_buffer.data(), numSamples, uint32_t(sampleRate), uint8_t(numChannels)));
   }
 };
 

--- a/shards/modules/audio/dsp.cpp
+++ b/shards/modules/audio/dsp.cpp
@@ -251,7 +251,8 @@ struct IFFT : public FFTBase {
     if constexpr (OTYPE == SHType::Audio) {
       kiss_fftri(_rstate, _cscratch.data(), _fscratch.data());
 
-      return Var(SHAudio{0, uint16_t(olen), uint16_t(1), _fscratch.data()});
+      // IFFT output: mono audio at default 44100 Hz (no sample rate info available)
+      return Var(SHAudio{_fscratch.data(), uint32_t(olen), SHAUDIO_ENCODE_SAMPLE_RATE(44100), 1, 0});
     } else if constexpr (OTYPE == SHType::Float) {
       kiss_fftri(_rstate, _cscratch.data(), _fscratch.data());
 

--- a/shards/modules/audio/dsp.cpp
+++ b/shards/modules/audio/dsp.cpp
@@ -259,7 +259,7 @@ struct IFFT : public FFTBase {
       kiss_fftri(_rstate, _cscratch.data(), _fscratch.data());
 
       // IFFT output: mono audio with configurable sample rate (default 44100 Hz)
-      return Var(SHAudio{_fscratch.data(), uint32_t(olen), SHAUDIO_ENCODE_SAMPLE_RATE(_sampleRate), 1, 0});
+      return Var(makeAudio(_fscratch.data(), uint32_t(olen), _sampleRate, 1));
     } else if constexpr (OTYPE == SHType::Float) {
       kiss_fftri(_rstate, _cscratch.data(), _fscratch.data());
 

--- a/shards/modules/audio/dsp.cpp
+++ b/shards/modules/audio/dsp.cpp
@@ -150,6 +150,7 @@ struct FFT : public FFTBase {
 struct IFFT : public FFTBase {
   bool _asAudio{false};
   bool _complex{false};
+  uint32_t _sampleRate{44100};
 
   static SHOptionalString help() {
     return SHCCSTR("This shard performs an Inverse Fast Fourier Transform (IFFT) on the input. It takes the frequency-domain "
@@ -172,7 +173,8 @@ struct IFFT : public FFTBase {
 
   static inline Parameters Params{
       {"Audio", SHCCSTR("If the output should be an Audio chunk."), {CoreInfo::BoolType}},
-      {"Complex", SHCCSTR("If the output should be complex numbers (only if not Audio)."), {CoreInfo::BoolType}}};
+      {"Complex", SHCCSTR("If the output should be complex numbers (only if not Audio)."), {CoreInfo::BoolType}},
+      {"SampleRate", SHCCSTR("The sample rate for audio output (only used when Audio is true)."), {CoreInfo::IntType}}};
 
   SHParametersInfo parameters() { return Params; }
 
@@ -183,6 +185,9 @@ struct IFFT : public FFTBase {
       break;
     case 1:
       _complex = value.payload.boolValue;
+      break;
+    case 2:
+      _sampleRate = uint32_t(value.payload.intValue);
       break;
     default:
       throw InvalidParameterIndex();
@@ -195,6 +200,8 @@ struct IFFT : public FFTBase {
       return Var(_asAudio);
     case 1:
       return Var(_complex);
+    case 2:
+      return Var(int64_t(_sampleRate));
     default:
       throw InvalidParameterIndex();
     }
@@ -251,8 +258,8 @@ struct IFFT : public FFTBase {
     if constexpr (OTYPE == SHType::Audio) {
       kiss_fftri(_rstate, _cscratch.data(), _fscratch.data());
 
-      // IFFT output: mono audio at default 44100 Hz (no sample rate info available)
-      return Var(SHAudio{_fscratch.data(), uint32_t(olen), SHAUDIO_ENCODE_SAMPLE_RATE(44100), 1, 0});
+      // IFFT output: mono audio with configurable sample rate (default 44100 Hz)
+      return Var(SHAudio{_fscratch.data(), uint32_t(olen), SHAUDIO_ENCODE_SAMPLE_RATE(_sampleRate), 1, 0});
     } else if constexpr (OTYPE == SHType::Float) {
       kiss_fftri(_rstate, _cscratch.data(), _fscratch.data());
 

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -1445,10 +1445,6 @@ struct FloatsToAudio {
 
     uint32_t nsamples = totalSamples / channels;
 
-    if (nsamples > UINT16_MAX) {
-      throw ActivationError("Audio data exceeds the maximum number of samples (65535)");
-    }
-
     _samples.resize(totalSamples);
 
     // Copy the float values from the sequence to the samples array
@@ -1466,13 +1462,7 @@ struct FloatsToAudio {
       _samples[i] = value;
     }
 
-    SHAudio outAudio;
-    outAudio.channels = channels;
-    outAudio.nsamples = nsamples;
-    outAudio.sampleRate = sampleRate;
-    outAudio.samples = _samples.data();
-
-    return Var(outAudio);
+    return Var(makeAudio(_samples.data(), nsamples, sampleRate, uint8_t(channels)));
   }
 };
 
@@ -1524,10 +1514,6 @@ struct BytesToAudio {
     int bytesPerSample = bits / 8;
     size_t nsamples = input.payload.bytesSize / (bytesPerSample * channels);
 
-    if (nsamples > UINT16_MAX) {
-      throw ActivationError("Audio data exceeds the maximum number of samples (65535)");
-    }
-
     size_t totalSamples = nsamples * channels;
     _samples.resize(totalSamples);
 
@@ -1567,13 +1553,7 @@ struct BytesToAudio {
       }
     }
 
-    SHAudio outAudio;
-    outAudio.channels = channels;
-    outAudio.nsamples = nsamples;
-    outAudio.sampleRate = sampleRate;
-    outAudio.samples = _samples.data();
-
-    return Var(outAudio);
+    return Var(makeAudio(_samples.data(), uint32_t(nsamples), sampleRate, uint8_t(channels)));
   }
 };
 

--- a/shards/modules/json/json.cpp
+++ b/shards/modules/json/json.cpp
@@ -115,9 +115,9 @@ void to_json(json &j, const SHVar &var) {
       buffer.resize(size);
       memcpy(&buffer[0], var.payload.audioValue.samples, size * sizeof(float));
       j = json{{"type", valType},
-               {"sampleRate", var.payload.audioValue.sampleRate},
+               {"sampleRate", SHAUDIO_DECODE_SAMPLE_RATE(var.payload.audioValue.sampleRate)},
                {"nsamples", var.payload.audioValue.nsamples},
-               {"channels", var.payload.audioValue.channels},
+               {"channels", (int)var.payload.audioValue.channels},
                {"samples", buffer}};
     } else {
       j = json{{"type", 0}, {"value", int(SHWireState::Continue)}};
@@ -355,9 +355,10 @@ void from_json(const json &j, SHVar &var) {
   }
   case SHType::Audio: {
     var.valueType = SHType::Audio;
-    var.payload.audioValue.sampleRate = j.at("sampleRate").get<float>();
-    var.payload.audioValue.nsamples = j.at("nsamples").get<uint16_t>();
-    var.payload.audioValue.channels = j.at("channels").get<uint16_t>();
+    var.payload.audioValue.sampleRate = SHAUDIO_ENCODE_SAMPLE_RATE(j.at("sampleRate").get<uint32_t>());
+    var.payload.audioValue.nsamples = j.at("nsamples").get<uint32_t>();
+    var.payload.audioValue.channels = j.at("channels").get<uint8_t>();
+    var.payload.audioValue.reserved = 0;  // Reserved for future use
     auto size = var.payload.audioValue.nsamples * var.payload.audioValue.channels;
     var.payload.audioValue.samples = new float[size];
     auto buffer = j.at("samples").get<std::vector<float>>();

--- a/shards/modules/json/json.cpp
+++ b/shards/modules/json/json.cpp
@@ -358,7 +358,7 @@ void from_json(const json &j, SHVar &var) {
     var.payload.audioValue.sampleRate = SHAUDIO_ENCODE_SAMPLE_RATE(j.at("sampleRate").get<uint32_t>());
     var.payload.audioValue.nsamples = j.at("nsamples").get<uint32_t>();
     var.payload.audioValue.channels = j.at("channels").get<uint8_t>();
-    var.payload.audioValue.reserved = 0;  // Reserved for future use
+    var.payload.audioValue.reserved = 0; // Reserved for future use
     auto size = var.payload.audioValue.nsamples * var.payload.audioValue.channels;
     var.payload.audioValue.samples = new float[size];
     auto buffer = j.at("samples").get<std::vector<float>>();

--- a/shards/rust/src/types/table.rs
+++ b/shards/rust/src/types/table.rs
@@ -970,10 +970,12 @@ impl std::fmt::Display for Var {
       }
       SHType::Audio => unsafe {
         let audio = self.payload.__bindgen_anon_1.audioValue;
+        // Decode sample rate: stored as actual_rate / 25
+        let decoded_sample_rate = (audio.sampleRate as u32) * 25;
         write!(
           f,
           "Audio SampleRate: {} Samples: {} Channels: {}",
-          audio.sampleRate, audio.nsamples, audio.channels
+          decoded_sample_rate, audio.nsamples, audio.channels
         )
       },
       SHType::Bytes => unsafe {

--- a/shards/tests/test_runtime.cpp
+++ b/shards/tests/test_runtime.cpp
@@ -150,9 +150,10 @@ TEST_CASE("SHVar-comparison", "[ops]") {
     std::vector<float> b1(1024);
     std::vector<float> b2(1024);
     std::vector<float> b3(1024);
-    SHVar x{.payload = {.audioValue = SHAudio{44100, 512, 2, b1.data()}}, .valueType = SHType::Audio};
-    SHVar y{.payload = {.audioValue = SHAudio{44100, 512, 2, b2.data()}}, .valueType = SHType::Audio};
-    SHVar z{.payload = {.audioValue = SHAudio{44100, 1024, 1, b3.data()}}, .valueType = SHType::Audio};
+    // SHAudio layout: {samples, nsamples, sampleRate (encoded), channels, reserved}
+    SHVar x{.payload = {.audioValue = makeAudio(b1.data(), 512, 44100, 2)}, .valueType = SHType::Audio};
+    SHVar y{.payload = {.audioValue = makeAudio(b2.data(), 512, 44100, 2)}, .valueType = SHType::Audio};
+    SHVar z{.payload = {.audioValue = makeAudio(b3.data(), 1024, 44100, 1)}, .valueType = SHType::Audio};
     auto empty = Var::Empty;
     REQUIRE(x == y);
     REQUIRE(x != z);


### PR DESCRIPTION
- Change SHAudio layout: samples ptr, nsamples (u32), sampleRate (u16 encoded), channels (u8), reserved (u8)
- Sample rate now encoded as actual_rate/25 to fit in u16 (decode with *25)
- Audio always planar: channel N at samples + N * nsamples
- Add helper functions: makeAudio(), audioGetSampleRate(), audioGetChannel(), audioDeinterleave(), audioInterleave()
- Update audio modules to interleave/deinterleave at device/codec boundaries (miniaudio, Opus)
- Update serialization, cloning, JSON, and display formatting
- Breaking change: SHAudio struct layout changed


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
