### PR TITLE
Fix variablesMetadata pointer instability after map rehash

### DIFF
--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1303,10 +1303,10 @@ SHComposeResult internalComposeWire(const std::vector<ShardPtr> &wire, SHInstanc
         if (mesh) {
           for (auto &v : mesh->getVariables()) {
             // only add variables with metadata basically
-            auto metadata = mesh->getMetadata(&v.second);
+            shassert(v.first.payload.stringValue && "Key must be a valid string");
+            std::string_view sName(v.first.payload.stringValue, v.first.payload.stringLen);
+            auto metadata = mesh->getMetadata(sName);
             if (metadata) {
-              shassert(v.first.payload.stringValue && "Key must be a valid string");
-              std::string_view sName(v.first.payload.stringValue, v.first.payload.stringLen);
               ctx.sharedContext->inherited.insert(sName, *metadata);
             }
           }
@@ -2864,8 +2864,9 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
 
   result->setMeshVariableType = [](SHMeshRef mesh, SHStringWithLen name, const SHExposedTypeInfo *type) noexcept {
     auto smesh = reinterpret_cast<std::shared_ptr<SHMesh> *>(mesh);
-    auto vName = shards::OwnedVar::Foreign(name);
-    (*smesh)->setMetadata(&(*smesh)->getVariables()[vName], *type);
+    shassert(type->name && "type->name must be set");
+    shassert(std::string_view(name.string, name.len) == std::string_view(type->name) && "name parameter must match type->name");
+    (*smesh)->setMetadata(*type);
   };
 
   result->suspend = [](SHContext *context, double seconds) noexcept {

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -732,13 +732,9 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
     _pendingUnschedule.clear();
 
     // find dangling variables and notice
-    for (auto var : variables) {
+    for (auto &var : variables) {
       if (var.second.refcount > 0) {
         SHLOG_ERROR("Found a dangling global variable: {}", var.first);
-      }
-      auto it = variablesMetadata.find(&var.second);
-      if (it != variablesMetadata.end()) {
-        it->second = shards::ExposedTypeInfo();
       }
     }
     variables.clear();
@@ -804,7 +800,8 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
     //  the variable was left over from before, but has no references
     auto &vPtr = variables[key];
     if (vPtr.refcount == 0) {
-      auto it = variablesMetadata.find(&vPtr);
+      std::string_view nameView(name.string, name.len);
+      auto it = variablesMetadata.find(nameView);
       if (it != variablesMetadata.end()) {
         variablesMetadata.erase(it);
       }
@@ -814,8 +811,9 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
 
   constexpr auto &getVariables() { return variables; }
 
-  void setMetadata(SHVar *var, SHExposedTypeInfo info, bool force = false) {
-    auto it = variablesMetadata.find(var);
+  void setMetadata(SHExposedTypeInfo info, bool force = false) {
+    std::string_view name(info.name);
+    auto it = variablesMetadata.find(name);
     if (!force) {
       if (it != variablesMetadata.end()) {
         if (!shards::matchTypes(info.exposedType, it->second._innerInfo.exposedType, false, true, true)) {
@@ -824,17 +822,14 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
           return;
         }
       }
-      variablesMetadata.emplace(var, info);
+      variablesMetadata.emplace(std::string(name), info);
     } else {
-      if (it != variablesMetadata.end()) {
-        variablesMetadata.erase(it);
-      }
-      variablesMetadata.emplace(var, info);
+      variablesMetadata.insert_or_assign(std::string(name), shards::ExposedTypeInfo(info));
     }
   }
 
-  std::optional<SHExposedTypeInfo> getMetadata(SHVar *var) {
-    auto it = variablesMetadata.find(var);
+  std::optional<SHExposedTypeInfo> getMetadata(std::string_view name) {
+    auto it = variablesMetadata.find(name);
     if (it != variablesMetadata.end()) {
       return *it->second;
     } else {
@@ -943,7 +938,17 @@ private:
       variables;
 
   // this is used for the above global variables, not refs
-  std::unordered_map<SHVar *, shards::ExposedTypeInfo> variablesMetadata;
+  // Uses transparent hash/equal to allow lookups with string_view without allocating
+  struct StringHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
+    size_t operator()(const std::string &s) const { return std::hash<std::string_view>{}(s); }
+  };
+  struct StringEqual {
+    using is_transparent = void;
+    bool operator()(std::string_view a, std::string_view b) const { return a == b; }
+  };
+  std::unordered_map<std::string, shards::ExposedTypeInfo, StringHash, StringEqual> variablesMetadata;
 
   // variables with lifetime managed externally
   std::unordered_map<shards::OwnedVar, SHVar *, std::hash<shards::OwnedVar>, std::equal_to<shards::OwnedVar>,

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -1427,10 +1427,10 @@ struct Set : public SetUpdateBase {
       } else {
         if (_isTable) {
           // Table types can change, so we need to force the metadata update
-          mesh->setMetadata(_target, SHExposedTypeInfo(_exposedInfo._innerInfo.elements[0]), true);
+          mesh->setMetadata(SHExposedTypeInfo(_exposedInfo._innerInfo.elements[0]), true);
         } else {
           // Regular types can't change, so we can just set the metadata and fail if it already exists
-          mesh->setMetadata(_target, SHExposedTypeInfo(_exposedInfo._innerInfo.elements[0]));
+          mesh->setMetadata(SHExposedTypeInfo(_exposedInfo._innerInfo.elements[0]));
         }
       }
     }


### PR DESCRIPTION
Changed variablesMetadata key from SHVar* to std::string (variable name).

The previous implementation used raw pointers into the variables unordered_map as keys in variablesMetadata. When variables map rehashed (due to insertions), these pointers became invalid. Memory reuse could then cause address collisions, leading to metadata corruption and double-free crashes on erase.

Using the variable name as key is stable across rehashes.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
