### PR TITLE
Feature/joint wire parameter

### DIFF
--- a/shards/modules/channels/events.cpp
+++ b/shards/modules/channels/events.cpp
@@ -61,8 +61,7 @@ protected:
     if (currentDispatcherType.basicType == SHType::None) {
       (*_dispatcher).get().assignType(targetType);
     } else if (!matchTypes(targetType, currentDispatcherType, false, true, true)) {
-      SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, targetType,
-                  currentDispatcherType);
+      SHLOG_ERROR("Event type mismatch for event: {}, provided: {}, existing: {}", _eventName, targetType, currentDispatcherType);
       throw shards::Error("Event type mismatch");
     }
     return targetType;

--- a/shards/modules/core/wires.cpp
+++ b/shards/modules/core/wires.cpp
@@ -1803,14 +1803,23 @@ struct Spawn : public CapturingSpawners {
                    "every time the shard is called.");
   }
 
-  static inline Parameters _params{{"Wire", SHCCSTR("The Wire to schedule and run asynchronously"), IntoWire::RunnableTypes}};
+  static inline Parameters _params{
+      {"Wire", SHCCSTR("The Wire to schedule and run asynchronously"), IntoWire::RunnableTypes},
+      {"Joint",
+       SHCCSTR("If true, all the spawned wires will be stopped whenever the parent wire is stopped."),
+       {CoreInfo::BoolType}}};
 
   static SHParametersInfo parameters() { return _params; }
+
+  bool _joint{false};
 
   void setParam(int index, const SHVar &value) {
     switch (index) {
     case 0:
       wireref = value;
+      break;
+    case 1:
+      _joint = value.payload.boolValue;
       break;
     default:
       break;
@@ -1821,6 +1830,8 @@ struct Spawn : public CapturingSpawners {
     switch (index) {
     case 0:
       return wireref;
+    case 1:
+      return Var(_joint);
     default:
       return Var::Empty;
     }
@@ -1879,6 +1890,10 @@ struct Spawn : public CapturingSpawners {
   }
 
   void cleanup(SHContext *context) {
+    if (_joint && _pool) {
+      _pool->stopAll();
+    }
+
     for (auto &v : _vars) {
       v.cleanup();
     }
@@ -1946,6 +1961,10 @@ struct WhenDone : Spawn {
   SeqVar _cache;
   bool _scheduled{false};
   bool _activated{false};
+
+  // Need to override Spawn ones, cos we only use Wire
+  static inline Parameters _params{{"Wire", SHCCSTR("The Wire to schedule and run asynchronously"), IntoWire::RunnableTypes}};
+  static SHParametersInfo parameters() { return _params; }
 
   void warmup(SHContext *context) {
     _scheduled = false;

--- a/shards/modules/core/wires.hpp
+++ b/shards/modules/core/wires.hpp
@@ -240,6 +240,7 @@ struct BaseRunner : public WireBase {
   }
 
   bool _restart{false};
+  bool _joint{false};
   void activateDetached(SHContext *context, const SHVar &input) {
     assert(_mesh);
 
@@ -269,7 +270,7 @@ struct BaseRunner : public WireBase {
 
       // also mark this wire as fully detached if needed
       // this means stopping this Shard will not stop the wire
-      if (detached)
+      if (detached && !_joint)
         wire->detached = true;
     } else if (_restart) {
       _mesh->remove(wire);
@@ -373,6 +374,9 @@ template <bool INPUT_PASSTHROUGH, RunWireMode WIRE_MODE> struct RunWire : public
 
   static inline Parameters DetachParamsInfo{
       {"Wire", SHCCSTR("The wire to execute."), {WireTypes}},
+      {"Joint",
+       SHCCSTR("If true, the specified wire will be stopped whenever the parent wire is stopped."),
+       {CoreInfo::BoolType}},
       {"Restart",
        SHCCSTR("If true, the specified wire will restart whenever the shard is called, even if it is already running."),
        {CoreInfo::BoolType}}};
@@ -394,9 +398,14 @@ template <bool INPUT_PASSTHROUGH, RunWireMode WIRE_MODE> struct RunWire : public
       break;
     case 1:
       if constexpr (WIRE_MODE == RunWireMode::Async) {
-        _restart = value.payload.boolValue;
-        break;
+        _joint = value.payload.boolValue;
       }
+      break;
+    case 2:
+      if constexpr (WIRE_MODE == RunWireMode::Async) {
+        _restart = value.payload.boolValue;
+      }
+      break;
     default:
       break;
     }
@@ -406,11 +415,16 @@ template <bool INPUT_PASSTHROUGH, RunWireMode WIRE_MODE> struct RunWire : public
     switch (index) {
     case 0:
       return wireref;
-    case 1: {
+    case 1:
+      if constexpr (WIRE_MODE == RunWireMode::Async) {
+        return Var(_joint);
+      }
+      break;
+    case 2:
       if constexpr (WIRE_MODE == RunWireMode::Async) {
         return Var(_restart);
       }
-    }
+      break;
     default:
       break;
     }

--- a/shards/tests/subwires.shs
+++ b/shards/tests/subwires.shs
@@ -211,3 +211,55 @@
 
 @schedule(root load)
 @run(root) | Assert.Is(true)
+
+// ===== Joint Parameter Tests =====
+
+// Test: Detach with Joint: true - child stops when parent stops
+@wire(joint-looped-child {
+  Msg("joint-looped-child: tick")
+  Pause(0.05)
+} Looped: true)
+
+@wire(joint-detach-parent {
+  Msg("joint-detach-parent: starting")
+  Detach(joint-looped-child Joint: true)
+  Pause(0.1)  // Let child run a bit
+  Msg("joint-detach-parent: completing")
+})
+
+@wire(test-joint-detach {
+  Detach(joint-detach-parent)
+  Wait(joint-detach-parent)
+  Pause(0.05)  // Give cleanup time
+  IsRunning(joint-looped-child) | Assert.Is(false true)
+  Msg("Joint Detach test PASSED")
+})
+
+@schedule(root test-joint-detach)
+@run(root) | Assert.Is(true)
+
+// Test: Spawn with Joint: true - spawned wires stop when parent stops
+@wire(long-running-task {
+  Msg("long-running-task: starting")
+  Pause(0.5)  // Takes a while
+  Msg("long-running-task: completed")
+})
+
+@wire(spawn-joint-parent {
+  Msg("spawn-joint-parent: spawning tasks")
+  [1 2 3] | ForEach({
+    Spawn(long-running-task Joint: true)
+  })
+  Pause(0.05)  // Let them start but not finish
+  Msg("spawn-joint-parent: completing early")
+})
+
+@wire(test-spawn-joint {
+  Detach(spawn-joint-parent)
+  Wait(spawn-joint-parent)
+  Pause(0.1)  // Allow cleanup
+  Msg("Spawn Joint test PASSED - spawned tasks stopped with parent")
+})
+
+@schedule(root test-spawn-joint)
+@run(root) | Assert.Is(true)


### PR DESCRIPTION
Add Joint parameter to Detach and Spawn shards
When Joint: true, child wires are stopped when the parent wire stops:
- Detach: Wire won't be marked as fully detached, so it stops with parent
- Spawn: Calls _pool->stopAll() in cleanup to stop all spawned wires

Added tests in subwires.shs to verify the behavior.

<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
