### PR TITLE
Add BM25 search support to fileops module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +614,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bm25"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c4ae9a02daa8daf248a3e0d0d0fb991da2988edc77cedb4bc17695d8d8726c"
+dependencies = [
+ "cached",
+ "fxhash",
+ "rust-stemmers",
+ "stop-words",
+ "whichlang",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +704,39 @@ checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
 ]
+
+[[package]]
+name = "cached"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d73155ae6b28cf5de4cfc29aeb02b8a1c6dab883cb015d15cd514e42766846"
+dependencies = [
+ "ahash",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown 0.14.5",
+ "once_cell",
+ "thiserror 1.0.69",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.103",
+ "quote 1.0.42",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cairo-sys-rs"
@@ -2299,6 +2351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gdk-pixbuf-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2781,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -5586,6 +5651,16 @@ version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6473,6 +6548,7 @@ dependencies = [
 name = "shards-fileops"
 version = "0.1.0"
 dependencies = [
+ "bm25",
  "compile-time-crc32",
  "dirs 5.0.1",
  "grep-matcher",
@@ -6867,6 +6943,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stop-words"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6a86be9f7fa4559b7339669e72026eb437f5e9c5a85c207fe1033079033a17"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "strict-num"
@@ -8418,6 +8503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8457,6 +8552,12 @@ dependencies = [
  "rustix 1.1.2",
  "winsafe",
 ]
+
+[[package]]
+name = "whichlang"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9aa3ad29c3d08283ac6b769e3ec15ad1ddb88af7d2e9bc402c574973b937e7"
 
 [[package]]
 name = "wide"

--- a/shards/modules/fileops/Cargo.toml
+++ b/shards/modules/fileops/Cargo.toml
@@ -18,4 +18,5 @@ grep-matcher = "0.1"
 grep-regex = "0.1"
 walkdir = "2.4"
 dirs = "5.0"
+bm25 = { version = "0.2", features = ["language_detection"] }
 

--- a/shards/modules/fileops/src/lib.rs
+++ b/shards/modules/fileops/src/lib.rs
@@ -1568,18 +1568,26 @@ impl Shard for BM25IndexShard {
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
     // Extract strings from input sequence, deduplicating
-    let seq = input.as_seq().map_err(|_| "Input must be a sequence of strings")?;
+    let seq = input.as_seq().map_err(|e| {
+      shlog_error!("Input must be a sequence of strings: {:?}", e);
+      "Input must be a sequence of strings"
+    })?;
 
     let mut seen = std::collections::HashSet::new();
     let mut documents: Vec<String> = Vec::with_capacity(seq.len());
     for item in seq.iter() {
-      let s: &str = item.as_ref().try_into().map_err(|_| "All items must be strings")?;
-      if seen.insert(s.to_string()) {
-        documents.push(s.to_string());
+      let s: &str = item.as_ref().try_into().map_err(|e| {
+        shlog_error!("All items must be strings: {:?}", e);
+        "All items must be strings"
+      })?;
+      let doc = s.to_string();
+      if seen.insert(doc.clone()) {
+        documents.push(doc);
       }
     }
 
     if documents.is_empty() {
+      shlog_error!("Cannot create index from empty corpus");
       return Err("Cannot create index from empty corpus");
     }
 
@@ -1588,7 +1596,10 @@ impl Shard for BM25IndexShard {
       LanguageMode::Detect
     } else {
       let lang_str: &str = self.language.0.as_ref().try_into()
-        .map_err(|_| "Language must be a string")?;
+        .map_err(|e| {
+          shlog_error!("Language must be a string: {:?}", e);
+          "Language must be a string"
+        })?;
       let language = match lang_str.to_lowercase().as_str() {
         "arabic" => Language::Arabic,
         "danish" => Language::Danish,
@@ -1607,12 +1618,17 @@ impl Shard for BM25IndexShard {
         "swedish" => Language::Swedish,
         "tamil" => Language::Tamil,
         "turkish" => Language::Turkish,
-        _ => return Err("Unsupported language. Supported: arabic, danish, dutch, english, french, german, greek, hungarian, italian, norwegian, portuguese, romanian, russian, spanish, swedish, tamil, turkish"),
+        _ => {
+          shlog_error!("Unsupported language: {}", lang_str);
+          return Err("Unsupported language. Supported: arabic, danish, dutch, english, french, german, greek, hungarian, italian, norwegian, portuguese, romanian, russian, spanish, swedish, tamil, turkish");
+        }
       };
       LanguageMode::Fixed(language)
     };
 
     // Build search engine with corpus
+    // Note: clone is necessary because bm25 stores its own copy internally via with_corpus,
+    // but we also need the documents vec for retrieving content by ID in BM25.Query
     let engine = SearchEngineBuilder::<u32>::with_corpus(language_mode, documents.clone())
       .build();
 
@@ -1676,27 +1692,33 @@ impl Shard for BM25QueryShard {
 
   fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
     self.compose_helper(data)?;
-
-    if self.index.is_none() {
-      return Err("Index parameter is required");
-    }
-
     Ok(self.output_types()[0])
   }
 
   fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-    let query: &str = input.try_into()?;
+    let query: &str = input.try_into().map_err(|e| {
+      shlog_error!("Query must be a string: {:?}", e);
+      "Query must be a string"
+    })?;
 
     let top_k: i64 = self.top_k.0.as_ref().try_into()
-      .map_err(|_| "TopK must be an integer")?;
+      .map_err(|e| {
+        shlog_error!("TopK must be an integer: {:?}", e);
+        "TopK must be an integer"
+      })?;
 
     if top_k <= 0 {
+      shlog_error!("TopK must be positive, got: {}", top_k);
       return Err("TopK must be positive");
     }
 
     // Get the index from parameter
     let index = unsafe {
-      &*Var::from_ref_counted_object::<BM25Index>(&self.index.get(), &*BM25_INDEX_TYPE)?
+      &*Var::from_ref_counted_object::<BM25Index>(&self.index.get(), &*BM25_INDEX_TYPE)
+        .map_err(|e| {
+          shlog_error!("Failed to get BM25 index: {}", e);
+          e
+        })?
     };
 
     // Perform search
@@ -1706,14 +1728,16 @@ impl Shard for BM25QueryShard {
     self.output.0.clear();
 
     // Build result sequence with content and score
+    // Document IDs from bm25 correspond to the order documents were indexed
     for result in results {
       let mut result_table = AutoTableVar::new();
 
-      // Get the document content using the document ID
       let doc_id = result.document.id as usize;
       if let Some(content) = index.documents.get(doc_id) {
         result_table.0.insert_fast_static("content", &Var::ephemeral_string(content));
       } else {
+        // This shouldn't happen if bm25 is working correctly, but handle defensively
+        shlog_error!("Document ID {} out of bounds (corpus size: {})", doc_id, index.documents.len());
         result_table.0.insert_fast_static("content", &Var::ephemeral_string(""));
       }
 

--- a/shards/modules/fileops/src/lib.rs
+++ b/shards/modules/fileops/src/lib.rs
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2025 Fragcolor Pte. Ltd. */
 
+#[macro_use]
+extern crate shards;
+
+#[macro_use]
+extern crate lazy_static;
+
 use std::path::{Path, PathBuf};
 use std::env;
 use std::fs;
@@ -10,12 +16,32 @@ use std::io::Read;
 
 use shards::core::register_shard;
 use shards::shard::Shard;
-use shards::shlog_error;
 use shards::types::{
   common_type, AutoSeqVar, AutoTableVar, ClonedVar, ParamVar,
-  STRING_TYPES, SEQ_OF_ANY_TABLE_TYPES,
+  STRING_TYPES, SEQ_OF_ANY_TABLE_TYPES, STRINGS_TYPES, FRAG_CC,
 };
 use shards::types::{Context, ExposedTypes, InstanceData, Type, Types, Var};
+use shards::fourCharacterCode;
+
+use bm25::{Language, LanguageMode, SearchEngine, SearchEngineBuilder};
+
+// ============================================================================
+// BM25 Index Object Type
+// ============================================================================
+
+/// BM25 search index wrapping a search engine and the original documents
+pub struct BM25Index {
+  engine: SearchEngine<u32>,
+  documents: Vec<String>,
+}
+
+ref_counted_object_type_impl!(BM25Index);
+
+lazy_static! {
+  pub static ref BM25_INDEX_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"bm25"));
+  pub static ref BM25_INDEX_TYPE_VEC: Vec<Type> = vec![*BM25_INDEX_TYPE];
+  pub static ref BM25_INDEX_VAR_TYPE: Type = Type::context_variable(&BM25_INDEX_TYPE_VEC);
+}
 
 use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{SearcherBuilder, Searcher, Sink, SinkMatch, SinkContext};
@@ -1489,6 +1515,218 @@ impl Shard for InsertAtLineShard {
 }
 
 // ============================================================================
+// BM25.Index Shard
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info("BM25.Index", "Creates a BM25 search index from a sequence of strings")]
+struct BM25IndexShard {
+  #[shard_required]
+  required: ExposedTypes,
+
+  #[shard_param("Language", "Language for tokenization (e.g. \"english\", \"german\"). If none, auto-detects per document.", [common_type::none, common_type::string])]
+  language: ClonedVar,
+
+  output: ClonedVar,
+}
+
+impl Default for BM25IndexShard {
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      language: ClonedVar::default(),
+      output: ClonedVar::default(),
+    }
+  }
+}
+
+#[shards::shard_impl]
+impl Shard for BM25IndexShard {
+  fn input_types(&mut self) -> &Types {
+    &STRINGS_TYPES
+  }
+
+  fn output_types(&mut self) -> &Types {
+    &BM25_INDEX_TYPE_VEC
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    // Extract strings from input sequence, deduplicating
+    let seq = input.as_seq().map_err(|_| "Input must be a sequence of strings")?;
+
+    let mut seen = std::collections::HashSet::new();
+    let mut documents: Vec<String> = Vec::with_capacity(seq.len());
+    for item in seq.iter() {
+      let s: &str = item.as_ref().try_into().map_err(|_| "All items must be strings")?;
+      if seen.insert(s.to_string()) {
+        documents.push(s.to_string());
+      }
+    }
+
+    if documents.is_empty() {
+      return Err("Cannot create index from empty corpus");
+    }
+
+    // Determine language mode
+    let language_mode = if self.language.0.is_none() {
+      LanguageMode::Detect
+    } else {
+      let lang_str: &str = self.language.0.as_ref().try_into()
+        .map_err(|_| "Language must be a string")?;
+      let language = match lang_str.to_lowercase().as_str() {
+        "arabic" => Language::Arabic,
+        "danish" => Language::Danish,
+        "dutch" => Language::Dutch,
+        "english" => Language::English,
+        "french" => Language::French,
+        "german" => Language::German,
+        "greek" => Language::Greek,
+        "hungarian" => Language::Hungarian,
+        "italian" => Language::Italian,
+        "norwegian" => Language::Norwegian,
+        "portuguese" => Language::Portuguese,
+        "romanian" => Language::Romanian,
+        "russian" => Language::Russian,
+        "spanish" => Language::Spanish,
+        "swedish" => Language::Swedish,
+        "tamil" => Language::Tamil,
+        "turkish" => Language::Turkish,
+        _ => return Err("Unsupported language. Supported: arabic, danish, dutch, english, french, german, greek, hungarian, italian, norwegian, portuguese, romanian, russian, spanish, swedish, tamil, turkish"),
+      };
+      LanguageMode::Fixed(language)
+    };
+
+    // Build search engine with corpus
+    let engine = SearchEngineBuilder::<u32>::with_corpus(language_mode, documents.clone())
+      .build();
+
+    let index = BM25Index { engine, documents };
+
+    self.output = Var::new_ref_counted(index, &*BM25_INDEX_TYPE).into();
+    Ok(Some(self.output.0))
+  }
+}
+
+// ============================================================================
+// BM25.Query Shard
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info("BM25.Query", "Queries a BM25 index and returns top matching documents with scores")]
+struct BM25QueryShard {
+  #[shard_required]
+  required: ExposedTypes,
+
+  #[shard_param("Index", "The BM25 index to query", [*BM25_INDEX_VAR_TYPE])]
+  index: ParamVar,
+
+  #[shard_param("TopK", "Maximum number of results to return", [common_type::int])]
+  top_k: ClonedVar,
+
+  output: AutoSeqVar,
+}
+
+impl Default for BM25QueryShard {
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      index: ParamVar::default(),
+      top_k: 10i64.into(),
+      output: AutoSeqVar::new(),
+    }
+  }
+}
+
+#[shards::shard_impl]
+impl Shard for BM25QueryShard {
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
+
+  fn output_types(&mut self) -> &Types {
+    &SEQ_OF_ANY_TABLE_TYPES
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output.0.clear();
+    Ok(())
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+
+    if self.index.is_none() {
+      return Err("Index parameter is required");
+    }
+
+    Ok(self.output_types()[0])
+  }
+
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let query: &str = input.try_into()?;
+
+    let top_k: i64 = self.top_k.0.as_ref().try_into()
+      .map_err(|_| "TopK must be an integer")?;
+
+    if top_k <= 0 {
+      return Err("TopK must be positive");
+    }
+
+    // Get the index from parameter
+    let index = unsafe {
+      &*Var::from_ref_counted_object::<BM25Index>(&self.index.get(), &*BM25_INDEX_TYPE)?
+    };
+
+    // Perform search
+    let results = index.engine.search(query, top_k as usize);
+
+    // Clear previous results
+    self.output.0.clear();
+
+    // Build result sequence with content and score
+    for result in results {
+      let mut result_table = AutoTableVar::new();
+
+      // Get the document content using the document ID
+      let doc_id = result.document.id as usize;
+      if let Some(content) = index.documents.get(doc_id) {
+        result_table.0.insert_fast_static("content", &Var::ephemeral_string(content));
+      } else {
+        result_table.0.insert_fast_static("content", &Var::ephemeral_string(""));
+      }
+
+      result_table.0.insert_fast_static("score", &(result.score as f64).into());
+
+      self.output.0.push(&result_table.0.0);
+    }
+
+    Ok(Some(self.output.0.0))
+  }
+}
+
+// ============================================================================
 // Module Registration
 // ============================================================================
 
