### PR TITLE
Add Audio buffer manipulation support (AppendTo, PrependTo, Slice, Pa…

### DIFF
--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -558,31 +558,11 @@ struct XPendBase {
     const uint8_t channels = colAudio.channels;
     const uint16_t sampleRate = colAudio.sampleRate; // Save before potential destroy
     const size_t newTotal = size_t(newNsamples) * channels;
-    const size_t currentCapacity = SHVAR_AUDIO_GET_CAPACITY(collection);
 
-    if (currentCapacity >= newTotal && colAudio.samples != nullptr) {
-      // In-place expansion - we have enough capacity
-      if (prepend) {
-        // Shift existing data right, then copy new data at the start (per channel)
-        for (int ch = channels - 1; ch >= 0; ch--) {
-          float *chBase = colAudio.samples + ch * newNsamples;
-          // Move existing samples to their new position
-          memmove(chBase + inAudio.nsamples, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
-          // Copy new samples at the beginning
-          memcpy(chBase, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
-        }
-      } else {
-        // Append: shift existing data to new positions, then copy new data at the end (per channel)
-        for (int ch = channels - 1; ch >= 0; ch--) {
-          float *chBase = colAudio.samples + ch * newNsamples;
-          // Move existing samples to their new position
-          memmove(chBase, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
-          // Copy new samples at the end
-          memcpy(chBase + colAudio.nsamples, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
-        }
-      }
-      colAudio.nsamples = newNsamples;
-    } else {
+    // Note: In-place expansion is complex for multi-channel planar audio because
+    // channel strides change (old: nsamples, new: newNsamples). The channels would
+    // overlap during reorganization. We always use scratch buffer for correctness.
+    {
       // Need to allocate new buffer
       _scratchStr.resize(newTotal * sizeof(float));
       float *scratch = reinterpret_cast<float *>(_scratchStr.data());

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -3393,6 +3393,12 @@ struct Pad {
       throw ActivationError("Pad: Before and After must be non-negative.");
     }
 
+    // Overflow check
+    const uint64_t totalPadding = uint64_t(before) + uint64_t(after);
+    if (totalPadding > UINT32_MAX - inSeq.len) {
+      throw ActivationError("Pad: padded sequence would exceed maximum size.");
+    }
+
     const uint32_t newLen = inSeq.len + uint32_t(before) + uint32_t(after);
 
     // Prepare output - reuse existing seq if possible
@@ -3437,6 +3443,13 @@ struct Pad {
     }
 
     const uint32_t inputLen = SHSTRLEN(input);
+
+    // Overflow check
+    const uint64_t totalPadding = uint64_t(before) + uint64_t(after);
+    if (totalPadding > UINT32_MAX - inputLen) {
+      throw ActivationError("Pad: padded string would exceed maximum size.");
+    }
+
     const uint32_t newLen = inputLen + uint32_t(before) + uint32_t(after);
 
     _buffer.resize(newLen + 1);
@@ -3465,6 +3478,13 @@ struct Pad {
     }
 
     const uint32_t inputLen = input.payload.bytesSize;
+
+    // Overflow check
+    const uint64_t totalPadding = uint64_t(before) + uint64_t(after);
+    if (totalPadding > UINT32_MAX - inputLen) {
+      throw ActivationError("Pad: padded bytes would exceed maximum size.");
+    }
+
     const uint32_t newLen = inputLen + uint32_t(before) + uint32_t(after);
 
     _buffer.resize(newLen);
@@ -3533,8 +3553,9 @@ struct Trim {
       throw ActivationError("Trim: Before and After must be non-negative.");
     }
 
-    const int64_t totalTrim = before + after;
-    if (totalTrim > int64_t(inAudio.nsamples)) {
+    // Use uint64_t to avoid int64_t overflow when adding two large positive values
+    const uint64_t totalTrim = uint64_t(before) + uint64_t(after);
+    if (totalTrim > inAudio.nsamples) {
       throw ActivationError(
           fmt::format("Trim: Cannot trim {} samples from audio with {} samples.", totalTrim, inAudio.nsamples));
     }
@@ -3563,8 +3584,9 @@ struct Trim {
       throw ActivationError("Trim: Before and After must be non-negative.");
     }
 
-    const int64_t totalTrim = before + after;
-    if (totalTrim > int64_t(inSeq.len)) {
+    // Use uint64_t to avoid int64_t overflow when adding two large positive values
+    const uint64_t totalTrim = uint64_t(before) + uint64_t(after);
+    if (totalTrim > inSeq.len) {
       throw ActivationError(fmt::format("Trim: Cannot trim {} elements from sequence with {} elements.", totalTrim, inSeq.len));
     }
 
@@ -3592,8 +3614,9 @@ struct Trim {
     }
 
     const uint32_t inputLen = SHSTRLEN(input);
-    const int64_t totalTrim = before + after;
-    if (totalTrim > int64_t(inputLen)) {
+    // Use uint64_t to avoid int64_t overflow when adding two large positive values
+    const uint64_t totalTrim = uint64_t(before) + uint64_t(after);
+    if (totalTrim > inputLen) {
       throw ActivationError(fmt::format("Trim: Cannot trim {} characters from string with {} characters.", totalTrim, inputLen));
     }
 
@@ -3615,8 +3638,9 @@ struct Trim {
     }
 
     const uint32_t inputLen = input.payload.bytesSize;
-    const int64_t totalTrim = before + after;
-    if (totalTrim > int64_t(inputLen)) {
+    // Use uint64_t to avoid int64_t overflow when adding two large positive values
+    const uint64_t totalTrim = uint64_t(before) + uint64_t(after);
+    if (totalTrim > inputLen) {
       throw ActivationError(fmt::format("Trim: Cannot trim {} bytes from input with {} bytes.", totalTrim, inputLen));
     }
 

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -3358,21 +3358,10 @@ struct Pad {
       float *outCh = samples + ch * newNsamples;
       const float *inCh = inAudio.samples + ch * inAudio.nsamples;
 
-      // Zero padding using SIMD where available
-#ifdef SHARDS_HAS_ACCELERATE
-      if (before > 0) {
-        vDSP_vclr(outCh, 1, before);
-      }
-      memcpy(outCh + before, inCh, inAudio.nsamples * sizeof(float));
-      if (after > 0) {
-        vDSP_vclr(outCh + before + inAudio.nsamples, 1, after);
-      }
-#else
-      // Use SIMD zeroing for non-Apple platforms
+      // Zero padding using SIMD (applyAudioClear handles platform dispatch)
       Math::applyAudioClear(outCh, before);
       memcpy(outCh + before, inCh, inAudio.nsamples * sizeof(float));
       Math::applyAudioClear(outCh + before + inAudio.nsamples, after);
-#endif
     }
 
     return Var(SHAudio{samples, newNsamples, inAudio.sampleRate, channels, inAudio.reserved});

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -532,6 +532,88 @@ struct XPendBase {
 
   entt::dispatcher *_dispatcherPtr{nullptr};
 
+  // Helper for audio concatenation with overflow check and in-place optimization
+  // prepend=false: colAudio followed by inAudio (append)
+  // prepend=true: inAudio followed by colAudio (prepend)
+  void concatAudio(SHVar &collection, const SHAudio &inAudio, bool prepend, const char *shardName) {
+    auto &colAudio = collection.payload.audioValue;
+
+    // Validate channels and sample rate match
+    if (colAudio.channels != inAudio.channels) {
+      throw ActivationError(fmt::format("{}: channel mismatch (collection has {} channels, input has {})", shardName,
+                                        colAudio.channels, inAudio.channels));
+    }
+    if (colAudio.sampleRate != inAudio.sampleRate) {
+      // Sample rate is stored internally as Hz/25 to fit in uint16_t, multiply to show actual Hz
+      throw ActivationError(fmt::format("{}: sample rate mismatch (collection: {} Hz, input: {} Hz)", shardName,
+                                        colAudio.sampleRate * 25, inAudio.sampleRate * 25));
+    }
+
+    // Overflow check
+    if (colAudio.nsamples > UINT32_MAX - inAudio.nsamples) {
+      throw ActivationError(fmt::format("{}: combined audio would exceed maximum size", shardName));
+    }
+
+    const uint32_t newNsamples = colAudio.nsamples + inAudio.nsamples;
+    const uint8_t channels = colAudio.channels;
+    const uint16_t sampleRate = colAudio.sampleRate; // Save before potential destroy
+    const size_t newTotal = size_t(newNsamples) * channels;
+    const size_t currentCapacity = SHVAR_AUDIO_GET_CAPACITY(collection);
+
+    if (currentCapacity >= newTotal && colAudio.samples != nullptr) {
+      // In-place expansion - we have enough capacity
+      if (prepend) {
+        // Shift existing data right, then copy new data at the start (per channel)
+        for (int ch = channels - 1; ch >= 0; ch--) {
+          float *chBase = colAudio.samples + ch * newNsamples;
+          // Move existing samples to their new position
+          memmove(chBase + inAudio.nsamples, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
+          // Copy new samples at the beginning
+          memcpy(chBase, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
+        }
+      } else {
+        // Append: shift existing data to new positions, then copy new data at the end (per channel)
+        for (int ch = channels - 1; ch >= 0; ch--) {
+          float *chBase = colAudio.samples + ch * newNsamples;
+          // Move existing samples to their new position
+          memmove(chBase, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
+          // Copy new samples at the end
+          memcpy(chBase + colAudio.nsamples, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
+        }
+      }
+      colAudio.nsamples = newNsamples;
+    } else {
+      // Need to allocate new buffer
+      _scratchStr.resize(newTotal * sizeof(float));
+      float *scratch = reinterpret_cast<float *>(_scratchStr.data());
+
+      if (prepend) {
+        for (uint8_t ch = 0; ch < channels; ch++) {
+          memcpy(scratch + ch * newNsamples, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
+          memcpy(scratch + ch * newNsamples + inAudio.nsamples, colAudio.samples + ch * colAudio.nsamples,
+                 colAudio.nsamples * sizeof(float));
+        }
+      } else {
+        for (uint8_t ch = 0; ch < channels; ch++) {
+          memcpy(scratch + ch * newNsamples, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
+          memcpy(scratch + ch * newNsamples + colAudio.nsamples, inAudio.samples + ch * inAudio.nsamples,
+                 inAudio.nsamples * sizeof(float));
+        }
+      }
+
+      // Reallocate the collection's audio buffer
+      destroyVar(collection);
+      collection.valueType = SHType::Audio;
+      collection.payload.audioValue.samples = new float[newTotal];
+      collection.payload.audioValue.nsamples = newNsamples;
+      collection.payload.audioValue.sampleRate = sampleRate; // Use saved value (colAudio is invalid after destroyVar)
+      collection.payload.audioValue.channels = channels;
+      collection.payload.audioValue.reserved = 0;
+      SHVAR_AUDIO_SET_CAPACITY(collection, newTotal);
+      memcpy(collection.payload.audioValue.samples, scratch, newTotal * sizeof(float));
+    }
+  }
+
   void maybeSendEvents(SHContext *context, SHVar &var) {
     if (var.trackingMask != 0) {
       OnTrackedVarSet ev{context->main->id, _collection.variableNameView(), Var::Empty, var, _isGlobal, context->currentWire()};
@@ -580,39 +662,11 @@ struct AppendTo : public XPendBase {
       break;
     }
     case SHType::Audio: {
-      auto &colAudio = collection.payload.audioValue;
-      const auto &inAudio = input.payload.audioValue;
-
-      // Validate channels and sample rate match
-      if (colAudio.channels != inAudio.channels) {
-        throw ActivationError(
-            fmt::format("AppendTo: Audio channel mismatch (collection: {}, input: {})", colAudio.channels, inAudio.channels));
-      }
-      if (colAudio.sampleRate != inAudio.sampleRate) {
-        throw ActivationError(fmt::format("AppendTo: Audio sample rate mismatch (collection: {}, input: {})",
-                                          colAudio.sampleRate * 25, inAudio.sampleRate * 25));
-      }
-
-      const uint32_t newNsamples = colAudio.nsamples + inAudio.nsamples;
-      const uint8_t channels = colAudio.channels;
-
-      // Build combined audio in scratch buffer (resize reuses capacity)
-      _scratchStr.resize(newNsamples * channels * sizeof(float));
-      float *scratch = reinterpret_cast<float *>(_scratchStr.data());
-
-      for (uint8_t ch = 0; ch < channels; ch++) {
-        memcpy(scratch + ch * newNsamples, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
-        memcpy(scratch + ch * newNsamples + colAudio.nsamples, inAudio.samples + ch * inAudio.nsamples,
-               inAudio.nsamples * sizeof(float));
-      }
-
-      // cloneVar handles reallocation efficiently
-      SHAudio tmpAudio{scratch, newNsamples, colAudio.sampleRate, channels, colAudio.reserved};
-      cloneVar(collection, Var(tmpAudio));
+      concatAudio(collection, input.payload.audioValue, false, "AppendTo");
       break;
     }
     default:
-      throw ActivationError(fmt::format("AppendTo, case not implemented for type {}", collection.valueType));
+      throw ActivationError(fmt::format("AppendTo: not implemented for type {}", collection.valueType));
     }
 
     maybeSendEvents(context, collection);
@@ -663,39 +717,11 @@ struct PrependTo : public XPendBase {
       break;
     }
     case SHType::Audio: {
-      auto &colAudio = collection.payload.audioValue;
-      const auto &inAudio = input.payload.audioValue;
-
-      // Validate channels and sample rate match
-      if (colAudio.channels != inAudio.channels) {
-        throw ActivationError(
-            fmt::format("PrependTo: Audio channel mismatch (collection: {}, input: {})", colAudio.channels, inAudio.channels));
-      }
-      if (colAudio.sampleRate != inAudio.sampleRate) {
-        throw ActivationError(fmt::format("PrependTo: Audio sample rate mismatch (collection: {}, input: {})",
-                                          colAudio.sampleRate * 25, inAudio.sampleRate * 25));
-      }
-
-      const uint32_t newNsamples = colAudio.nsamples + inAudio.nsamples;
-      const uint8_t channels = colAudio.channels;
-
-      // Build combined audio in scratch buffer (resize reuses capacity)
-      _scratchStr.resize(newNsamples * channels * sizeof(float));
-      float *scratch = reinterpret_cast<float *>(_scratchStr.data());
-
-      for (uint8_t ch = 0; ch < channels; ch++) {
-        memcpy(scratch + ch * newNsamples, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
-        memcpy(scratch + ch * newNsamples + inAudio.nsamples, colAudio.samples + ch * colAudio.nsamples,
-               colAudio.nsamples * sizeof(float));
-      }
-
-      // cloneVar handles reallocation efficiently
-      SHAudio tmpAudio{scratch, newNsamples, colAudio.sampleRate, channels, colAudio.reserved};
-      cloneVar(collection, Var(tmpAudio));
+      concatAudio(collection, input.payload.audioValue, true, "PrependTo");
       break;
     }
     default:
-      throw ActivationError("PrependTo, case not implemented");
+      throw ActivationError(fmt::format("PrependTo: not implemented for type {}", collection.valueType));
     }
 
     maybeSendEvents(context, collection);
@@ -3339,6 +3365,12 @@ struct Pad {
 
     if (before < 0 || after < 0) {
       throw ActivationError("Pad: Before and After must be non-negative.");
+    }
+
+    // Overflow check
+    const uint64_t totalPadding = uint64_t(before) + uint64_t(after);
+    if (totalPadding > UINT32_MAX - inAudio.nsamples) {
+      throw ActivationError("Pad: padded audio would exceed maximum size.");
     }
 
     const uint32_t newNsamples = inAudio.nsamples + uint32_t(before) + uint32_t(after);

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -556,7 +556,7 @@ struct XPendBase {
 
     const uint32_t newNsamples = colAudio.nsamples + inAudio.nsamples;
     const uint8_t channels = colAudio.channels;
-    const uint16_t sampleRate = colAudio.sampleRate; // Save before potential destroy
+    const uint32_t sampleRateHz = audioGetSampleRate(colAudio); // Save actual Hz before potential destroy
     const size_t newTotal = size_t(newNsamples) * channels;
 
     // Note: In-place expansion is complex for multi-channel planar audio because
@@ -581,16 +581,10 @@ struct XPendBase {
         }
       }
 
-      // Reallocate the collection's audio buffer
-      destroyVar(collection);
-      collection.valueType = SHType::Audio;
-      collection.payload.audioValue.samples = new float[newTotal];
-      collection.payload.audioValue.nsamples = newNsamples;
-      collection.payload.audioValue.sampleRate = sampleRate; // Use saved value (colAudio is invalid after destroyVar)
-      collection.payload.audioValue.channels = channels;
-      collection.payload.audioValue.reserved = 0;
-      SHVAR_AUDIO_SET_CAPACITY(collection, newTotal);
-      memcpy(collection.payload.audioValue.samples, scratch, newTotal * sizeof(float));
+      // Use makeAudio on scratch buffer, cloneVar handles destroy/realloc efficiently
+      // (see cloneVarSlow in runtime.cpp for Audio - it reuses dst buffer when capacity allows)
+      SHVar scratchAudio{.payload = {.audioValue = makeAudio(scratch, newNsamples, sampleRateHz, channels)}, .valueType = SHType::Audio};
+      cloneVar(collection, scratchAudio);
     }
   }
 

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -8,6 +8,7 @@
 #include <shards/utility.hpp>
 #include <shards/inlined.hpp>
 #include <shards/modules/core/core.hpp>
+#include <shards/modules/core/math_base.hpp>
 #include <boost/algorithm/string.hpp>
 #include <chrono>
 #include <shards/core/params.hpp>
@@ -459,7 +460,8 @@ struct XPendBase {
   static SHTypesInfo inputTypes() { return CoreInfo::AnyType; }
   static SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
 
-  static inline Types xpendTypes{{CoreInfo::AnyVarSeqType, CoreInfo::StringVarType, CoreInfo::BytesVarType}};
+  static inline Types xpendTypes{
+      {CoreInfo::AnyVarSeqType, CoreInfo::StringVarType, CoreInfo::BytesVarType, CoreInfo::AudioVarType}};
   static inline ParamsInfo paramsInfo =
       ParamsInfo(ParamsInfo::Param("Collection", SHCCSTR("The collection to add the input to."), xpendTypes));
 
@@ -472,9 +474,8 @@ struct XPendBase {
     for (auto &cons : data.shared) {
       if (strcmp(cons.name, _collection.variableName()) == 0) {
         if (cons.exposedType.basicType != SHType::Seq && cons.exposedType.basicType != SHType::Bytes &&
-            cons.exposedType.basicType != SHType::String) {
-          throw shards::Error("AppendTo/PrependTo expects either a SHType::Seq, SHType::String "
-                              "or SHType::Bytes variable as collection.");
+            cons.exposedType.basicType != SHType::String && cons.exposedType.basicType != SHType::Audio) {
+          throw shards::Error("AppendTo/PrependTo expects either a Seq, String, Bytes, or Audio variable as collection.");
         } else {
           if (cons.exposedType.basicType != SHType::Seq && cons.exposedType != data.inputType) {
             SHLOG_ERROR("AppendTo/PrependTo input is: {} variable is: {}", data.inputType, cons.exposedType);
@@ -578,6 +579,38 @@ struct AppendTo : public XPendBase {
       cloneVar(collection, tmp);
       break;
     }
+    case SHType::Audio: {
+      auto &colAudio = collection.payload.audioValue;
+      const auto &inAudio = input.payload.audioValue;
+
+      // Validate channels and sample rate match
+      if (colAudio.channels != inAudio.channels) {
+        throw ActivationError(
+            fmt::format("AppendTo: Audio channel mismatch (collection: {}, input: {})", colAudio.channels, inAudio.channels));
+      }
+      if (colAudio.sampleRate != inAudio.sampleRate) {
+        throw ActivationError(fmt::format("AppendTo: Audio sample rate mismatch (collection: {}, input: {})",
+                                          colAudio.sampleRate * 25, inAudio.sampleRate * 25));
+      }
+
+      const uint32_t newNsamples = colAudio.nsamples + inAudio.nsamples;
+      const uint8_t channels = colAudio.channels;
+
+      // Build combined audio in scratch buffer (resize reuses capacity)
+      _scratchStr.resize(newNsamples * channels * sizeof(float));
+      float *scratch = reinterpret_cast<float *>(_scratchStr.data());
+
+      for (uint8_t ch = 0; ch < channels; ch++) {
+        memcpy(scratch + ch * newNsamples, colAudio.samples + ch * colAudio.nsamples, colAudio.nsamples * sizeof(float));
+        memcpy(scratch + ch * newNsamples + colAudio.nsamples, inAudio.samples + ch * inAudio.nsamples,
+               inAudio.nsamples * sizeof(float));
+      }
+
+      // cloneVar handles reallocation efficiently
+      SHAudio tmpAudio{scratch, newNsamples, colAudio.sampleRate, channels, colAudio.reserved};
+      cloneVar(collection, Var(tmpAudio));
+      break;
+    }
     default:
       throw ActivationError(fmt::format("AppendTo, case not implemented for type {}", collection.valueType));
     }
@@ -627,6 +660,38 @@ struct PrependTo : public XPendBase {
       _scratchStr.append((char *)collection.payload.bytesValue, collection.payload.bytesSize);
       Var tmp((uint8_t *)_scratchStr.data(), _scratchStr.size());
       cloneVar(collection, tmp);
+      break;
+    }
+    case SHType::Audio: {
+      auto &colAudio = collection.payload.audioValue;
+      const auto &inAudio = input.payload.audioValue;
+
+      // Validate channels and sample rate match
+      if (colAudio.channels != inAudio.channels) {
+        throw ActivationError(
+            fmt::format("PrependTo: Audio channel mismatch (collection: {}, input: {})", colAudio.channels, inAudio.channels));
+      }
+      if (colAudio.sampleRate != inAudio.sampleRate) {
+        throw ActivationError(fmt::format("PrependTo: Audio sample rate mismatch (collection: {}, input: {})",
+                                          colAudio.sampleRate * 25, inAudio.sampleRate * 25));
+      }
+
+      const uint32_t newNsamples = colAudio.nsamples + inAudio.nsamples;
+      const uint8_t channels = colAudio.channels;
+
+      // Build combined audio in scratch buffer (resize reuses capacity)
+      _scratchStr.resize(newNsamples * channels * sizeof(float));
+      float *scratch = reinterpret_cast<float *>(_scratchStr.data());
+
+      for (uint8_t ch = 0; ch < channels; ch++) {
+        memcpy(scratch + ch * newNsamples, inAudio.samples + ch * inAudio.nsamples, inAudio.nsamples * sizeof(float));
+        memcpy(scratch + ch * newNsamples + inAudio.nsamples, colAudio.samples + ch * colAudio.nsamples,
+               colAudio.nsamples * sizeof(float));
+      }
+
+      // cloneVar handles reallocation efficiently
+      SHAudio tmpAudio{scratch, newNsamples, colAudio.sampleRate, channels, colAudio.reserved};
+      cloneVar(collection, Var(tmpAudio));
       break;
     }
     default:
@@ -3215,6 +3280,345 @@ struct WebBrowseShard : public LambdaShard<webBrowseActivation, CoreInfo::String
   static SHOptionalString outputHelp() { return DefaultHelpText::OutputHelpPass; }
 };
 
+struct Pad {
+  static SHOptionalString help() {
+    return SHCCSTR("Adds padding to the beginning and/or end of a collection (Audio, Seq, String, or Bytes).");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The collection to pad."); }
+  static SHOptionalString outputHelp() { return SHCCSTR("The padded collection."); }
+
+  static inline Types PadInputTypes{
+      {CoreInfo::AudioType, CoreInfo::AnySeqType, CoreInfo::StringType, CoreInfo::BytesType}};
+
+  static SHTypesInfo inputTypes() { return PadInputTypes; }
+  static SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
+
+  PARAM_VAR(_before, "Before", "Number of elements to add at the beginning.", {CoreInfo::IntType});
+  PARAM_VAR(_after, "After", "Number of elements to add at the end.", {CoreInfo::IntType});
+  PARAM_PARAMVAR(_value, "Value", "Value to pad with. For Audio, this is ignored (always zero). For Seq, defaults to None.",
+                 {CoreInfo::NoneType, CoreInfo::AnyType, CoreInfo::AnyVarType});
+
+  PARAM_IMPL(PARAM_IMPL_FOR(_before), PARAM_IMPL_FOR(_after), PARAM_IMPL_FOR(_value));
+
+  PARAM_REQUIRED_VARIABLES();
+
+  std::vector<uint8_t> _buffer{};
+  OwnedVar _seqOutput{};
+
+  Pad() {
+    _before = Var(0);
+    _after = Var(0);
+  }
+
+  void warmup(SHContext *context) { PARAM_WARMUP(context); }
+  void cleanup(SHContext *context) {
+    PARAM_CLEANUP(context);
+    _seqOutput = Var::Empty;
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    PARAM_COMPOSE_REQUIRED_VARIABLES(data);
+
+    if (data.inputType.basicType == SHType::Audio) {
+      OVERRIDE_ACTIVATE(data, activateAudio);
+    } else if (data.inputType.basicType == SHType::Seq) {
+      OVERRIDE_ACTIVATE(data, activateSeq);
+    } else if (data.inputType.basicType == SHType::String) {
+      OVERRIDE_ACTIVATE(data, activateString);
+    } else if (data.inputType.basicType == SHType::Bytes) {
+      OVERRIDE_ACTIVATE(data, activateBytes);
+    }
+
+    return data.inputType;
+  }
+
+  SHVar activateAudio(SHContext *context, const SHVar &input) {
+    const auto &inAudio = input.payload.audioValue;
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Pad: Before and After must be non-negative.");
+    }
+
+    const uint32_t newNsamples = inAudio.nsamples + uint32_t(before) + uint32_t(after);
+    const uint8_t channels = inAudio.channels;
+
+    _buffer.resize(newNsamples * channels * sizeof(float));
+    float *samples = reinterpret_cast<float *>(_buffer.data());
+
+    // For each channel in planar layout
+    for (uint8_t ch = 0; ch < channels; ch++) {
+      float *outCh = samples + ch * newNsamples;
+      const float *inCh = inAudio.samples + ch * inAudio.nsamples;
+
+      // Zero padding using SIMD where available
+#ifdef SHARDS_HAS_ACCELERATE
+      if (before > 0) {
+        vDSP_vclr(outCh, 1, before);
+      }
+      memcpy(outCh + before, inCh, inAudio.nsamples * sizeof(float));
+      if (after > 0) {
+        vDSP_vclr(outCh + before + inAudio.nsamples, 1, after);
+      }
+#else
+      // Use SIMD zeroing for non-Apple platforms
+      Math::applyAudioClear(outCh, before);
+      memcpy(outCh + before, inCh, inAudio.nsamples * sizeof(float));
+      Math::applyAudioClear(outCh + before + inAudio.nsamples, after);
+#endif
+    }
+
+    return Var(SHAudio{samples, newNsamples, inAudio.sampleRate, channels, inAudio.reserved});
+  }
+
+  SHVar activateSeq(SHContext *context, const SHVar &input) {
+    const auto &inSeq = input.payload.seqValue;
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Pad: Before and After must be non-negative.");
+    }
+
+    const uint32_t newLen = inSeq.len + uint32_t(before) + uint32_t(after);
+
+    // Prepare output - reuse existing seq if possible
+    if (_seqOutput.valueType != SHType::Seq) {
+      _seqOutput.valueType = SHType::Seq;
+      _seqOutput.payload.seqValue = {};
+    }
+    shards::arrayResize(_seqOutput.payload.seqValue, newLen);
+
+    const auto &padValue = _value.get();
+
+    // Pad at beginning
+    for (uint32_t i = 0; i < uint32_t(before); i++) {
+      cloneVar(_seqOutput.payload.seqValue.elements[i], padValue);
+    }
+
+    // Copy original elements
+    for (uint32_t i = 0; i < inSeq.len; i++) {
+      cloneVar(_seqOutput.payload.seqValue.elements[before + i], inSeq.elements[i]);
+    }
+
+    // Pad at end
+    for (uint32_t i = 0; i < uint32_t(after); i++) {
+      cloneVar(_seqOutput.payload.seqValue.elements[before + inSeq.len + i], padValue);
+    }
+
+    return _seqOutput;
+  }
+
+  SHVar activateString(SHContext *context, const SHVar &input) {
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Pad: Before and After must be non-negative.");
+    }
+
+    const auto &padValue = _value.get();
+    char padChar = ' '; // default is space
+    if (padValue.valueType == SHType::String && SHSTRLEN(padValue) > 0) {
+      padChar = padValue.payload.stringValue[0];
+    }
+
+    const uint32_t inputLen = SHSTRLEN(input);
+    const uint32_t newLen = inputLen + uint32_t(before) + uint32_t(after);
+
+    _buffer.resize(newLen + 1);
+    memset(_buffer.data(), padChar, before);
+    memcpy(_buffer.data() + before, input.payload.stringValue, inputLen);
+    memset(_buffer.data() + before + inputLen, padChar, after);
+    _buffer[newLen] = '\0';
+
+    return Var(reinterpret_cast<const char *>(_buffer.data()), newLen);
+  }
+
+  SHVar activateBytes(SHContext *context, const SHVar &input) {
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Pad: Before and After must be non-negative.");
+    }
+
+    const auto &padValue = _value.get();
+    uint8_t padByte = 0x00; // default is zero
+    if (padValue.valueType == SHType::Bytes && padValue.payload.bytesSize > 0) {
+      padByte = padValue.payload.bytesValue[0];
+    } else if (padValue.valueType == SHType::Int) {
+      padByte = uint8_t(padValue.payload.intValue & 0xFF);
+    }
+
+    const uint32_t inputLen = input.payload.bytesSize;
+    const uint32_t newLen = inputLen + uint32_t(before) + uint32_t(after);
+
+    _buffer.resize(newLen);
+    memset(_buffer.data(), padByte, before);
+    memcpy(_buffer.data() + before, input.payload.bytesValue, inputLen);
+    memset(_buffer.data() + before + inputLen, padByte, after);
+
+    return Var(_buffer.data(), newLen);
+  }
+
+  SHVar activate(SHContext *context, const SHVar &input) { throw ActivationError("Pad: unreachable code path"); }
+};
+
+struct Trim {
+  static SHOptionalString help() {
+    return SHCCSTR("Removes elements from the beginning and/or end of a collection (Audio, Seq, String, or Bytes).");
+  }
+  static SHOptionalString inputHelp() { return SHCCSTR("The collection to trim."); }
+  static SHOptionalString outputHelp() { return SHCCSTR("The trimmed collection."); }
+
+  static inline Types TrimInputTypes{
+      {CoreInfo::AudioType, CoreInfo::AnySeqType, CoreInfo::StringType, CoreInfo::BytesType}};
+
+  static SHTypesInfo inputTypes() { return TrimInputTypes; }
+  static SHTypesInfo outputTypes() { return CoreInfo::AnyType; }
+
+  PARAM_VAR(_before, "Before", "Number of elements to remove from the beginning.", {CoreInfo::IntType});
+  PARAM_VAR(_after, "After", "Number of elements to remove from the end.", {CoreInfo::IntType});
+
+  PARAM_IMPL(PARAM_IMPL_FOR(_before), PARAM_IMPL_FOR(_after));
+
+  std::vector<uint8_t> _buffer{};
+  OwnedVar _seqOutput{};
+
+  Trim() {
+    _before = Var(0);
+    _after = Var(0);
+  }
+
+  void warmup(SHContext *context) { PARAM_WARMUP(context); }
+  void cleanup(SHContext *context) {
+    PARAM_CLEANUP(context);
+    _seqOutput = Var::Empty;
+  }
+
+  SHTypeInfo compose(const SHInstanceData &data) {
+    if (data.inputType.basicType == SHType::Audio) {
+      OVERRIDE_ACTIVATE(data, activateAudio);
+    } else if (data.inputType.basicType == SHType::Seq) {
+      OVERRIDE_ACTIVATE(data, activateSeq);
+    } else if (data.inputType.basicType == SHType::String) {
+      OVERRIDE_ACTIVATE(data, activateString);
+    } else if (data.inputType.basicType == SHType::Bytes) {
+      OVERRIDE_ACTIVATE(data, activateBytes);
+    }
+
+    return data.inputType;
+  }
+
+  SHVar activateAudio(SHContext *context, const SHVar &input) {
+    const auto &inAudio = input.payload.audioValue;
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Trim: Before and After must be non-negative.");
+    }
+
+    const int64_t totalTrim = before + after;
+    if (totalTrim > int64_t(inAudio.nsamples)) {
+      throw ActivationError(
+          fmt::format("Trim: Cannot trim {} samples from audio with {} samples.", totalTrim, inAudio.nsamples));
+    }
+
+    const uint32_t newNsamples = inAudio.nsamples - uint32_t(before) - uint32_t(after);
+    const uint8_t channels = inAudio.channels;
+
+    _buffer.resize(newNsamples * channels * sizeof(float));
+    float *samples = reinterpret_cast<float *>(_buffer.data());
+
+    for (uint8_t ch = 0; ch < channels; ch++) {
+      float *outCh = samples + ch * newNsamples;
+      const float *inCh = inAudio.samples + ch * inAudio.nsamples + before;
+      memcpy(outCh, inCh, newNsamples * sizeof(float));
+    }
+
+    return Var(SHAudio{samples, newNsamples, inAudio.sampleRate, channels, inAudio.reserved});
+  }
+
+  SHVar activateSeq(SHContext *context, const SHVar &input) {
+    const auto &inSeq = input.payload.seqValue;
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Trim: Before and After must be non-negative.");
+    }
+
+    const int64_t totalTrim = before + after;
+    if (totalTrim > int64_t(inSeq.len)) {
+      throw ActivationError(fmt::format("Trim: Cannot trim {} elements from sequence with {} elements.", totalTrim, inSeq.len));
+    }
+
+    const uint32_t newLen = inSeq.len - uint32_t(before) - uint32_t(after);
+
+    if (_seqOutput.valueType != SHType::Seq) {
+      _seqOutput.valueType = SHType::Seq;
+      _seqOutput.payload.seqValue = {};
+    }
+    shards::arrayResize(_seqOutput.payload.seqValue, newLen);
+
+    for (uint32_t i = 0; i < newLen; i++) {
+      cloneVar(_seqOutput.payload.seqValue.elements[i], inSeq.elements[before + i]);
+    }
+
+    return _seqOutput;
+  }
+
+  SHVar activateString(SHContext *context, const SHVar &input) {
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Trim: Before and After must be non-negative.");
+    }
+
+    const uint32_t inputLen = SHSTRLEN(input);
+    const int64_t totalTrim = before + after;
+    if (totalTrim > int64_t(inputLen)) {
+      throw ActivationError(fmt::format("Trim: Cannot trim {} characters from string with {} characters.", totalTrim, inputLen));
+    }
+
+    const uint32_t newLen = inputLen - uint32_t(before) - uint32_t(after);
+
+    _buffer.resize(newLen + 1);
+    memcpy(_buffer.data(), input.payload.stringValue + before, newLen);
+    _buffer[newLen] = '\0';
+
+    return Var(reinterpret_cast<const char *>(_buffer.data()), newLen);
+  }
+
+  SHVar activateBytes(SHContext *context, const SHVar &input) {
+    const int64_t before = _before->payload.intValue;
+    const int64_t after = _after->payload.intValue;
+
+    if (before < 0 || after < 0) {
+      throw ActivationError("Trim: Before and After must be non-negative.");
+    }
+
+    const uint32_t inputLen = input.payload.bytesSize;
+    const int64_t totalTrim = before + after;
+    if (totalTrim > int64_t(inputLen)) {
+      throw ActivationError(fmt::format("Trim: Cannot trim {} bytes from input with {} bytes.", totalTrim, inputLen));
+    }
+
+    const uint32_t newLen = inputLen - uint32_t(before) - uint32_t(after);
+
+    _buffer.resize(newLen);
+    memcpy(_buffer.data(), input.payload.bytesValue + before, newLen);
+
+    return Var(_buffer.data(), newLen);
+  }
+
+  SHVar activate(SHContext *context, const SHVar &input) { throw ActivationError("Trim: unreachable code path"); }
+};
+
 SHARDS_REGISTER_FN(core) {
   REGISTER_ENUM(CoreInfo2::TypeEnumInfo);
 
@@ -3240,6 +3644,8 @@ SHARDS_REGISTER_FN(core) {
   REGISTER_CORE_SHARD(RTake);
   REGISTER_SHARD("Split", Split);
   REGISTER_SHARD("Slice", Slice);
+  REGISTER_SHARD("Pad", Pad);
+  REGISTER_SHARD("Trim", Trim);
   REGISTER_CORE_SHARD(Limit);
   REGISTER_CORE_SHARD(RLimit);
   REGISTER_SHARD("Repeat", Repeat);

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -4042,6 +4042,8 @@ struct Slice {
       }
     } else {
       // Stepped copy: element by element
+      // Note: idx < actualLen is defensive; mathematically i >= to always terminates first
+      // since actualLen = ceil((to-from)/step)
       for (uint8_t ch = 0; ch < channels; ch++) {
         uint32_t idx = 0;
         for (SHInt i = from; i < to && idx < actualLen; i += step) {

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -2876,11 +2876,12 @@ struct SeqUser : VariableBase {
 
 struct Count : SeqUser {
   static SHOptionalString help() {
-    return SHCCSTR("This shard counts the sequence, string or table variable specified in the Name parameter. If the variable "
+    return SHCCSTR("This shard counts the sequence, string, table, or audio variable specified in the Name parameter. If the variable "
                    "specified is "
                    "a string, it will count the number of characters. If the variable specified is a sequence, it will count "
                    "the number of "
-                   "elements. If the variable specified is a table, it will count the number of key-value pairs."
+                   "elements. If the variable specified is a table, it will count the number of key-value pairs. "
+                   "If the variable specified is audio, it will count the number of samples (per channel). "
                    "If the variable is left empty and instead an input is provided, the input will be counted instead.");
   }
 
@@ -2915,6 +2916,8 @@ struct Count : SeqUser {
       return shards::Var(int64_t(value.payload.stringLen > 0 || value.payload.stringValue == nullptr
                                      ? value.payload.stringLen
                                      : strlen(value.payload.stringValue)));
+    case SHType::Audio:
+      return shards::Var(int64_t(value.payload.audioValue.nsamples));
     default:
       return shards::Var(0);
     }

--- a/shards/modules/core/core.hpp
+++ b/shards/modules/core/core.hpp
@@ -3832,7 +3832,7 @@ struct Slice {
     }
   }
 
-  static inline Types InputTypes{{CoreInfo::AnySeqType, CoreInfo::BytesType, CoreInfo::StringType}};
+  static inline Types InputTypes{{CoreInfo::AnySeqType, CoreInfo::BytesType, CoreInfo::StringType, CoreInfo::AudioType}};
 
   static SHTypesInfo inputTypes() { return InputTypes; }
   static SHOptionalString inputHelp() {
@@ -3851,6 +3851,8 @@ struct Slice {
       OVERRIDE_ACTIVATE(data, activateBytes);
     } else if (data.inputType.basicType == SHType::String) {
       OVERRIDE_ACTIVATE(data, activateString);
+    } else if (data.inputType.basicType == SHType::Audio) {
+      OVERRIDE_ACTIVATE(data, activateAudio);
     }
 
     return data.inputType;
@@ -3992,6 +3994,61 @@ struct Slice {
       }
       return shards::Var(_cachedSeq);
     }
+  }
+
+  SHVar activateAudio(SHContext *context, const SHVar &input) {
+    const auto &inAudio = input.payload.audioValue;
+    const auto inputLen = inAudio.nsamples;
+    const auto &vfrom = _from.get();
+    const auto &vto = _to.get();
+    SHInt from = vfrom.payload.intValue;
+    SHInt to = vto.valueType == SHType::None ? SHInt(inputLen) : vto.payload.intValue;
+    SHInt step = _step->payload.intValue;
+
+    // Convert negative indices to positive
+    from = from < 0 ? SHInt(inputLen) + from : from;
+    to = to < 0 ? SHInt(inputLen) + to : to;
+
+    // Bounds checking
+    if (from < 0 || to < 0 || uint32_t(from) > inputLen || uint32_t(to) > inputLen) {
+      throw OutOfRangeEx(inputLen, from, to);
+    }
+
+    // Ensure from is less than to
+    if (from > to) {
+      throw ActivationError("From index must be less than To index.");
+    }
+
+    const uint32_t len = uint32_t(to - from);
+    if (step <= 0) {
+      throw ActivationError("Slice's Step must be greater than 0");
+    }
+
+    const uint32_t actualLen = len / step + (len % step != 0 ? 1 : 0);
+    const uint8_t channels = inAudio.channels;
+
+    // Use _cachedBytes for sample storage (resize reuses capacity)
+    _cachedBytes.resize(actualLen * channels * sizeof(float));
+    float *samples = reinterpret_cast<float *>(_cachedBytes.data());
+
+    // Extract samples for each channel using planar layout
+    if (step == 1) {
+      // Fast path: contiguous copy using memcpy
+      for (uint8_t ch = 0; ch < channels; ch++) {
+        memcpy(samples + ch * actualLen, inAudio.samples + ch * inputLen + from, actualLen * sizeof(float));
+      }
+    } else {
+      // Stepped copy: element by element
+      for (uint8_t ch = 0; ch < channels; ch++) {
+        uint32_t idx = 0;
+        for (SHInt i = from; i < to && idx < actualLen; i += step) {
+          samples[ch * actualLen + idx] = inAudio.samples[ch * inputLen + i];
+          idx++;
+        }
+      }
+    }
+
+    return Var(SHAudio{samples, actualLen, inAudio.sampleRate, channels, inAudio.reserved});
   }
 
   SHVar activate(SHContext *context, const SHVar &input) { throw ActivationError("Slice: unreachable code path"); }

--- a/shards/modules/core/math_base.hpp
+++ b/shards/modules/core/math_base.hpp
@@ -119,6 +119,29 @@ struct SubtractOp;
 struct MultiplyOp;
 struct DivideOp;
 
+// SIMD audio clear (zero buffer) - used by Pad shard
+inline void applyAudioClear(float *__restrict out, size_t count) {
+  if (count == 0) return;
+#ifdef SHARDS_HAS_ACCELERATE
+  vDSP_vclr(out, 1, count);
+#else
+  size_t i = 0;
+#if defined(__AVX2__)
+  __m256 vzero = _mm256_setzero_ps();
+  for (; i + 8 <= count; i += 8) {
+    _mm256_storeu_ps(out + i, vzero);
+  }
+#elif defined(__ARM_NEON) || defined(__ARM_NEON__)
+  float32x4_t vzero = vdupq_n_f32(0.0f);
+  for (; i + 4 <= count; i += 4) {
+    vst1q_f32(out + i, vzero);
+  }
+#endif
+  for (; i < count; ++i)
+    out[i] = 0.0f;
+#endif
+}
+
 // SIMD binary audio add
 inline void applyBinaryAudioAdd(float *__restrict out, const float *__restrict a, const float *__restrict b, size_t count) {
 #ifdef SHARDS_HAS_ACCELERATE

--- a/shards/tests/math_audio.shs
+++ b/shards/tests/math_audio.shs
@@ -173,8 +173,329 @@
   Msg("Audio chain operations test passed!")
 })
 
+; ============================================================================
+; Audio Collection Operations Tests (AppendTo, PrependTo, Slice, Pad, Trim)
+; ============================================================================
+
+@wire(test-audio-append-prepend {
+  Msg("Testing Audio AppendTo/PrependTo...")
+
+  ; Generate test audio samples
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) = audio1
+  880.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.3 Samples: 50) = audio2
+
+  ; === Test AppendTo - basic case ===
+  audio1 | Set(collection)
+  audio2 | AppendTo(collection)
+  collection | Log("AppendTo result (should have 150 samples)")
+
+  ; === Test PrependTo - basic case ===
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) | Set(collection2)
+  880.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.3 Samples: 50) | PrependTo(collection2)
+  collection2 | Log("PrependTo result (should have 150 samples)")
+
+  ; === Test multiple append operations (buffer reuse) ===
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 10) | Set(multi-append)
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 5) = small-audio
+  small-audio | AppendTo(multi-append)
+  small-audio | AppendTo(multi-append)
+  small-audio | AppendTo(multi-append)
+  multi-append | Log("Multiple appends (should have 25 samples)")
+
+  ; === Test mono audio ===
+  ; TODO: Test mono when Audio.Oscillator supports it
+
+  Msg("Audio AppendTo/PrependTo tests passed!")
+})
+
+@wire(test-audio-slice {
+  Msg("Testing Audio Slice...")
+
+  ; Generate test audio
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 1.0 Samples: 100) = audio
+
+  ; === Basic slice (From and To) ===
+  audio | Slice(From: 10 To: 50) = sliced
+  sliced | Log("Sliced audio (40 samples from index 10-50)")
+
+  ; === Slice from beginning (To only) ===
+  audio | Slice(To: 30) = front-slice
+  front-slice | Log("Front slice (first 30 samples)")
+
+  ; === Slice to end (From only) ===
+  audio | Slice(From: 70) = back-slice
+  back-slice | Log("Back slice (last 30 samples)")
+
+  ; === Negative indices (from end) ===
+  audio | Slice(From: -20) = last-20
+  last-20 | Log("Last 20 samples using negative index")
+
+  audio | Slice(From: -50 To: -10) = neg-slice
+  neg-slice | Log("Slice with negative from and to (-50 to -10)")
+
+  ; === Slice with step ===
+  audio | Slice(From: 0 To: 50 Step: 2) = stepped
+  stepped | Log("Every other sample (25 samples)")
+
+  audio | Slice(From: 0 To: 60 Step: 3) = stepped-3
+  stepped-3 | Log("Every 3rd sample (20 samples)")
+
+  ; === Edge cases ===
+  audio | Slice(From: 0 To: 100) = full-copy
+  full-copy | Log("Full slice (100 samples)")
+
+  audio | Slice(From: 50 To: 50) = empty-slice
+  empty-slice | Log("Empty slice (0 samples from 50-50)")
+
+  Msg("Audio Slice tests passed!")
+})
+
+@wire(test-audio-pad {
+  Msg("Testing Pad for Audio...")
+
+  ; Generate test audio
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) = audio
+
+  ; === Pad at beginning only ===
+  audio | Pad(Before: 50) = padded-before
+  padded-before | Log("Audio padded at beginning (150 samples)")
+
+  ; === Pad at end only ===
+  audio | Pad(After: 50) = padded-after
+  padded-after | Log("Audio padded at end (150 samples)")
+
+  ; === Pad both ends ===
+  audio | Pad(Before: 25 After: 25) = padded-both
+  padded-both | Log("Audio padded both ends (150 samples)")
+
+  ; === Zero padding (default values) ===
+  audio | Pad(Before: 0 After: 0) = no-pad
+  no-pad | Log("No padding (100 samples)")
+
+  ; === Large padding ===
+  audio | Pad(Before: 1000 After: 1000) = large-pad
+  large-pad | Log("Large padding (2100 samples)")
+
+  Msg("Audio Pad tests passed!")
+})
+
+@wire(test-audio-trim {
+  Msg("Testing Trim for Audio...")
+
+  ; Generate test audio
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) = audio
+
+  ; === Trim from beginning only ===
+  audio | Trim(Before: 20) = trimmed-before
+  trimmed-before | Log("Audio trimmed at beginning (80 samples)")
+
+  ; === Trim from end only ===
+  audio | Trim(After: 20) = trimmed-after
+  trimmed-after | Log("Audio trimmed at end (80 samples)")
+
+  ; === Trim both ends ===
+  audio | Trim(Before: 10 After: 10) = trimmed-both
+  trimmed-both | Log("Audio trimmed both ends (80 samples)")
+
+  ; === Zero trim (no change) ===
+  audio | Trim(Before: 0 After: 0) = no-trim
+  no-trim | Log("No trim (100 samples)")
+
+  ; === Trim to near-empty ===
+  audio | Trim(Before: 49 After: 50) = almost-empty
+  almost-empty | Log("Nearly empty audio (1 sample)")
+
+  Msg("Audio Trim tests passed!")
+})
+
+@wire(test-pad-seq {
+  Msg("Testing Pad for Seq...")
+
+  ; === Seq with default pad value (None) ===
+  [1 2 3] | Pad(Before: 2 After: 2) = padded-default
+  padded-default | Log("Padded sequence with default (None)")
+
+  ; === Seq with custom pad value ===
+  [1 2 3] | Pad(Before: 2 After: 2 Value: 0) = padded-zero
+  padded-zero | Log("Padded sequence with 0")
+  padded-zero | Assert.Is([0 0 1 2 3 0 0])
+
+  ; === Seq with string pad value ===
+  ["a" "b"] | Pad(Before: 1 After: 1 Value: "x") = padded-str
+  padded-str | Log("Padded string sequence")
+  padded-str | Assert.Is(["x" "a" "b" "x"])
+
+  ; === Pad only before ===
+  [1 2 3] | Pad(Before: 3 Value: -1) = pad-before
+  pad-before | Assert.Is([-1 -1 -1 1 2 3])
+
+  ; === Pad only after ===
+  [1 2 3] | Pad(After: 3 Value: -1) = pad-after
+  pad-after | Assert.Is([1 2 3 -1 -1 -1])
+
+  Msg("Pad Seq tests passed!")
+})
+
+@wire(test-pad-string {
+  Msg("Testing Pad for String...")
+
+  ; === Default padding (spaces) ===
+  "hi" | Pad(Before: 2 After: 2) = space-padded
+  space-padded | Log("Space padded string")
+  space-padded | Assert.Is("  hi  ")
+
+  ; === Custom character padding ===
+  "hello" | Pad(Before: 3 After: 3 Value: "*") = star-padded
+  star-padded | Log("Star padded string")
+  star-padded | Assert.Is("***hello***")
+
+  ; === Only before ===
+  "test" | Pad(Before: 5 Value: "-") = before-only
+  before-only | Assert.Is("-----test")
+
+  ; === Only after ===
+  "test" | Pad(After: 5 Value: "-") = after-only
+  after-only | Assert.Is("test-----")
+
+  ; === Single char from longer string ===
+  "abc" | Pad(Before: 2 After: 2 Value: "xyz") = first-char
+  first-char | Log("Uses first char of pad string")
+  first-char | Assert.Is("xxabcxx")
+
+  Msg("Pad String tests passed!")
+})
+
+@wire(test-pad-bytes {
+  Msg("Testing Pad for Bytes...")
+
+  ; === Default zero padding ===
+  "AB" | StringToBytes | Pad(Before: 2 After: 2) = zero-padded
+  zero-padded | Log("Zero padded bytes")
+
+  ; === Custom byte from Int ===
+  "test" | StringToBytes | Pad(Before: 2 After: 2 Value: 255) = int-padded
+  int-padded | Log("Padded with 0xFF from Int")
+
+  ; === Custom byte from Bytes ===
+  "CD" | StringToBytes | Pad(Before: 1 After: 1 Value: ("X" | StringToBytes)) = bytes-padded
+  bytes-padded | BytesToString | Assert.Is("XCDX")
+
+  Msg("Pad Bytes tests passed!")
+})
+
+@wire(test-trim-seq {
+  Msg("Testing Trim for Seq...")
+
+  ; === Basic trim ===
+  [0 0 1 2 3 0 0] | Trim(Before: 2 After: 2) = trimmed
+  trimmed | Log("Trimmed sequence")
+  trimmed | Assert.Is([1 2 3])
+
+  ; === Trim only before ===
+  [1 2 3 4 5] | Trim(Before: 2) = trim-before
+  trim-before | Assert.Is([3 4 5])
+
+  ; === Trim only after ===
+  [1 2 3 4 5] | Trim(After: 2) = trim-after
+  trim-after | Assert.Is([1 2 3])
+
+  ; === Zero trim ===
+  [1 2 3] | Trim(Before: 0 After: 0) = no-trim
+  no-trim | Assert.Is([1 2 3])
+
+  ; === Trim to single element ===
+  [1 2 3 4 5] | Trim(Before: 2 After: 2) = single
+  single | Assert.Is([3])
+
+  Msg("Trim Seq tests passed!")
+})
+
+@wire(test-trim-string {
+  Msg("Testing Trim for String...")
+
+  ; === Basic trim ===
+  "***hello***" | Trim(Before: 3 After: 3) = trimmed
+  trimmed | Log("Trimmed string")
+  trimmed | Assert.Is("hello")
+
+  ; === Trim only before ===
+  "xxxtest" | Trim(Before: 3) = trim-before
+  trim-before | Assert.Is("test")
+
+  ; === Trim only after ===
+  "testyyy" | Trim(After: 3) = trim-after
+  trim-after | Assert.Is("test")
+
+  ; === Zero trim ===
+  "hello" | Trim(Before: 0 After: 0) = no-trim
+  no-trim | Assert.Is("hello")
+
+  ; === Trim to single char ===
+  "xxAxx" | Trim(Before: 2 After: 2) = single-char
+  single-char | Assert.Is("A")
+
+  Msg("Trim String tests passed!")
+})
+
+@wire(test-trim-bytes {
+  Msg("Testing Trim for Bytes...")
+
+  ; === Basic trim ===
+  "##test##" | StringToBytes | Trim(Before: 2 After: 2) = trimmed
+  trimmed | BytesToString | Assert.Is("test")
+
+  ; === Trim only before ===
+  "XXXdata" | StringToBytes | Trim(Before: 3) = trim-before
+  trim-before | BytesToString | Assert.Is("data")
+
+  ; === Trim only after ===
+  "dataYYY" | StringToBytes | Trim(After: 3) = trim-after
+  trim-after | BytesToString | Assert.Is("data")
+
+  Msg("Trim Bytes tests passed!")
+})
+
+@wire(test-audio-workflow {
+  Msg("Testing audio mixing workflow with Pad + Math.Add...")
+
+  ; Create two audio buffers of different lengths
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) = short-audio
+  880.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.3 Samples: 150) = long-audio
+
+  ; Pad the short audio to match the long audio
+  short-audio | Pad(After: 50) = padded-short
+
+  ; Now mix them using Math.Add
+  padded-short | Math.Add(long-audio) = mixed
+  mixed | Log("Mixed audio (150 samples)")
+
+  ; Test concatenation workflow
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 50) | Set(concat-audio)
+  880.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 50) | AppendTo(concat-audio)
+  660.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 50) | AppendTo(concat-audio)
+  concat-audio | Log("Concatenated audio (150 samples)")
+
+  ; Test slice + pad workflow (extract and pad to original size)
+  concat-audio | Slice(From: 50 To: 100) = middle-section
+  middle-section | Pad(Before: 50 After: 50) = restored-size
+  restored-size | Log("Extracted middle, padded back to 150 samples")
+
+  Msg("Audio workflow tests passed!")
+})
+
 @mesh(main)
 @schedule(main test-audio-binary)
 @schedule(main test-audio-unary)
 @schedule(main test-audio-chain)
+@schedule(main test-audio-append-prepend)
+@schedule(main test-audio-slice)
+@schedule(main test-audio-pad)
+@schedule(main test-audio-trim)
+@schedule(main test-pad-seq)
+@schedule(main test-pad-string)
+@schedule(main test-pad-bytes)
+@schedule(main test-trim-seq)
+@schedule(main test-trim-string)
+@schedule(main test-trim-bytes)
+@schedule(main test-audio-workflow)
 @run(main)

--- a/shards/tests/math_audio.shs
+++ b/shards/tests/math_audio.shs
@@ -483,6 +483,126 @@
   Msg("Audio workflow tests passed!")
 })
 
+; === Error condition tests ===
+
+@wire(test-error-channel-mismatch {
+  Msg("Testing error: channel mismatch...")
+
+  ; Create mono and stereo audio
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100 Channels: 1) = mono
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100 Channels: 2) = stereo
+
+  ; Try to append stereo to mono - should fail
+  mono | Set(collection)
+  Maybe({
+    stereo | AppendTo(collection)
+    "ERROR: Should have thrown channel mismatch!" | Fail
+  } {
+    Msg("Correctly caught channel mismatch error in AppendTo")
+  })
+
+  ; Try to prepend stereo to mono - should fail
+  mono | Set(collection2)
+  Maybe({
+    stereo | PrependTo(collection2)
+    "ERROR: Should have thrown channel mismatch!" | Fail
+  } {
+    Msg("Correctly caught channel mismatch error in PrependTo")
+  })
+
+  Msg("Channel mismatch error tests passed!")
+})
+
+@wire(test-error-samplerate-mismatch {
+  Msg("Testing error: sample rate mismatch...")
+
+  ; Create audio with different sample rates
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) = audio44k
+  440.0 | Audio.Oscillator(SampleRate: 48000 Amplitude: 0.5 Samples: 100) = audio48k
+
+  ; Try to append different sample rates - should fail
+  audio44k | Set(collection)
+  Maybe({
+    audio48k | AppendTo(collection)
+    "ERROR: Should have thrown sample rate mismatch!" | Fail
+  } {
+    Msg("Correctly caught sample rate mismatch error in AppendTo")
+  })
+
+  ; Try to prepend different sample rates - should fail
+  audio44k | Set(collection2)
+  Maybe({
+    audio48k | PrependTo(collection2)
+    "ERROR: Should have thrown sample rate mismatch!" | Fail
+  } {
+    Msg("Correctly caught sample rate mismatch error in PrependTo")
+  })
+
+  Msg("Sample rate mismatch error tests passed!")
+})
+
+@wire(test-error-trim-overflow {
+  Msg("Testing error: trim overflow...")
+
+  ; Create short audio
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 10) = short-audio
+
+  ; Try to trim more than available - should fail
+  Maybe({
+    short-audio | Trim(Before: 6 After: 6)
+    "ERROR: Should have thrown trim overflow!" | Fail
+  } {
+    Msg("Correctly caught trim overflow error")
+  })
+
+  ; Test exact trim to empty - this is valid (results in 0 samples)
+  short-audio | Trim(Before: 5 After: 5) = empty-audio
+  empty-audio | Log("Trimmed to 0 samples (valid)")
+
+  Msg("Trim overflow error tests passed!")
+})
+
+@wire(test-error-negative-params {
+  Msg("Testing error: negative parameters...")
+
+  ; Create test audio
+  440.0 | Audio.Oscillator(SampleRate: 44100 Amplitude: 0.5 Samples: 100) = audio
+
+  ; Test negative Before in Pad - should fail
+  Maybe({
+    audio | Pad(Before: -1 After: 0)
+    "ERROR: Should have thrown negative param error!" | Fail
+  } {
+    Msg("Correctly caught negative Before in Pad")
+  })
+
+  ; Test negative After in Pad - should fail
+  Maybe({
+    audio | Pad(Before: 0 After: -1)
+    "ERROR: Should have thrown negative param error!" | Fail
+  } {
+    Msg("Correctly caught negative After in Pad")
+  })
+
+  ; Test negative Before in Trim - should fail
+  Maybe({
+    audio | Trim(Before: -1 After: 0)
+    "ERROR: Should have thrown negative param error!" | Fail
+  } {
+    Msg("Correctly caught negative Before in Trim")
+  })
+
+  ; Test negative After in Trim - should fail
+  Maybe({
+    audio | Trim(Before: 0 After: -1)
+    "ERROR: Should have thrown negative param error!" | Fail
+  } {
+    Msg("Correctly caught negative After in Trim")
+  })
+
+  Msg("Negative parameter error tests passed!")
+})
+
 @mesh(main)
 @schedule(main test-audio-binary)
 @schedule(main test-audio-unary)
@@ -498,4 +618,8 @@
 @schedule(main test-trim-string)
 @schedule(main test-trim-bytes)
 @schedule(main test-audio-workflow)
+@schedule(main test-error-channel-mismatch)
+@schedule(main test-error-samplerate-mismatch)
+@schedule(main test-error-trim-overflow)
+@schedule(main test-error-negative-params)
 @run(main)


### PR DESCRIPTION
…d, Trim)

- Enable AppendTo/PrependTo for Audio type with channel/sample rate validation
- Add Slice support for Audio with negative indices and step parameter
- Implement new Pad shard for Audio, Seq, String, Bytes
- Implement new Trim shard for Audio, Seq, String, Bytes
- Add comprehensive test coverage in math_audio.shs


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
