### PR TITLE
Add Type parameter to Events shards

### DIFF
--- a/shards/modules/channels/events.cpp
+++ b/shards/modules/channels/events.cpp
@@ -38,9 +38,8 @@ struct Base {
 
 protected:
   // Helper to validate and set event type, returns the resolved event type
-  // If explicit type is provided, validates it matches existing dispatcher type
-  // If no explicit type and fallbackType provided, uses fallbackType
-  // If no explicit type and no fallbackType, returns dispatcher type or throws if not set
+  // Priority: explicit Type param > fallbackType > existing dispatcher type
+  // Note: This is safe because compose() runs sequentially during wire compilation
   SHTypeInfo resolveEventType(bool requireType = true, const SHTypeInfo *fallbackType = nullptr) {
     auto currentDispatcherType = (*_dispatcher).get().getType();
 
@@ -104,7 +103,7 @@ struct Emit : Send {
   SHTypeInfo compose(const SHInstanceData &data) {
     Base::compose(data);
 
-    // Emit always sends Bool - validate explicit Type is compatible if provided
+    // Emit always sends Bool - if explicit Type is provided, validate it's compatible
     if (_type.valueType == SHType::Type) {
       auto explicitType = *_type.payload.typeValue;
       if (!matchTypes(CoreInfo::BoolType, explicitType, false, true, true)) {
@@ -113,8 +112,8 @@ struct Emit : Send {
       }
     }
 
-    // Use Bool as the event type (with explicit Type taking precedence if compatible)
-    resolveEventType(true, &CoreInfo::BoolType);
+    // Register event type: uses explicit Type if provided (validated above), else Bool
+    resolveEventType(true, *CoreInfo::BoolType);
     return data.inputType;
   }
 
@@ -192,7 +191,9 @@ struct Check : Receive {
 
   SHTypeInfo compose(const SHInstanceData &data) {
     Base::compose(data);
-    resolveEventType(false); // validate type if provided, but don't require it
+    // Validate/set type if explicit Type provided, but don't require it since Check just returns Bool
+    // This ensures type consistency if user specifies Type on Check before any Send
+    resolveEventType(false);
     return CoreInfo::BoolType;
   }
 

--- a/shards/modules/channels/events.cpp
+++ b/shards/modules/channels/events.cpp
@@ -17,7 +17,11 @@ struct Base {
         {CoreInfo::StringType, CoreInfo::StringVarType});
   PARAM_PARAMVAR(_id, "ID", "The optional ID to use to differentiate events with the same name.",
                  {CoreInfo::IntType, CoreInfo::IntVarType, CoreInfo::NoneType});
-  PARAM_IMPL(PARAM_IMPL_FOR(_eventName), PARAM_IMPL_FOR(_id));
+  PARAM(OwnedVar, _type, "Type",
+        "The optional explicit type for this event. Allows defining the event type upfront without "
+        "requiring Events.Send to be called first (enables receiver-first pattern).",
+        {CoreInfo::NoneType, CoreInfo::TypeType});
+  PARAM_IMPL(PARAM_IMPL_FOR(_eventName), PARAM_IMPL_FOR(_id), PARAM_IMPL_FOR(_type));
 
   PARAM_REQUIRED_VARIABLES();
 
@@ -31,15 +35,47 @@ struct Base {
   void warmup(SHContext *context) { PARAM_WARMUP(context); }
 
   void cleanup(SHContext *context) { PARAM_CLEANUP(context); }
+
+protected:
+  // Helper to validate and set event type, returns the resolved event type
+  // If explicit type is provided, validates it matches existing dispatcher type
+  // If no explicit type, returns dispatcher type or throws if not set
+  SHTypeInfo resolveEventType(bool requireType = true) {
+    auto currentDispatcherType = (*_dispatcher).get().getType();
+
+    if (_type.valueType == SHType::Type) {
+      auto explicitType = *_type.payload.typeValue;
+      if (currentDispatcherType.basicType == SHType::None) {
+        (*_dispatcher).get().assignType(explicitType);
+      } else if (!matchTypes(explicitType, currentDispatcherType, false, true, true)) {
+        SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, explicitType,
+                    currentDispatcherType);
+        throw shards::Error("Event type mismatch");
+      }
+      return explicitType;
+    } else {
+      if (requireType && currentDispatcherType.basicType == SHType::None) {
+        SHLOG_ERROR("Event type not set for event: {}, use Events.Send first or specify Type parameter", _eventName);
+        throw shards::Error("Event type not set");
+      }
+      return currentDispatcherType;
+    }
+  }
 };
 
 struct Send : Base {
   SHTypeInfo compose(const SHInstanceData &data) {
     Base::compose(data);
 
-    // when we send we store the type of the event
-    // we store the type of the event
-    (*_dispatcher).get().assignType(data.inputType);
+    // use explicit type if provided, otherwise use input type
+    const auto &eventType = _type.valueType == SHType::Type ? *_type.payload.typeValue : data.inputType;
+    auto currentDispatcherType = (*_dispatcher).get().getType();
+    if (currentDispatcherType.basicType == SHType::None) {
+      (*_dispatcher).get().assignType(eventType);
+    } else if (!matchTypes(eventType, currentDispatcherType, false, true, true)) {
+      SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, eventType, currentDispatcherType);
+      throw shards::Error("Event type mismatch");
+    }
 
     return data.inputType;
   }
@@ -95,15 +131,7 @@ struct Receive : Base {
   SHTypeInfo compose(const SHInstanceData &data) {
     Base::compose(data);
 
-    // prevent none
-    auto currentType = (*_dispatcher).get().getType();
-    if (currentType.basicType == SHType::None) {
-      SHLOG_ERROR("Event type not set for event: {}, use Events.Send first", _eventName);
-      throw shards::Error("Event type not set");
-    }
-
-    // fixup type
-    singleType = currentType;
+    singleType = resolveEventType();
     outputType = Type::SeqOf(singleType);
 
     return outputType;
@@ -157,6 +185,7 @@ struct Check : Receive {
 
   SHTypeInfo compose(const SHInstanceData &data) {
     Base::compose(data);
+    resolveEventType(false); // validate type if provided, but don't require it
     return CoreInfo::BoolType;
   }
 

--- a/shards/modules/channels/events.cpp
+++ b/shards/modules/channels/events.cpp
@@ -105,6 +105,15 @@ struct Send : Base {
 
 struct Emit : Send {
   SHTypeInfo compose(const SHInstanceData &data) {
+    // Emit always sends Bool, validate explicit Type is compatible
+    if (_type.valueType == SHType::Type) {
+      auto explicitType = *_type.payload.typeValue;
+      if (!matchTypes(CoreInfo::BoolType, explicitType, false, true, true)) {
+        SHLOG_ERROR("Events.Emit always sends Bool, but explicit Type {} is incompatible", explicitType);
+        throw shards::Error("Emit Type must be compatible with Bool");
+      }
+    }
+
     auto dataCopy = data;
     dataCopy.inputType = CoreInfo::BoolType;
     Send::compose(dataCopy);

--- a/shards/modules/channels/events.cpp
+++ b/shards/modules/channels/events.cpp
@@ -39,20 +39,17 @@ struct Base {
 protected:
   // Helper to validate and set event type, returns the resolved event type
   // If explicit type is provided, validates it matches existing dispatcher type
-  // If no explicit type, returns dispatcher type or throws if not set
-  SHTypeInfo resolveEventType(bool requireType = true) {
+  // If no explicit type and fallbackType provided, uses fallbackType
+  // If no explicit type and no fallbackType, returns dispatcher type or throws if not set
+  SHTypeInfo resolveEventType(bool requireType = true, const SHTypeInfo *fallbackType = nullptr) {
     auto currentDispatcherType = (*_dispatcher).get().getType();
 
+    // Determine the target type: explicit Type param > fallbackType > dispatcher type
+    SHTypeInfo targetType;
     if (_type.valueType == SHType::Type) {
-      auto explicitType = *_type.payload.typeValue;
-      if (currentDispatcherType.basicType == SHType::None) {
-        (*_dispatcher).get().assignType(explicitType);
-      } else if (!matchTypes(explicitType, currentDispatcherType, false, true, true)) {
-        SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, explicitType,
-                    currentDispatcherType);
-        throw shards::Error("Event type mismatch");
-      }
-      return explicitType;
+      targetType = *_type.payload.typeValue;
+    } else if (fallbackType) {
+      targetType = *fallbackType;
     } else {
       if (requireType && currentDispatcherType.basicType == SHType::None) {
         SHLOG_ERROR("Event type not set for event: {}, use Events.Send first or specify Type parameter", _eventName);
@@ -60,23 +57,23 @@ protected:
       }
       return currentDispatcherType;
     }
+
+    // Validate and set dispatcher type
+    if (currentDispatcherType.basicType == SHType::None) {
+      (*_dispatcher).get().assignType(targetType);
+    } else if (!matchTypes(targetType, currentDispatcherType, false, true, true)) {
+      SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, targetType,
+                  currentDispatcherType);
+      throw shards::Error("Event type mismatch");
+    }
+    return targetType;
   }
 };
 
 struct Send : Base {
   SHTypeInfo compose(const SHInstanceData &data) {
     Base::compose(data);
-
-    // use explicit type if provided, otherwise use input type
-    const auto &eventType = _type.valueType == SHType::Type ? *_type.payload.typeValue : data.inputType;
-    auto currentDispatcherType = (*_dispatcher).get().getType();
-    if (currentDispatcherType.basicType == SHType::None) {
-      (*_dispatcher).get().assignType(eventType);
-    } else if (!matchTypes(eventType, currentDispatcherType, false, true, true)) {
-      SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, eventType, currentDispatcherType);
-      throw shards::Error("Event type mismatch");
-    }
-
+    resolveEventType(true, &data.inputType);
     return data.inputType;
   }
 
@@ -105,7 +102,9 @@ struct Send : Base {
 
 struct Emit : Send {
   SHTypeInfo compose(const SHInstanceData &data) {
-    // Emit always sends Bool, validate explicit Type is compatible
+    Base::compose(data);
+
+    // Emit always sends Bool - validate explicit Type is compatible if provided
     if (_type.valueType == SHType::Type) {
       auto explicitType = *_type.payload.typeValue;
       if (!matchTypes(CoreInfo::BoolType, explicitType, false, true, true)) {
@@ -114,9 +113,8 @@ struct Emit : Send {
       }
     }
 
-    auto dataCopy = data;
-    dataCopy.inputType = CoreInfo::BoolType;
-    Send::compose(dataCopy);
+    // Use Bool as the event type (with explicit Type taking precedence if compatible)
+    resolveEventType(true, &CoreInfo::BoolType);
     return data.inputType;
   }
 

--- a/shards/tests/events.shs
+++ b/shards/tests/events.shs
@@ -42,3 +42,63 @@
 @schedule(main signal-process)
 
 @run(main FPS: 20 Iterations: 100) | Assert.Is(true)
+
+; Test explicit Type parameter - receiver can be defined before sender
+@mesh(typed-events)
+
+; Receive with explicit Type - no Send needed first!
+@wire(typed-receive {
+  Events.Receive("TypedChannel" Type: @type(Type::String)) | ExpectSeq | ForEach({ExpectString | Log("TypedRecv")})
+} Looped: true)
+
+; Send with explicit Type
+@wire(typed-send {
+  "Hello typed events!" | Events.Send("TypedChannel" Type: @type(Type::String)) | Log("TypedSend") | Pause(0.1)
+} Looped: true)
+
+@wire(typed-updater {
+  Events.Update("TypedChannel") | Pause(0.1)
+} Looped: true)
+
+; Schedule receive BEFORE send - this now works with explicit Type!
+@schedule(typed-events typed-receive)
+@schedule(typed-events typed-send)
+@schedule(typed-events typed-updater)
+@run(typed-events FPS: 20 Iterations: 50) | Assert.Is(true)
+
+; Test Check with explicit Type
+@mesh(check-typed)
+
+@wire(check-typed-emit {
+  Pause(0.05) | Events.Emit("check-signal" Type: @type(Type::Bool))
+})
+
+@wire(check-typed-process {
+  Events.Update("check-signal") |
+  When({Events.Check("check-signal" Type: @type(Type::Bool))} {Msg("CHECK-TYPED TRIGGERED") | Stop})
+} Looped: true)
+
+@schedule(check-typed check-typed-process)
+@schedule(check-typed check-typed-emit)
+@run(check-typed FPS: 20 Iterations: 50) | Assert.Is(true)
+
+; Test Events.Emit with explicit Type parameter
+@mesh(emit-typed)
+
+@wire(emit-typed-send {
+  Pause(0.05) | Events.Emit("emit-signal" Type: @type(Type::Bool))
+})
+
+@wire(emit-typed-receive {
+  Events.Receive("emit-signal" Type: @type(Type::Bool)) | ExpectSeq | ForEach({ExpectBool | Log("EmitTypedRecv")})
+} Looped: true)
+
+@wire(emit-typed-updater {
+  Events.Update("emit-signal") |
+  When({Events.Check("emit-signal")} {Msg("EMIT-TYPED DONE") | Stop})
+} Looped: true)
+
+@schedule(emit-typed emit-typed-receive)
+@schedule(emit-typed emit-typed-updater)
+@schedule(emit-typed emit-typed-send)
+@run(emit-typed FPS: 20 Iterations: 50) | Assert.Is(true)


### PR DESCRIPTION
- Add optional Type parameter to Events.Send, Receive, Check
- Allows explicit type specification for events
- Enables receiver-first pattern (Receive can be scheduled before Send)
- Maintains backwards compatibility (Type defaults to input/dispatcher type)
- Add tests for new Type parameter functionality


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