@@ -1505,4 +1743,6 @@ pub extern "C" fn shardsRegister_fileops_rust(core: *mut shards::shardsc::SHCore
   register_shard::<ReplaceStringFirstShard>();
   register_shard::<ReplaceStringAllShard>();
   register_shard::<InsertAtLineShard>();
+  register_shard::<BM25IndexShard>();
+  register_shard::<BM25QueryShard>();
 }

--- a/shards/tests/CLAUDE.md
+++ b/shards/tests/CLAUDE.md
@@ -19,7 +19,17 @@ Shards is a **dataflow programming language**. Data flows through channels like 
 
 // No semicolons, no braces for code blocks (except wire/template definitions)
 // Whitespace flexible
-// Data flows through | (pipe operator)
+
+// Data flows left-to-right, top-to-bottom
+// Newlines are IMPLICIT pipes - flow continues across lines
+// These are equivalent:
+"Hello" | Log
+
+"Hello"
+Log
+
+// This is NOT like imperative languages where newlines end statements
+// In Shards, data keeps flowing until explicitly stopped
 
 // Identifiers
 my-variable       // Variables: lowercase, kebab-case

--- a/shards/tests/fileops.shs
+++ b/shards/tests/fileops.shs
@@ -406,6 +406,57 @@ single-line-matches | Log("Grep String: single line search")
 single-line-matches | Count | Assert.Is(1 true)
 
 // ============================================================================
+// Test 26: BM25.Index and BM25.Query - Basic search
+// ============================================================================
+["The rabbit munched the orange carrot"
+ "The snake hugged the green lizard"
+ "The hedgehog impaled the orange orange"
+ "The squirrel buried the brown nut"] | BM25.Index = bm25-index
+
+"orange" | BM25.Query(bm25-index TopK: 2) = bm25-results
+bm25-results | Log("BM25: search for 'orange'")
+
+; Should find 2 matches (hedgehog has 'orange' twice, rabbit has it once)
+bm25-results | Count | Assert.Is(2 true)
+
+; First result should be hedgehog (has 'orange' twice so higher score)
+bm25-results | Take(0) | Take("content") | Log("BM25: top result")
+
+; Verify score field exists and is a float
+bm25-results | Take(0) | Take("score") | IsFloat | Assert.Is(true true)
+
+// ============================================================================
+// Test 27: BM25.Query - Query with no matches
+// ============================================================================
+"elephant" | BM25.Query(bm25-index TopK: 5) = no-match-results
+no-match-results | Log("BM25: search for 'elephant'")
+
+; Should return empty sequence
+no-match-results | Count | Assert.Is(0 true)
+
+// ============================================================================
+// Test 28: BM25.Query - TopK limiting
+// ============================================================================
+; Note: "the" is a stopword filtered out by English tokenizer, use different words
+"brown green" | BM25.Query(bm25-index TopK: 2) = limited-results
+limited-results | Log("BM25: TopK limiting")
+
+; Should find matches for "brown" (rabbit) and "green" (snake), limited to 2
+limited-results | Count | Assert.Is(2 true)
+
+// ============================================================================
+// Test 29: BM25.Index with explicit Language parameter
+// ============================================================================
+["Das Kaninchen fraß die orange Karotte"
+ "Die Schlange umarmte die grüne Eidechse"] | BM25.Index(Language: "german") = german-index
+
+"Karotte" | BM25.Query(german-index TopK: 2) = german-results
+german-results | Log("BM25: German language search")
+
+; Should find 1 match (the rabbit/carrot sentence)
+german-results | Count | Assert.Is(1 true)
+
+// ============================================================================
 // Cleanup
 // ============================================================================
 "test-fileops" | FS.RemoveAll


### PR DESCRIPTION
- Add BM25.Index shard: creates search index from sequence of strings
  - Optional Language parameter for fixed language tokenization
  - Auto-detects language per document when Language not specified
  - Supports 17 languages: arabic, danish, dutch, english, french, german, greek, hungarian, italian, norwegian, portuguese, romanian, russian, spanish, swedish, tamil, turkish

- Add BM25.Query shard: queries index and returns top matches
  - Returns tables with content and score fields
  - TopK parameter to limit results (default: 10)

- Add bm25 crate dependency with language_detection feature
- Add test cases for BM25 functionality


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
