### PR TITLE
Add Audio.Envelope (ADSR) and Audio.Filter (SVF) shards

### DIFF
--- a/shards/modules/audio/synth.cpp
+++ b/shards/modules/audio/synth.cpp
@@ -709,6 +709,421 @@ struct Noise {
   SHVar activate(SHContext *context, const SHVar &input) { return activateWhite(context, input); }
 };
 
+// =============================================================================
+// ADSR Envelope Generator
+// =============================================================================
+
+struct Envelope {
+  enum class Stage { Idle, Attack, Decay, Sustain, Release };
+
+  enum class Curve { Linear, Exponential };
+  DECL_ENUM_INFO(Curve, EnvelopeCurve, "Envelope curve type.", 'ecur');
+
+  // Parameters
+  PARAM_PARAMVAR(_attack, "Attack", "Attack time in seconds (0.001 to 10.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_PARAMVAR(_decay, "Decay", "Decay time in seconds (0.001 to 10.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_PARAMVAR(_sustain, "Sustain", "Sustain level (0.0 to 1.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_PARAMVAR(_release, "Release", "Release time in seconds (0.001 to 10.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_VAR(_curve, "Curve", "Envelope curve type (Linear or Exponential).", {EnvelopeCurveEnumInfo::Type});
+
+  PARAM_IMPL(PARAM_IMPL_FOR(_attack), PARAM_IMPL_FOR(_decay), PARAM_IMPL_FOR(_sustain), PARAM_IMPL_FOR(_release),
+             PARAM_IMPL_FOR(_curve));
+
+  // Per-channel state
+  struct ChannelState {
+    Stage stage{Stage::Idle};
+    double level{0.0};
+    double releaseStartLevel{0.0};
+    uint64_t stageSamples{0};
+  };
+  std::array<ChannelState, MAX_CHANNELS> _channelStates{};
+
+  std::vector<float> _buffer;
+
+  SHVar *_deviceVar{nullptr};
+  Device *_device{nullptr};
+
+  Envelope() {
+    _attack = Var(0.01);  // 10ms default attack
+    _decay = Var(0.1);    // 100ms default decay
+    _sustain = Var(0.7);  // 70% sustain level
+    _release = Var(0.3);  // 300ms release
+    _curve = Var::Enum(Curve::Exponential, CoreCC, EnvelopeCurveEnumInfo::TypeId);
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("ADSR envelope generator. Takes a gate signal (audio or trigger) as input, "
+                   "where values > 0 indicate gate on and values <= 0 indicate gate off. "
+                   "Outputs an envelope signal from 0.0 to 1.0 that can be multiplied with "
+                   "an oscillator for amplitude modulation (VCA).");
+  }
+
+  static SHTypesInfo inputTypes() { return CoreInfo::AudioType; }
+  static SHOptionalString inputHelp() {
+    return SHCCSTR("Gate signal where > 0 is gate on, <= 0 is gate off.");
+  }
+  static SHTypesInfo outputTypes() { return CoreInfo::AudioType; }
+  static SHOptionalString outputHelp() { return SHCCSTR("Envelope values from 0.0 to 1.0."); }
+
+  PARAM_REQUIRED_VARIABLES();
+
+  SHTypeInfo compose(SHInstanceData &data) {
+    PARAM_COMPOSE_REQUIRED_VARIABLES(data);
+
+    Curve curve = Curve(_curve.payload.enumValue);
+    if (curve == Curve::Linear) {
+      OVERRIDE_ACTIVATE(data, activateLinear);
+    } else {
+      OVERRIDE_ACTIVATE(data, activateExponential);
+    }
+    return CoreInfo::AudioType;
+  }
+
+  void warmup(SHContext *context) {
+    PARAM_WARMUP(context);
+
+    _deviceVar = referenceVariable(context, "Audio.Device");
+    if (_deviceVar->valueType == SHType::Object) {
+      _device = reinterpret_cast<Device *>(_deviceVar->payload.objectValue);
+    }
+
+    // Reset all channel states
+    for (auto &state : _channelStates) {
+      state = ChannelState{};
+    }
+  }
+
+  void cleanup(SHContext *context) {
+    PARAM_CLEANUP(context);
+
+    if (_deviceVar) {
+      releaseVariable(_deviceVar);
+      _deviceVar = nullptr;
+      _device = nullptr;
+    }
+  }
+
+  template <typename ProcessFunc> SHVar processEnvelope(const SHVar &input, ProcessFunc processFunc) {
+    const auto &audio = input.payload.audioValue;
+    const uint32_t nsamples = audio.nsamples;
+    const uint32_t sampleRate = audioGetSampleRate(audio);
+    const uint32_t channels = audio.channels;
+
+    // Get parameters
+    const double attack = std::max(0.001, _attack.get().payload.floatValue);
+    const double decay = std::max(0.001, _decay.get().payload.floatValue);
+    const double sustain = std::clamp(_sustain.get().payload.floatValue, 0.0, 1.0);
+    const double release = std::max(0.001, _release.get().payload.floatValue);
+
+    // Calculate samples for each stage
+    const uint64_t attackSamples = uint64_t(attack * sampleRate);
+    const uint64_t decaySamples = uint64_t(decay * sampleRate);
+    const uint64_t releaseSamples = uint64_t(release * sampleRate);
+
+    // Validate buffer size
+    if (nsamples > MAX_SAMPLES || channels > MAX_CHANNELS) {
+      throw ActivationError("Audio.Envelope: buffer size exceeds limits");
+    }
+
+    _buffer.resize(channels * nsamples);
+
+    // Process each channel independently
+    for (uint32_t ch = 0; ch < channels; ch++) {
+      const float *gateSamples = audio.samples + ch * nsamples;
+      float *outSamples = _buffer.data() + ch * nsamples;
+      ChannelState &state = _channelStates[ch];
+
+      for (uint32_t i = 0; i < nsamples; i++) {
+        bool gateOn = gateSamples[i] > 0.0f;
+
+        // Handle gate transitions
+        if (gateOn && (state.stage == Stage::Idle || state.stage == Stage::Release)) {
+          // Gate on - start attack (retrigger support)
+          state.stage = Stage::Attack;
+          state.stageSamples = 0;
+          // level continues from current value for smooth retrigger
+        } else if (!gateOn && state.stage != Stage::Idle && state.stage != Stage::Release) {
+          // Gate off - start release
+          state.stage = Stage::Release;
+          state.releaseStartLevel = state.level;
+          state.stageSamples = 0;
+        }
+
+        // Process current stage
+        processFunc(state, sustain, attackSamples, decaySamples, releaseSamples);
+
+        outSamples[i] = float(state.level);
+        state.stageSamples++;
+      }
+    }
+
+    return Var(makeAudio(_buffer.data(), nsamples, sampleRate, uint8_t(channels)));
+  }
+
+  SHVar activateLinear(SHContext *context, const SHVar &input) {
+    return processEnvelope(input, [](ChannelState &state, double sustain, uint64_t attackSamples, uint64_t decaySamples,
+                                     uint64_t releaseSamples) {
+      switch (state.stage) {
+      case Stage::Attack: {
+        double t = double(state.stageSamples) / double(attackSamples);
+        state.level = t;
+        if (state.stageSamples >= attackSamples) {
+          state.stage = Stage::Decay;
+          state.stageSamples = 0;
+          state.level = 1.0;
+        }
+        break;
+      }
+      case Stage::Decay: {
+        double t = double(state.stageSamples) / double(decaySamples);
+        state.level = 1.0 - t * (1.0 - sustain);
+        if (state.stageSamples >= decaySamples) {
+          state.stage = Stage::Sustain;
+          state.stageSamples = 0;
+          state.level = sustain;
+        }
+        break;
+      }
+      case Stage::Sustain:
+        state.level = sustain;
+        break;
+      case Stage::Release: {
+        double t = double(state.stageSamples) / double(releaseSamples);
+        state.level = state.releaseStartLevel * (1.0 - t);
+        if (state.stageSamples >= releaseSamples) {
+          state.stage = Stage::Idle;
+          state.stageSamples = 0;
+          state.level = 0.0;
+        }
+        break;
+      }
+      case Stage::Idle:
+        state.level = 0.0;
+        break;
+      }
+    });
+  }
+
+  SHVar activateExponential(SHContext *context, const SHVar &input) {
+    return processEnvelope(input, [](ChannelState &state, double sustain, uint64_t attackSamples, uint64_t decaySamples,
+                                     uint64_t releaseSamples) {
+      // Exponential curve coefficient (higher = faster curve, 5.0 gives natural envelope feel)
+      constexpr double EXP_COEFF = 5.0;
+
+      switch (state.stage) {
+      case Stage::Attack: {
+        double t = double(state.stageSamples) / double(attackSamples);
+        // Exponential attack: 1 - e^(-kt)
+        state.level = 1.0 - std::exp(-EXP_COEFF * t);
+        if (state.stageSamples >= attackSamples) {
+          state.stage = Stage::Decay;
+          state.stageSamples = 0;
+          state.level = 1.0;
+        }
+        break;
+      }
+      case Stage::Decay: {
+        double t = double(state.stageSamples) / double(decaySamples);
+        // Exponential decay from 1.0 to sustain
+        state.level = sustain + (1.0 - sustain) * std::exp(-EXP_COEFF * t);
+        if (state.stageSamples >= decaySamples) {
+          state.stage = Stage::Sustain;
+          state.stageSamples = 0;
+          state.level = sustain;
+        }
+        break;
+      }
+      case Stage::Sustain:
+        state.level = sustain;
+        break;
+      case Stage::Release: {
+        double t = double(state.stageSamples) / double(releaseSamples);
+        // Exponential release from releaseStartLevel to 0
+        state.level = state.releaseStartLevel * std::exp(-EXP_COEFF * t);
+        if (state.stageSamples >= releaseSamples) {
+          state.stage = Stage::Idle;
+          state.stageSamples = 0;
+          state.level = 0.0;
+        }
+        break;
+      }
+      case Stage::Idle:
+        state.level = 0.0;
+        break;
+      }
+    });
+  }
+
+  SHVar activate(SHContext *context, const SHVar &input) { return activateExponential(context, input); }
+};
+
+// =============================================================================
+// State Variable Filter (SVF)
+// =============================================================================
+
+struct Filter {
+  enum class FilterType { Lowpass, Highpass, Bandpass, Notch };
+  DECL_ENUM_INFO(FilterType, FilterType, "Type of filter response.", 'filt');
+
+  // Parameters
+  PARAM_VAR(_type, "Type", "Filter type (Lowpass, Highpass, Bandpass, Notch).", {FilterTypeEnumInfo::Type});
+  PARAM_PARAMVAR(_cutoff, "Cutoff", "Cutoff frequency in Hz.", {CoreInfo::FloatType, CoreInfo::FloatVarType});
+  PARAM_PARAMVAR(_resonance, "Resonance", "Resonance amount (0.0 to 1.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
+
+  PARAM_IMPL(PARAM_IMPL_FOR(_type), PARAM_IMPL_FOR(_cutoff), PARAM_IMPL_FOR(_resonance));
+
+  // Per-channel SVF state (Cytomic/Vadim Zavalishin style)
+  struct SVFState {
+    double ic1eq{0.0}; // Integrator 1 state
+    double ic2eq{0.0}; // Integrator 2 state
+  };
+  std::array<SVFState, MAX_CHANNELS> _svfStates{};
+
+  std::vector<float> _buffer;
+
+  SHVar *_deviceVar{nullptr};
+  Device *_device{nullptr};
+
+  Filter() {
+    _type = Var::Enum(FilterType::Lowpass, CoreCC, FilterTypeEnumInfo::TypeId);
+    _cutoff = Var(1000.0);   // 1kHz default cutoff
+    _resonance = Var(0.5);   // 50% resonance
+  }
+
+  static SHOptionalString help() {
+    return SHCCSTR("State Variable Filter (SVF) with Lowpass, Highpass, Bandpass, and Notch modes. "
+                   "Cutoff and Resonance can be modulated for filter sweeps and effects.");
+  }
+
+  static SHTypesInfo inputTypes() { return CoreInfo::AudioType; }
+  static SHOptionalString inputHelp() { return SHCCSTR("Audio signal to filter."); }
+  static SHTypesInfo outputTypes() { return CoreInfo::AudioType; }
+  static SHOptionalString outputHelp() { return SHCCSTR("Filtered audio signal."); }
+
+  PARAM_REQUIRED_VARIABLES();
+
+  SHTypeInfo compose(SHInstanceData &data) {
+    PARAM_COMPOSE_REQUIRED_VARIABLES(data);
+
+    FilterType type = FilterType(_type.payload.enumValue);
+    switch (type) {
+    case FilterType::Lowpass:
+      OVERRIDE_ACTIVATE(data, activateLowpass);
+      break;
+    case FilterType::Highpass:
+      OVERRIDE_ACTIVATE(data, activateHighpass);
+      break;
+    case FilterType::Bandpass:
+      OVERRIDE_ACTIVATE(data, activateBandpass);
+      break;
+    case FilterType::Notch:
+      OVERRIDE_ACTIVATE(data, activateNotch);
+      break;
+    }
+    return CoreInfo::AudioType;
+  }
+
+  void warmup(SHContext *context) {
+    PARAM_WARMUP(context);
+
+    _deviceVar = referenceVariable(context, "Audio.Device");
+    if (_deviceVar->valueType == SHType::Object) {
+      _device = reinterpret_cast<Device *>(_deviceVar->payload.objectValue);
+    }
+
+    // Reset filter states
+    for (auto &state : _svfStates) {
+      state = SVFState{};
+    }
+  }
+
+  void cleanup(SHContext *context) {
+    PARAM_CLEANUP(context);
+
+    if (_deviceVar) {
+      releaseVariable(_deviceVar);
+      _deviceVar = nullptr;
+      _device = nullptr;
+    }
+  }
+
+  // SVF core processing (Cytomic/Vadim Zavalishin TPT implementation)
+  // Returns: lowpass, highpass, bandpass outputs via reference
+  inline void processSVF(double v0, double g, double k, SVFState &state, double &lowpass, double &highpass, double &bandpass) {
+    // TPT SVF equations
+    double v1 = (state.ic1eq + g * (v0 - state.ic2eq)) / (1.0 + g * (g + k));
+    double v2 = state.ic2eq + g * v1;
+
+    // Update state
+    state.ic1eq = 2.0 * v1 - state.ic1eq;
+    state.ic2eq = 2.0 * v2 - state.ic2eq;
+
+    // Outputs
+    lowpass = v2;
+    bandpass = v1;
+    highpass = v0 - k * v1 - v2;
+  }
+
+  template <FilterType Type> SHVar processFilter(SHContext *context, const SHVar &input) {
+    const auto &audio = input.payload.audioValue;
+    const uint32_t nsamples = audio.nsamples;
+    const uint32_t sampleRate = audioGetSampleRate(audio);
+    const uint32_t channels = audio.channels;
+
+    // Get parameters
+    const double cutoff = std::clamp(_cutoff.get().payload.floatValue, 20.0, double(sampleRate) * 0.49);
+    const double resonance = std::clamp(_resonance.get().payload.floatValue, 0.0, 1.0);
+
+    // SVF coefficients
+    // g = tan(π * cutoff / sampleRate)
+    const double g = std::tan(M_PI * cutoff / double(sampleRate));
+    // k = 2.0 - 2.0 * resonance (resonance 0 -> k=2, resonance 1 -> k=0)
+    // k=0 gives self-oscillation, we clamp to avoid instability
+    const double k = 2.0 - 2.0 * resonance * 0.99;
+
+    // Validate buffer size
+    if (nsamples > MAX_SAMPLES || channels > MAX_CHANNELS) {
+      throw ActivationError("Audio.Filter: buffer size exceeds limits");
+    }
+
+    _buffer.resize(channels * nsamples);
+
+    // Process each channel independently
+    for (uint32_t ch = 0; ch < channels; ch++) {
+      const float *inSamples = audio.samples + ch * nsamples;
+      float *outSamples = _buffer.data() + ch * nsamples;
+      SVFState &state = _svfStates[ch];
+
+      for (uint32_t i = 0; i < nsamples; i++) {
+        double v0 = double(inSamples[i]);
+        double lowpass, highpass, bandpass;
+        processSVF(v0, g, k, state, lowpass, highpass, bandpass);
+
+        // Select output based on filter type (compile-time dispatch)
+        if constexpr (Type == FilterType::Lowpass) {
+          outSamples[i] = float(lowpass);
+        } else if constexpr (Type == FilterType::Highpass) {
+          outSamples[i] = float(highpass);
+        } else if constexpr (Type == FilterType::Bandpass) {
+          outSamples[i] = float(bandpass);
+        } else if constexpr (Type == FilterType::Notch) {
+          // Notch = lowpass + highpass
+          outSamples[i] = float(lowpass + highpass);
+        }
+      }
+    }
+
+    return Var(makeAudio(_buffer.data(), nsamples, sampleRate, uint8_t(channels)));
+  }
+
+  SHVar activateLowpass(SHContext *context, const SHVar &input) { return processFilter<FilterType::Lowpass>(context, input); }
+  SHVar activateHighpass(SHContext *context, const SHVar &input) { return processFilter<FilterType::Highpass>(context, input); }
+  SHVar activateBandpass(SHContext *context, const SHVar &input) { return processFilter<FilterType::Bandpass>(context, input); }
+  SHVar activateNotch(SHContext *context, const SHVar &input) { return processFilter<FilterType::Notch>(context, input); }
+
+  SHVar activate(SHContext *context, const SHVar &input) { return activateLowpass(context, input); }
+};
+
 } // namespace Synth
 } // namespace Audio
 } // namespace shards
@@ -718,6 +1133,10 @@ SHARDS_REGISTER_FN(synth) {
   REGISTER_ENUM(Oscillator::WaveformEnumInfo);
   REGISTER_ENUM(Oscillator::FMModeEnumInfo);
   REGISTER_ENUM(Noise::NoiseTypeEnumInfo);
+  REGISTER_ENUM(Envelope::EnvelopeCurveEnumInfo);
+  REGISTER_ENUM(Filter::FilterTypeEnumInfo);
   REGISTER_SHARD("Audio.Oscillator", Oscillator);
   REGISTER_SHARD("Audio.Noise", Noise);
+  REGISTER_SHARD("Audio.Envelope", Envelope);
+  REGISTER_SHARD("Audio.Filter", Filter);
 }

--- a/shards/modules/audio/synth.cpp
+++ b/shards/modules/audio/synth.cpp
@@ -733,15 +733,13 @@ struct Envelope {
   struct ChannelState {
     Stage stage{Stage::Idle};
     double level{0.0};
+    double attackStartLevel{0.0};  // For smooth retrigger - where attack starts from
     double releaseStartLevel{0.0};
     uint64_t stageSamples{0};
   };
   std::array<ChannelState, MAX_CHANNELS> _channelStates{};
 
   std::vector<float> _buffer;
-
-  SHVar *_deviceVar{nullptr};
-  Device *_device{nullptr};
 
   Envelope() {
     _attack = Var(0.01);  // 10ms default attack
@@ -782,11 +780,6 @@ struct Envelope {
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
 
-    _deviceVar = referenceVariable(context, "Audio.Device");
-    if (_deviceVar->valueType == SHType::Object) {
-      _device = reinterpret_cast<Device *>(_deviceVar->payload.objectValue);
-    }
-
     // Reset all channel states
     for (auto &state : _channelStates) {
       state = ChannelState{};
@@ -795,12 +788,6 @@ struct Envelope {
 
   void cleanup(SHContext *context) {
     PARAM_CLEANUP(context);
-
-    if (_deviceVar) {
-      releaseVariable(_deviceVar);
-      _deviceVar = nullptr;
-      _device = nullptr;
-    }
   }
 
   template <typename ProcessFunc> SHVar processEnvelope(const SHVar &input, ProcessFunc processFunc) {
@@ -838,10 +825,10 @@ struct Envelope {
 
         // Handle gate transitions
         if (gateOn && (state.stage == Stage::Idle || state.stage == Stage::Release)) {
-          // Gate on - start attack (retrigger support)
+          // Gate on - start attack from current level (smooth retrigger)
           state.stage = Stage::Attack;
+          state.attackStartLevel = state.level;  // Remember where we're starting from
           state.stageSamples = 0;
-          // level continues from current value for smooth retrigger
         } else if (!gateOn && state.stage != Stage::Idle && state.stage != Stage::Release) {
           // Gate off - start release
           state.stage = Stage::Release;
@@ -866,7 +853,8 @@ struct Envelope {
       switch (state.stage) {
       case Stage::Attack: {
         double t = double(state.stageSamples) / double(attackSamples);
-        state.level = t;
+        // Linear interpolation from attackStartLevel to 1.0 (smooth retrigger)
+        state.level = state.attackStartLevel + t * (1.0 - state.attackStartLevel);
         if (state.stageSamples >= attackSamples) {
           state.stage = Stage::Decay;
           state.stageSamples = 0;
@@ -907,14 +895,18 @@ struct Envelope {
   SHVar activateExponential(SHContext *context, const SHVar &input) {
     return processEnvelope(input, [](ChannelState &state, double sustain, uint64_t attackSamples, uint64_t decaySamples,
                                      uint64_t releaseSamples) {
-      // Exponential curve coefficient (higher = faster curve, 5.0 gives natural envelope feel)
+      // Exponential curve coefficient: 5.0 means the curve reaches ~99.3% (1 - e^-5) of its
+      // target at t=1.0. This gives a natural-sounding envelope with most movement in the
+      // early portion of each stage, mimicking capacitor charge/discharge behavior.
       constexpr double EXP_COEFF = 5.0;
 
       switch (state.stage) {
       case Stage::Attack: {
         double t = double(state.stageSamples) / double(attackSamples);
-        // Exponential attack: 1 - e^(-kt)
-        state.level = 1.0 - std::exp(-EXP_COEFF * t);
+        // Exponential attack from attackStartLevel to 1.0 (smooth retrigger)
+        // Uses asymptotic approach: level = start + (target - start) * (1 - e^(-kt))
+        double attackRange = 1.0 - state.attackStartLevel;
+        state.level = state.attackStartLevel + attackRange * (1.0 - std::exp(-EXP_COEFF * t));
         if (state.stageSamples >= attackSamples) {
           state.stage = Stage::Decay;
           state.stageSamples = 0;
@@ -982,9 +974,6 @@ struct Filter {
 
   std::vector<float> _buffer;
 
-  SHVar *_deviceVar{nullptr};
-  Device *_device{nullptr};
-
   Filter() {
     _type = Var::Enum(FilterType::Lowpass, CoreCC, FilterTypeEnumInfo::TypeId);
     _cutoff = Var(1000.0);   // 1kHz default cutoff
@@ -1028,11 +1017,6 @@ struct Filter {
   void warmup(SHContext *context) {
     PARAM_WARMUP(context);
 
-    _deviceVar = referenceVariable(context, "Audio.Device");
-    if (_deviceVar->valueType == SHType::Object) {
-      _device = reinterpret_cast<Device *>(_deviceVar->payload.objectValue);
-    }
-
     // Reset filter states
     _ic1eq.fill(0.0f);
     _ic2eq.fill(0.0f);
@@ -1040,12 +1024,6 @@ struct Filter {
 
   void cleanup(SHContext *context) {
     PARAM_CLEANUP(context);
-
-    if (_deviceVar) {
-      releaseVariable(_deviceVar);
-      _deviceVar = nullptr;
-      _device = nullptr;
-    }
   }
 
 #if defined(SYNTH_HAS_NEON)
@@ -1207,11 +1185,16 @@ struct Filter {
     const uint32_t channels = audio.channels;
 
     // Get parameters
-    const float cutoff = float(std::clamp(_cutoff.get().payload.floatValue, 20.0, double(sampleRate) * 0.49));
+    // Clamp cutoff to 0.45 * Nyquist to prevent numerical instability from tan() approaching infinity
+    // At 0.45, tan(π * 0.45) ≈ 3.08 which is well-behaved. At 0.49, tan(π * 0.49) ≈ 27.3
+    const float cutoff = float(std::clamp(_cutoff.get().payload.floatValue, 20.0, double(sampleRate) * 0.45));
     const float resonance = float(std::clamp(_resonance.get().payload.floatValue, 0.0, 1.0));
 
     // SVF coefficients (float for SIMD)
     const float g = std::tan(float(M_PI) * cutoff / float(sampleRate));
+    // k controls damping: k=2 is critically damped, k approaching 0 gives self-oscillation.
+    // We allow resonance up to 0.99 which gives k=0.02, allowing near self-oscillation
+    // for creative filter effects (acid bass lines, etc). The filter remains stable.
     const float k = 2.0f - 2.0f * resonance * 0.99f;
 
     // Validate buffer size

--- a/shards/modules/audio/synth.cpp
+++ b/shards/modules/audio/synth.cpp
@@ -15,13 +15,13 @@
 #define SYNTH_HAS_ACCELERATE 1
 #endif
 
-// SIMD headers for non-Apple platforms
-#if !defined(SYNTH_HAS_ACCELERATE)
+// SIMD headers - needed for both Apple and non-Apple (multi-channel filter processing)
 #if defined(__ARM_NEON) || defined(__ARM_NEON__)
 #include <arm_neon.h>
+#define SYNTH_HAS_NEON 1
 #elif defined(__AVX2__) || defined(__SSE__)
 #include <immintrin.h>
-#endif
+#define SYNTH_HAS_SSE 1
 #endif
 
 // SLEEF for vectorized transcendentals (non-Apple platforms)
@@ -958,7 +958,7 @@ struct Envelope {
 };
 
 // =============================================================================
-// State Variable Filter (SVF)
+// State Variable Filter (SVF) - with SIMD multi-channel processing
 // =============================================================================
 
 struct Filter {
@@ -972,12 +972,13 @@ struct Filter {
 
   PARAM_IMPL(PARAM_IMPL_FOR(_type), PARAM_IMPL_FOR(_cutoff), PARAM_IMPL_FOR(_resonance));
 
-  // Per-channel SVF state (Cytomic/Vadim Zavalishin style)
-  struct SVFState {
-    double ic1eq{0.0}; // Integrator 1 state
-    double ic2eq{0.0}; // Integrator 2 state
-  };
-  std::array<SVFState, MAX_CHANNELS> _svfStates{};
+  // SVF state stored as aligned arrays for SIMD access
+  // We process up to 4 channels in parallel using SIMD
+  static constexpr uint32_t SIMD_WIDTH = 4;
+
+  // State arrays aligned for SIMD (padded to multiple of SIMD_WIDTH)
+  alignas(16) std::array<float, MAX_CHANNELS> _ic1eq{};
+  alignas(16) std::array<float, MAX_CHANNELS> _ic2eq{};
 
   std::vector<float> _buffer;
 
@@ -992,7 +993,8 @@ struct Filter {
 
   static SHOptionalString help() {
     return SHCCSTR("State Variable Filter (SVF) with Lowpass, Highpass, Bandpass, and Notch modes. "
-                   "Cutoff and Resonance can be modulated for filter sweeps and effects.");
+                   "Cutoff and Resonance can be modulated for filter sweeps and effects. "
+                   "Uses SIMD acceleration for multi-channel audio.");
   }
 
   static SHTypesInfo inputTypes() { return CoreInfo::AudioType; }
@@ -1032,9 +1034,8 @@ struct Filter {
     }
 
     // Reset filter states
-    for (auto &state : _svfStates) {
-      state = SVFState{};
-    }
+    _ic1eq.fill(0.0f);
+    _ic2eq.fill(0.0f);
   }
 
   void cleanup(SHContext *context) {
@@ -1047,21 +1048,156 @@ struct Filter {
     }
   }
 
-  // SVF core processing (Cytomic/Vadim Zavalishin TPT implementation)
-  // Returns: lowpass, highpass, bandpass outputs via reference
-  inline void processSVF(double v0, double g, double k, SVFState &state, double &lowpass, double &highpass, double &bandpass) {
-    // TPT SVF equations
-    double v1 = (state.ic1eq + g * (v0 - state.ic2eq)) / (1.0 + g * (g + k));
-    double v2 = state.ic2eq + g * v1;
+#if defined(SYNTH_HAS_NEON)
+  // NEON SIMD: Process 4 channels simultaneously for one sample
+  // Input: v0 contains sample i from channels 0-3
+  // Output: writes to out channels 0-3 at sample i
+  template <FilterType Type>
+  inline void processSVF_NEON_4ch(const float *in0, const float *in1, const float *in2, const float *in3,
+                                   float *out0, float *out1, float *out2, float *out3,
+                                   uint32_t nsamples, float g, float k, uint32_t chBase) {
+    // Load state for 4 channels
+    float32x4_t ic1 = vld1q_f32(&_ic1eq[chBase]);
+    float32x4_t ic2 = vld1q_f32(&_ic2eq[chBase]);
 
-    // Update state
-    state.ic1eq = 2.0 * v1 - state.ic1eq;
-    state.ic2eq = 2.0 * v2 - state.ic2eq;
+    // Precompute constants
+    float32x4_t vg = vdupq_n_f32(g);
+    float32x4_t vk = vdupq_n_f32(k);
+    float32x4_t v2 = vdupq_n_f32(2.0f);
+    float32x4_t denom = vdupq_n_f32(1.0f / (1.0f + g * (g + k)));
 
-    // Outputs
-    lowpass = v2;
-    bandpass = v1;
-    highpass = v0 - k * v1 - v2;
+    for (uint32_t i = 0; i < nsamples; i++) {
+      // Gather sample i from each channel
+      float32x4_t v0 = {in0[i], in1[i], in2[i], in3[i]};
+
+      // SVF equations (all 4 channels in parallel):
+      // v1 = (ic1eq + g * (v0 - ic2eq)) / (1 + g * (g + k))
+      float32x4_t v1 = vmulq_f32(vaddq_f32(ic1, vmulq_f32(vg, vsubq_f32(v0, ic2))), denom);
+
+      // v2_out = ic2eq + g * v1
+      float32x4_t v2_out = vaddq_f32(ic2, vmulq_f32(vg, v1));
+
+      // Update state: ic1eq = 2*v1 - ic1eq, ic2eq = 2*v2 - ic2eq
+      ic1 = vsubq_f32(vmulq_f32(v2, v1), ic1);
+      ic2 = vsubq_f32(vmulq_f32(v2, v2_out), ic2);
+
+      // Compute output based on filter type
+      float32x4_t result;
+      if constexpr (Type == FilterType::Lowpass) {
+        result = v2_out;
+      } else if constexpr (Type == FilterType::Highpass) {
+        // hp = v0 - k*v1 - v2
+        result = vsubq_f32(vsubq_f32(v0, vmulq_f32(vk, v1)), v2_out);
+      } else if constexpr (Type == FilterType::Bandpass) {
+        result = v1;
+      } else if constexpr (Type == FilterType::Notch) {
+        // notch = lp + hp = v2 + (v0 - k*v1 - v2) = v0 - k*v1
+        result = vsubq_f32(v0, vmulq_f32(vk, v1));
+      }
+
+      // Scatter result to each channel's output buffer
+      out0[i] = vgetq_lane_f32(result, 0);
+      out1[i] = vgetq_lane_f32(result, 1);
+      out2[i] = vgetq_lane_f32(result, 2);
+      out3[i] = vgetq_lane_f32(result, 3);
+    }
+
+    // Store state back
+    vst1q_f32(&_ic1eq[chBase], ic1);
+    vst1q_f32(&_ic2eq[chBase], ic2);
+  }
+#endif
+
+#if defined(SYNTH_HAS_SSE)
+  // SSE SIMD: Process 4 channels simultaneously for one sample
+  template <FilterType Type>
+  inline void processSVF_SSE_4ch(const float *in0, const float *in1, const float *in2, const float *in3,
+                                  float *out0, float *out1, float *out2, float *out3,
+                                  uint32_t nsamples, float g, float k, uint32_t chBase) {
+    // Load state for 4 channels
+    __m128 ic1 = _mm_load_ps(&_ic1eq[chBase]);
+    __m128 ic2 = _mm_load_ps(&_ic2eq[chBase]);
+
+    // Precompute constants
+    __m128 vg = _mm_set1_ps(g);
+    __m128 vk = _mm_set1_ps(k);
+    __m128 v2 = _mm_set1_ps(2.0f);
+    __m128 denom = _mm_set1_ps(1.0f / (1.0f + g * (g + k)));
+
+    for (uint32_t i = 0; i < nsamples; i++) {
+      // Gather sample i from each channel
+      __m128 v0 = _mm_set_ps(in3[i], in2[i], in1[i], in0[i]);
+
+      // SVF equations:
+      // v1 = (ic1eq + g * (v0 - ic2eq)) / (1 + g * (g + k))
+      __m128 v1 = _mm_mul_ps(_mm_add_ps(ic1, _mm_mul_ps(vg, _mm_sub_ps(v0, ic2))), denom);
+
+      // v2_out = ic2eq + g * v1
+      __m128 v2_out = _mm_add_ps(ic2, _mm_mul_ps(vg, v1));
+
+      // Update state
+      ic1 = _mm_sub_ps(_mm_mul_ps(v2, v1), ic1);
+      ic2 = _mm_sub_ps(_mm_mul_ps(v2, v2_out), ic2);
+
+      // Compute output based on filter type
+      __m128 result;
+      if constexpr (Type == FilterType::Lowpass) {
+        result = v2_out;
+      } else if constexpr (Type == FilterType::Highpass) {
+        result = _mm_sub_ps(_mm_sub_ps(v0, _mm_mul_ps(vk, v1)), v2_out);
+      } else if constexpr (Type == FilterType::Bandpass) {
+        result = v1;
+      } else if constexpr (Type == FilterType::Notch) {
+        result = _mm_sub_ps(v0, _mm_mul_ps(vk, v1));
+      }
+
+      // Scatter result to each channel's output buffer
+      alignas(16) float tmp[4];
+      _mm_store_ps(tmp, result);
+      out0[i] = tmp[0];
+      out1[i] = tmp[1];
+      out2[i] = tmp[2];
+      out3[i] = tmp[3];
+    }
+
+    // Store state back
+    _mm_store_ps(&_ic1eq[chBase], ic1);
+    _mm_store_ps(&_ic2eq[chBase], ic2);
+  }
+#endif
+
+  // Scalar fallback: process single channel
+  template <FilterType Type>
+  inline void processSVF_Scalar(const float *in, float *out, uint32_t nsamples, float g, float k, uint32_t ch) {
+    float ic1 = _ic1eq[ch];
+    float ic2 = _ic2eq[ch];
+    const float denom = 1.0f / (1.0f + g * (g + k));
+
+    for (uint32_t i = 0; i < nsamples; i++) {
+      float v0 = in[i];
+
+      // SVF equations
+      float v1 = (ic1 + g * (v0 - ic2)) * denom;
+      float v2_out = ic2 + g * v1;
+
+      // Update state
+      ic1 = 2.0f * v1 - ic1;
+      ic2 = 2.0f * v2_out - ic2;
+
+      // Output based on filter type
+      if constexpr (Type == FilterType::Lowpass) {
+        out[i] = v2_out;
+      } else if constexpr (Type == FilterType::Highpass) {
+        out[i] = v0 - k * v1 - v2_out;
+      } else if constexpr (Type == FilterType::Bandpass) {
+        out[i] = v1;
+      } else if constexpr (Type == FilterType::Notch) {
+        out[i] = v0 - k * v1;
+      }
+    }
+
+    _ic1eq[ch] = ic1;
+    _ic2eq[ch] = ic2;
   }
 
   template <FilterType Type> SHVar processFilter(SHContext *context, const SHVar &input) {
@@ -1071,15 +1207,12 @@ struct Filter {
     const uint32_t channels = audio.channels;
 
     // Get parameters
-    const double cutoff = std::clamp(_cutoff.get().payload.floatValue, 20.0, double(sampleRate) * 0.49);
-    const double resonance = std::clamp(_resonance.get().payload.floatValue, 0.0, 1.0);
+    const float cutoff = float(std::clamp(_cutoff.get().payload.floatValue, 20.0, double(sampleRate) * 0.49));
+    const float resonance = float(std::clamp(_resonance.get().payload.floatValue, 0.0, 1.0));
 
-    // SVF coefficients
-    // g = tan(π * cutoff / sampleRate)
-    const double g = std::tan(M_PI * cutoff / double(sampleRate));
-    // k = 2.0 - 2.0 * resonance (resonance 0 -> k=2, resonance 1 -> k=0)
-    // k=0 gives self-oscillation, we clamp to avoid instability
-    const double k = 2.0 - 2.0 * resonance * 0.99;
+    // SVF coefficients (float for SIMD)
+    const float g = std::tan(float(M_PI) * cutoff / float(sampleRate));
+    const float k = 2.0f - 2.0f * resonance * 0.99f;
 
     // Validate buffer size
     if (nsamples > MAX_SAMPLES || channels > MAX_CHANNELS) {
@@ -1088,29 +1221,34 @@ struct Filter {
 
     _buffer.resize(channels * nsamples);
 
-    // Process each channel independently
-    for (uint32_t ch = 0; ch < channels; ch++) {
+    uint32_t ch = 0;
+
+#if defined(SYNTH_HAS_NEON) || defined(SYNTH_HAS_SSE)
+    // Process groups of 4 channels using SIMD
+    for (; ch + 4 <= channels; ch += 4) {
+      const float *in0 = audio.samples + ch * nsamples;
+      const float *in1 = audio.samples + (ch + 1) * nsamples;
+      const float *in2 = audio.samples + (ch + 2) * nsamples;
+      const float *in3 = audio.samples + (ch + 3) * nsamples;
+
+      float *out0 = _buffer.data() + ch * nsamples;
+      float *out1 = _buffer.data() + (ch + 1) * nsamples;
+      float *out2 = _buffer.data() + (ch + 2) * nsamples;
+      float *out3 = _buffer.data() + (ch + 3) * nsamples;
+
+#if defined(SYNTH_HAS_NEON)
+      processSVF_NEON_4ch<Type>(in0, in1, in2, in3, out0, out1, out2, out3, nsamples, g, k, ch);
+#elif defined(SYNTH_HAS_SSE)
+      processSVF_SSE_4ch<Type>(in0, in1, in2, in3, out0, out1, out2, out3, nsamples, g, k, ch);
+#endif
+    }
+#endif
+
+    // Process remaining channels with scalar code
+    for (; ch < channels; ch++) {
       const float *inSamples = audio.samples + ch * nsamples;
       float *outSamples = _buffer.data() + ch * nsamples;
-      SVFState &state = _svfStates[ch];
-
-      for (uint32_t i = 0; i < nsamples; i++) {
-        double v0 = double(inSamples[i]);
-        double lowpass, highpass, bandpass;
-        processSVF(v0, g, k, state, lowpass, highpass, bandpass);
-
-        // Select output based on filter type (compile-time dispatch)
-        if constexpr (Type == FilterType::Lowpass) {
-          outSamples[i] = float(lowpass);
-        } else if constexpr (Type == FilterType::Highpass) {
-          outSamples[i] = float(highpass);
-        } else if constexpr (Type == FilterType::Bandpass) {
-          outSamples[i] = float(bandpass);
-        } else if constexpr (Type == FilterType::Notch) {
-          // Notch = lowpass + highpass
-          outSamples[i] = float(lowpass + highpass);
-        }
-      }
+      processSVF_Scalar<Type>(inSamples, outSamples, nsamples, g, k, ch);
     }
 
     return Var(makeAudio(_buffer.data(), nsamples, sampleRate, uint8_t(channels)));

--- a/shards/modules/audio/synth.cpp
+++ b/shards/modules/audio/synth.cpp
@@ -725,9 +725,11 @@ struct Envelope {
   PARAM_PARAMVAR(_sustain, "Sustain", "Sustain level (0.0 to 1.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
   PARAM_PARAMVAR(_release, "Release", "Release time in seconds (0.001 to 10.0).", {CoreInfo::FloatType, CoreInfo::FloatVarType});
   PARAM_VAR(_curve, "Curve", "Envelope curve type (Linear or Exponential).", {EnvelopeCurveEnumInfo::Type});
+  PARAM_PARAMVAR(_retrigger, "Retrigger", "If true, retrigger envelope on gate even during Decay/Sustain stages. If false (default), "
+                                          "only retrigger from Idle/Release (legato behavior).", {CoreInfo::BoolType, CoreInfo::BoolVarType});
 
   PARAM_IMPL(PARAM_IMPL_FOR(_attack), PARAM_IMPL_FOR(_decay), PARAM_IMPL_FOR(_sustain), PARAM_IMPL_FOR(_release),
-             PARAM_IMPL_FOR(_curve));
+             PARAM_IMPL_FOR(_curve), PARAM_IMPL_FOR(_retrigger));
 
   // Per-channel state
   struct ChannelState {
@@ -747,6 +749,7 @@ struct Envelope {
     _sustain = Var(0.7);  // 70% sustain level
     _release = Var(0.3);  // 300ms release
     _curve = Var::Enum(Curve::Exponential, CoreCC, EnvelopeCurveEnumInfo::TypeId);
+    _retrigger = Var(false);  // Default to legato behavior
   }
 
   static SHOptionalString help() {
@@ -801,11 +804,12 @@ struct Envelope {
     const double decay = std::max(0.001, _decay.get().payload.floatValue);
     const double sustain = std::clamp(_sustain.get().payload.floatValue, 0.0, 1.0);
     const double release = std::max(0.001, _release.get().payload.floatValue);
+    const bool retrigger = _retrigger.get().payload.boolValue;
 
-    // Calculate samples for each stage
-    const uint64_t attackSamples = uint64_t(attack * sampleRate);
-    const uint64_t decaySamples = uint64_t(decay * sampleRate);
-    const uint64_t releaseSamples = uint64_t(release * sampleRate);
+    // Calculate samples for each stage (round to nearest, minimum 1 sample to avoid div-by-zero)
+    const uint64_t attackSamples = std::max(uint64_t(1), uint64_t(std::round(attack * sampleRate)));
+    const uint64_t decaySamples = std::max(uint64_t(1), uint64_t(std::round(decay * sampleRate)));
+    const uint64_t releaseSamples = std::max(uint64_t(1), uint64_t(std::round(release * sampleRate)));
 
     // Validate buffer size
     if (nsamples > MAX_SAMPLES || channels > MAX_CHANNELS) {
@@ -824,7 +828,11 @@ struct Envelope {
         bool gateOn = gateSamples[i] > 0.0f;
 
         // Handle gate transitions
-        if (gateOn && (state.stage == Stage::Idle || state.stage == Stage::Release)) {
+        // Default (legato): only retrigger from Idle/Release
+        // With Retrigger=true: also retrigger from Decay/Sustain (polyphonic style)
+        bool canRetrigger = (state.stage == Stage::Idle || state.stage == Stage::Release) ||
+                            (retrigger && (state.stage == Stage::Decay || state.stage == Stage::Sustain));
+        if (gateOn && canRetrigger) {
           // Gate on - start attack from current level (smooth retrigger)
           state.stage = Stage::Attack;
           state.attackStartLevel = state.level;  // Remember where we're starting from
@@ -1044,9 +1052,13 @@ struct Filter {
     float32x4_t v2 = vdupq_n_f32(2.0f);
     float32x4_t denom = vdupq_n_f32(1.0f / (1.0f + g * (g + k)));
 
+    // Temp buffer for gather operation (outside loop to avoid repeated stack allocation)
+    alignas(16) float tmp[4];
+
     for (uint32_t i = 0; i < nsamples; i++) {
       // Gather sample i from each channel
-      float32x4_t v0 = {in0[i], in1[i], in2[i], in3[i]};
+      tmp[0] = in0[i]; tmp[1] = in1[i]; tmp[2] = in2[i]; tmp[3] = in3[i];
+      float32x4_t v0 = vld1q_f32(tmp);
 
       // SVF equations (all 4 channels in parallel):
       // v1 = (ic1eq + g * (v0 - ic2eq)) / (1 + g * (g + k))

--- a/shards/tests/math_audio.shs
+++ b/shards/tests/math_audio.shs
@@ -1136,6 +1136,37 @@
   Msg("Audio.Envelope VCA tests passed!")
 })
 
+@wire(test-audio-envelope-retrigger {
+  Msg("Testing Audio.Envelope retrigger behavior...")
+
+  ; Create a gate signal that goes: high -> low -> high (simulating rapid note triggers)
+  ; First 128 samples: gate on (attack/decay)
+  ; Next 64 samples: gate off (release)
+  ; Last 64 samples: gate on again (retrigger test)
+
+  ; Gate signal: 128 samples on, 64 samples off, 64 samples on
+  none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0 Samples: 128 SampleRate: 44100) >= gate-on-1
+  none | Audio.Oscillator(Frequency: 1.0 Amplitude: -1.0 Samples: 64 SampleRate: 44100) = gate-off
+  none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0 Samples: 64 SampleRate: 44100) = gate-on-2
+
+  ; Combine: start with gate-on-1, append off then on again
+  gate-off | AppendTo(gate-on-1)
+  gate-on-2 | AppendTo(gate-on-1)
+  gate-on-1 = combined-gate
+
+  ; Test legato mode (default Retrigger: false)
+  ; During sustain, new gate should NOT restart attack
+  combined-gate | Audio.Envelope(Attack: 0.005 Decay: 0.001 Sustain: 0.8 Release: 0.01) = legato-env
+  legato-env | Log("Legato envelope (Retrigger: false)")
+
+  ; Test polyphonic mode (Retrigger: true)
+  ; During sustain, new gate SHOULD restart attack from current level
+  combined-gate | Audio.Envelope(Attack: 0.005 Decay: 0.001 Sustain: 0.8 Release: 0.01 Retrigger: true) = poly-env
+  poly-env | Log("Polyphonic envelope (Retrigger: true)")
+
+  Msg("Audio.Envelope retrigger tests passed!")
+})
+
 ; ============================================================================
 ; Audio.Filter (SVF) Tests
 ; ============================================================================
@@ -1342,6 +1373,7 @@
 @schedule(main test-audio-envelope-params)
 @schedule(main test-audio-envelope-curves)
 @schedule(main test-audio-envelope-vca)
+@schedule(main test-audio-envelope-retrigger)
 @schedule(main test-audio-filter-types)
 @schedule(main test-audio-filter-resonance)
 @schedule(main test-audio-filter-sweep)

--- a/shards/tests/math_audio.shs
+++ b/shards/tests/math_audio.shs
@@ -1047,6 +1047,234 @@
   Msg("MulAdd variable params test passed!")
 })
 
+; ============================================================================
+; Audio.Envelope (ADSR) Tests
+; ============================================================================
+
+@wire(test-audio-envelope-basic {
+  Msg("Testing Audio.Envelope basic functionality...")
+
+  ; Create a simple gate signal (all positive = gate on for entire buffer)
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 256 SampleRate: 44100) = gate-on
+
+  ; Apply envelope with defaults
+  gate-on | Audio.Envelope = envelope-result
+  envelope-result | Log("Basic envelope with gate on")
+
+  ; Create gate off signal (all zeros)
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 0.0 Samples: 256 SampleRate: 44100) = gate-off
+  gate-off | Audio.Envelope = release-result
+  release-result | Log("Envelope with gate off (release)")
+
+  Msg("Audio.Envelope basic tests passed!")
+})
+
+@wire(test-audio-envelope-params {
+  Msg("Testing Audio.Envelope parameter variations...")
+
+  ; Generate gate signal
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 512 SampleRate: 44100) = gate
+
+  ; Fast attack, slow release
+  gate | Audio.Envelope(Attack: 0.001 Decay: 0.05 Sustain: 0.8 Release: 1.0) = fast-attack
+  fast-attack | Log("Fast attack (1ms), slow release (1s)")
+
+  ; Slow attack, fast release
+  gate | Audio.Envelope(Attack: 0.5 Decay: 0.1 Sustain: 0.5 Release: 0.01) = slow-attack
+  slow-attack | Log("Slow attack (500ms), fast release (10ms)")
+
+  ; Percussive (no sustain)
+  gate | Audio.Envelope(Attack: 0.001 Decay: 0.2 Sustain: 0.0 Release: 0.1) = percussive
+  percussive | Log("Percussive envelope (0 sustain)")
+
+  ; Full sustain (organ-like)
+  gate | Audio.Envelope(Attack: 0.01 Decay: 0.0 Sustain: 1.0 Release: 0.1) = organ
+  organ | Log("Organ envelope (full sustain)")
+
+  Msg("Audio.Envelope parameter tests passed!")
+})
+
+@wire(test-audio-envelope-curves {
+  Msg("Testing Audio.Envelope curve types...")
+
+  ; Generate gate signal
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 256 SampleRate: 44100) = gate
+
+  ; Linear curve
+  gate | Audio.Envelope(Attack: 0.1 Decay: 0.1 Sustain: 0.7 Release: 0.2 Curve: EnvelopeCurve::Linear) = linear
+  linear | Log("Linear envelope curve")
+
+  ; Exponential curve (default)
+  gate | Audio.Envelope(Attack: 0.1 Decay: 0.1 Sustain: 0.7 Release: 0.2 Curve: EnvelopeCurve::Exponential) = exponential
+  exponential | Log("Exponential envelope curve")
+
+  Msg("Audio.Envelope curve tests passed!")
+})
+
+@wire(test-audio-envelope-vca {
+  Msg("Testing Audio.Envelope as VCA...")
+
+  ; Generate oscillator and gate
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 512 SampleRate: 44100) = oscillator
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 512 SampleRate: 44100) = gate
+
+  ; Generate envelope
+  gate | Audio.Envelope(Attack: 0.01 Decay: 0.1 Sustain: 0.7 Release: 0.3) = envelope
+
+  ; Apply envelope to oscillator (VCA)
+  oscillator | Math.Multiply(envelope) = shaped-sound
+  shaped-sound | Log("Oscillator shaped by ADSR envelope")
+
+  ; FM synthesis with envelope
+  none | Audio.Oscillator(Frequency: 220.0 Amplitude: 1.0 Samples: 256 SampleRate: 44100)
+       | Audio.Oscillator(Frequency: 440.0 Index: 3.0) = fm-audio
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 256 SampleRate: 44100)
+       | Audio.Envelope(Attack: 0.005 Decay: 0.2 Sustain: 0.0 Release: 0.1) = fm-envelope
+  fm-audio | Math.Multiply(fm-envelope) = fm-with-envelope
+  fm-with-envelope | Log("FM audio shaped by percussive envelope")
+
+  Msg("Audio.Envelope VCA tests passed!")
+})
+
+; ============================================================================
+; Audio.Filter (SVF) Tests
+; ============================================================================
+
+@wire(test-audio-filter-types {
+  Msg("Testing Audio.Filter types...")
+
+  ; Generate white noise for filtering (shows filter response clearly)
+  none | Audio.Noise(Type: NoiseType::White Amplitude: 0.5 Samples: 256 SampleRate: 44100) = noise
+
+  ; Lowpass filter
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 1000.0 Resonance: 0.5) = lowpass
+  lowpass | Log("Lowpass filter at 1kHz")
+
+  ; Highpass filter
+  noise | Audio.Filter(Type: FilterType::Highpass Cutoff: 1000.0 Resonance: 0.5) = highpass
+  highpass | Log("Highpass filter at 1kHz")
+
+  ; Bandpass filter
+  noise | Audio.Filter(Type: FilterType::Bandpass Cutoff: 1000.0 Resonance: 0.7) = bandpass
+  bandpass | Log("Bandpass filter at 1kHz")
+
+  ; Notch filter
+  noise | Audio.Filter(Type: FilterType::Notch Cutoff: 1000.0 Resonance: 0.5) = notch
+  notch | Log("Notch filter at 1kHz")
+
+  Msg("Audio.Filter type tests passed!")
+})
+
+@wire(test-audio-filter-resonance {
+  Msg("Testing Audio.Filter resonance...")
+
+  ; Generate noise
+  none | Audio.Noise(Type: NoiseType::White Amplitude: 0.5 Samples: 256 SampleRate: 44100) = noise
+
+  ; Low resonance
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 500.0 Resonance: 0.1) = low-res
+  low-res | Log("Lowpass with low resonance (0.1)")
+
+  ; Medium resonance
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 500.0 Resonance: 0.5) = mid-res
+  mid-res | Log("Lowpass with medium resonance (0.5)")
+
+  ; High resonance (near self-oscillation)
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 500.0 Resonance: 0.95) = high-res
+  high-res | Log("Lowpass with high resonance (0.95)")
+
+  Msg("Audio.Filter resonance tests passed!")
+})
+
+@wire(test-audio-filter-sweep {
+  Msg("Testing Audio.Filter with modulated cutoff...")
+
+  ; Generate noise
+  none | Audio.Noise(Type: NoiseType::White Amplitude: 0.5 Samples: 256 SampleRate: 44100) = noise
+
+  ; Different cutoff frequencies
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 200.0 Resonance: 0.6) = low-cutoff
+  low-cutoff | Log("Lowpass at 200Hz")
+
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 2000.0 Resonance: 0.6) = mid-cutoff
+  mid-cutoff | Log("Lowpass at 2kHz")
+
+  noise | Audio.Filter(Type: FilterType::Lowpass Cutoff: 8000.0 Resonance: 0.6) = high-cutoff
+  high-cutoff | Log("Lowpass at 8kHz")
+
+  Msg("Audio.Filter sweep tests passed!")
+})
+
+@wire(test-audio-filter-chain {
+  Msg("Testing Audio.Filter chained operations...")
+
+  ; Generate oscillator
+  none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 0.5 Samples: 256 SampleRate: 44100) = saw
+
+  ; Classic subtractive synth: Oscillator -> Lowpass
+  saw | Audio.Filter(Type: FilterType::Lowpass Cutoff: 800.0 Resonance: 0.7) = filtered-saw
+  filtered-saw | Log("Sawtooth through lowpass (subtractive)")
+
+  ; Double filter (12dB/oct -> 24dB/oct effective slope)
+  saw | Audio.Filter(Type: FilterType::Lowpass Cutoff: 600.0 Resonance: 0.3)
+      | Audio.Filter(Type: FilterType::Lowpass Cutoff: 600.0 Resonance: 0.3) = double-filtered
+  double-filtered | Log("Double lowpass (steeper slope)")
+
+  ; Lowpass then highpass (bandpass effect)
+  none | Audio.Noise(Type: NoiseType::White Amplitude: 0.5 Samples: 256 SampleRate: 44100)
+       | Audio.Filter(Type: FilterType::Lowpass Cutoff: 2000.0 Resonance: 0.3)
+       | Audio.Filter(Type: FilterType::Highpass Cutoff: 500.0 Resonance: 0.3) = band-limited
+  band-limited | Log("LP then HP filter chain")
+
+  Msg("Audio.Filter chain tests passed!")
+})
+
+; ============================================================================
+; Complete Synth Workflow Test (Oscillator + Envelope + Filter)
+; ============================================================================
+
+@wire(test-audio-synth-workflow {
+  Msg("Testing complete synth workflow (VCO + VCF + VCA)...")
+
+  ; Classic subtractive synth patch:
+  ; VCO (sawtooth) -> VCF (lowpass with envelope) -> VCA (amplitude envelope)
+
+  ; Generate sawtooth oscillator (VCO)
+  none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 1.0 Samples: 1024 SampleRate: 44100) = vco
+
+  ; Generate gate
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 1024 SampleRate: 44100) = gate
+
+  ; Generate VCA envelope (amplitude)
+  gate | Audio.Envelope(Attack: 0.01 Decay: 0.2 Sustain: 0.6 Release: 0.5) = vca-env
+  vca-env | Log("VCA envelope")
+
+  ; VCO -> VCF (static filter for this test)
+  vco | Audio.Filter(Type: FilterType::Lowpass Cutoff: 1200.0 Resonance: 0.6) = vcf-out
+  vcf-out | Log("VCO -> VCF output")
+
+  ; VCF -> VCA
+  vcf-out | Math.Multiply(vca-env) = synth-out
+  synth-out | Log("Complete synth output (VCO->VCF->VCA)")
+
+  ; FM synth with filter and envelope
+  none | Audio.Oscillator(Frequency: 220.0 Amplitude: 1.0 Samples: 512 SampleRate: 44100)
+       | Audio.Oscillator(Frequency: 440.0 Index: 2.0 Amplitude: 0.8) = fm-vco
+  fm-vco | Audio.Filter(Type: FilterType::Lowpass Cutoff: 2000.0 Resonance: 0.4)
+         | Math.Multiply(vca-env | Slice(To: 512)) = fm-synth
+  fm-synth | Log("FM synth with filter and envelope")
+
+  ; Noise + filter for hi-hat style sound
+  none | Audio.Noise(Type: NoiseType::White Amplitude: 0.8 Samples: 256 SampleRate: 44100) = noise-vco
+  none | Audio.Oscillator(Frequency: 440.0 Amplitude: 1.0 Samples: 256 SampleRate: 44100)
+       | Audio.Envelope(Attack: 0.001 Decay: 0.05 Sustain: 0.0 Release: 0.05) = hihat-env
+  noise-vco | Audio.Filter(Type: FilterType::Highpass Cutoff: 6000.0 Resonance: 0.3)
+            | Math.Multiply(hihat-env) = hihat
+  hihat | Log("Hi-hat (noise + HP filter + percussive envelope)")
+
+  Msg("Complete synth workflow tests passed!")
+})
+
 @mesh(main)
 @schedule(main test-audio-binary)
 @schedule(main test-audio-unary)
@@ -1089,4 +1317,13 @@
 @schedule(main test-audio-muladd-stereo)
 @schedule(main test-audio-muladd-chain)
 @schedule(main test-audio-muladd-variable-params)
+@schedule(main test-audio-envelope-basic)
+@schedule(main test-audio-envelope-params)
+@schedule(main test-audio-envelope-curves)
+@schedule(main test-audio-envelope-vca)
+@schedule(main test-audio-filter-types)
+@schedule(main test-audio-filter-resonance)
+@schedule(main test-audio-filter-sweep)
+@schedule(main test-audio-filter-chain)
+@schedule(main test-audio-synth-workflow)
 @run(main)

--- a/shards/tests/math_audio.shs
+++ b/shards/tests/math_audio.shs
@@ -1205,6 +1205,27 @@
   Msg("Audio.Filter sweep tests passed!")
 })
 
+@wire(test-audio-filter-multichannel {
+  Msg("Testing Audio.Filter multi-channel SIMD...")
+
+  ; Test with 4 channels (triggers SIMD path)
+  none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 0.5 Samples: 256 SampleRate: 44100 Channels: 4) = quad-audio
+  quad-audio | Audio.Filter(Type: FilterType::Lowpass Cutoff: 1000.0 Resonance: 0.6) = quad-filtered
+  quad-filtered | Log("4-channel filter (SIMD path)")
+
+  ; Test with 5 channels (4 SIMD + 1 scalar)
+  none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 0.5 Samples: 256 SampleRate: 44100 Channels: 5) = five-ch
+  five-ch | Audio.Filter(Type: FilterType::Highpass Cutoff: 500.0 Resonance: 0.4) = five-filtered
+  five-filtered | Log("5-channel filter (4 SIMD + 1 scalar)")
+
+  ; Test with 8 channels (2x SIMD batches)
+  none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 0.5 Samples: 256 SampleRate: 44100 Channels: 8) = octo-audio
+  octo-audio | Audio.Filter(Type: FilterType::Bandpass Cutoff: 800.0 Resonance: 0.7) = octo-filtered
+  octo-filtered | Log("8-channel filter (2x SIMD batches)")
+
+  Msg("Audio.Filter multi-channel tests passed!")
+})
+
 @wire(test-audio-filter-chain {
   Msg("Testing Audio.Filter chained operations...")
 
@@ -1324,6 +1345,7 @@
 @schedule(main test-audio-filter-types)
 @schedule(main test-audio-filter-resonance)
 @schedule(main test-audio-filter-sweep)
+@schedule(main test-audio-filter-multichannel)
 @schedule(main test-audio-filter-chain)
 @schedule(main test-audio-synth-workflow)
 @run(main)

--- a/shards/tests/synth_demo.shs
+++ b/shards/tests/synth_demo.shs
@@ -1,7 +1,11 @@
-; Synth Demo - Audio.Oscillator and Audio.Noise playback demo
+; Synth Demo - Audio.Oscillator, Audio.Noise, Audio.Envelope, Audio.Filter playback demo
 ; Run with: shards run shards/tests/synth_demo.shs
 
 @mesh(main)
+
+; ============================================================================
+; OSCILLATOR DEMOS
+; ============================================================================
 
 ; Simple FM carrier - pure sine tone
 @wire(demo-fm-simple {
@@ -14,6 +18,42 @@
 })
 
 @schedule(main demo-fm-simple)
+@run(main)
+
+; Different waveforms
+@wire(demo-waveforms {
+  Msg("Playing different waveforms...")
+
+  Msg("  Sine wave (smooth)")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Oscillator(Frequency: 220.0 Waveform: Waveform::Sine Amplitude: 0.25)
+  })
+  Pause(1.0)
+
+  Msg("  Triangle wave (mellow)")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Oscillator(Frequency: 220.0 Waveform: Waveform::Triangle Amplitude: 0.25)
+  })
+  Pause(1.0)
+
+  Msg("  Sawtooth wave (bright, buzzy)")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Oscillator(Frequency: 220.0 Waveform: Waveform::Sawtooth Amplitude: 0.2)
+  })
+  Pause(1.0)
+
+  Msg("  Square wave (hollow, reedy)")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Oscillator(Frequency: 220.0 Waveform: Waveform::Square Amplitude: 0.2)
+  })
+  Pause(1.0)
+})
+
+@schedule(main demo-waveforms)
 @run(main)
 
 ; FM with modulation - classic FM sound
@@ -47,9 +87,28 @@
 @schedule(main demo-fm-chain)
 @run(main)
 
+; Exponential FM - modular synth style vibrato
+@wire(demo-exp-fm {
+  Msg("Playing exponential FM (1V/oct style vibrato)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Slow LFO modulating pitch exponentially
+    none | Audio.Oscillator(Frequency: 5.0 Amplitude: 1.0)
+         | Audio.Oscillator(Frequency: 440.0 Amplitude: 0.3 Index: 0.1 FMMode: FMMode::Exponential)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-exp-fm)
+@run(main)
+
+; ============================================================================
+; NOISE DEMOS
+; ============================================================================
+
 ; White noise
 @wire(demo-noise-white {
-  Msg("Playing white noise...")
+  Msg("Playing white noise (bright, hissy)...")
   Audio.Device
   Audio.Channel(Shards: {
     none | Audio.Noise(Type: NoiseType::White Amplitude: 0.15)
@@ -62,7 +121,7 @@
 
 ; Pink noise
 @wire(demo-noise-pink {
-  Msg("Playing pink noise (warmer)...")
+  Msg("Playing pink noise (warmer, natural)...")
   Audio.Device
   Audio.Channel(Shards: {
     none | Audio.Noise(Type: NoiseType::Pink Amplitude: 0.2)
@@ -84,6 +143,281 @@
 })
 
 @schedule(main demo-noise-brown)
+@run(main)
+
+; ============================================================================
+; FILTER DEMOS
+; ============================================================================
+
+; Lowpass filter on noise
+@wire(demo-filter-lowpass {
+  Msg("Playing filtered noise (lowpass at 500Hz)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Noise(Type: NoiseType::White Amplitude: 0.3)
+         | Audio.Filter(Type: FilterType::Lowpass Cutoff: 500.0 Resonance: 0.6)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-filter-lowpass)
+@run(main)
+
+; Highpass filter on noise
+@wire(demo-filter-highpass {
+  Msg("Playing filtered noise (highpass at 2kHz)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Noise(Type: NoiseType::White Amplitude: 0.2)
+         | Audio.Filter(Type: FilterType::Highpass Cutoff: 2000.0 Resonance: 0.5)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-filter-highpass)
+@run(main)
+
+; Resonant filter sweep on sawtooth
+@wire(demo-filter-resonant {
+  Msg("Playing resonant filter on sawtooth...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 0.4)
+         | Audio.Filter(Type: FilterType::Lowpass Cutoff: 800.0 Resonance: 0.85)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-filter-resonant)
+@run(main)
+
+; Bandpass filter for vocal-like formant
+@wire(demo-filter-bandpass {
+  Msg("Playing bandpass filter (formant-like)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Sawtooth Amplitude: 0.4)
+         | Audio.Filter(Type: FilterType::Bandpass Cutoff: 700.0 Resonance: 0.8)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-filter-bandpass)
+@run(main)
+
+; ============================================================================
+; ENVELOPE DEMOS (stateless - envelope applied to constant gate)
+; ============================================================================
+
+; Note: Audio.Envelope is stateful and tracks gate on/off transitions.
+; In a looped Audio.Channel, we generate a constant gate signal per buffer.
+; The envelope will progress through its stages across multiple buffers.
+
+; Percussive pluck sound
+@wire(demo-envelope-pluck {
+  Msg("Playing percussive envelope (pluck)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate signal (constant high)
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; VCO - sawtooth
+    none | Audio.Oscillator(Frequency: 330.0 Waveform: Waveform::Sawtooth Amplitude: 0.5) = vco
+
+    ; VCA envelope - fast attack, quick decay, no sustain
+    gate | Audio.Envelope(Attack: 0.001 Decay: 0.3 Sustain: 0.0 Release: 0.1) = env
+
+    ; VCO * VCA
+    vco | Math.Multiply(env)
+  })
+  Pause(1.5)
+})
+
+@schedule(main demo-envelope-pluck)
+@run(main)
+
+; Pad sound with slow attack
+@wire(demo-envelope-pad {
+  Msg("Playing pad envelope (slow attack)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate signal
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; VCO - sine for smooth pad
+    none | Audio.Oscillator(Frequency: 220.0 Waveform: Waveform::Sine Amplitude: 0.4) = vco
+
+    ; Slow attack envelope
+    gate | Audio.Envelope(Attack: 0.8 Decay: 0.2 Sustain: 0.7 Release: 0.5) = env
+
+    vco | Math.Multiply(env)
+  })
+  Pause(3.0)
+})
+
+@schedule(main demo-envelope-pad)
+@run(main)
+
+; ============================================================================
+; COMPLETE SYNTH PATCHES
+; ============================================================================
+
+; Classic subtractive bass
+@wire(demo-subtractive-bass {
+  Msg("Playing subtractive bass (VCO -> VCF -> VCA)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; VCO - sawtooth bass
+    none | Audio.Oscillator(Frequency: 55.0 Waveform: Waveform::Sawtooth Amplitude: 0.6) = vco
+
+    ; VCF - lowpass with resonance
+    vco | Audio.Filter(Type: FilterType::Lowpass Cutoff: 400.0 Resonance: 0.6) = vcf
+
+    ; VCA envelope - punchy bass
+    gate | Audio.Envelope(Attack: 0.005 Decay: 0.2 Sustain: 0.4 Release: 0.3) = vca-env
+
+    vcf | Math.Multiply(vca-env)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-subtractive-bass)
+@run(main)
+
+; FM electric piano
+@wire(demo-fm-epiano {
+  Msg("Playing FM electric piano...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; FM operators - 2:1 ratio for bell-like tone
+    none | Audio.Oscillator(Frequency: 880.0 Amplitude: 1.0)
+         | Audio.Oscillator(Frequency: 440.0 Amplitude: 0.5 Index: 2.5) = vco
+
+    ; Percussive envelope
+    gate | Audio.Envelope(Attack: 0.001 Decay: 0.8 Sustain: 0.0 Release: 0.2) = env
+
+    vco | Math.Multiply(env)
+  })
+  Pause(2.0)
+})
+
+@schedule(main demo-fm-epiano)
+@run(main)
+
+; Hi-hat
+@wire(demo-hihat {
+  Msg("Playing hi-hat (noise + HP filter + envelope)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; Noise source
+    none | Audio.Noise(Type: NoiseType::White Amplitude: 0.5) = noise
+
+    ; Highpass filter for tinny hi-hat sound
+    noise | Audio.Filter(Type: FilterType::Highpass Cutoff: 7000.0 Resonance: 0.3) = filtered
+
+    ; Very short percussive envelope
+    gate | Audio.Envelope(Attack: 0.001 Decay: 0.08 Sustain: 0.0 Release: 0.05) = env
+
+    filtered | Math.Multiply(env)
+  })
+  Pause(1.0)
+})
+
+@schedule(main demo-hihat)
+@run(main)
+
+; Snare drum
+@wire(demo-snare {
+  Msg("Playing snare drum (noise + tone + envelope)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; Noise component
+    none | Audio.Noise(Type: NoiseType::White Amplitude: 0.4)
+         | Audio.Filter(Type: FilterType::Highpass Cutoff: 2000.0 Resonance: 0.2) = noise
+
+    ; Tone component (low sine for body)
+    none | Audio.Oscillator(Frequency: 180.0 Waveform: Waveform::Sine Amplitude: 0.5) = tone
+
+    ; Mix noise and tone
+    noise | Math.Add(tone) = mix
+
+    ; Short envelope
+    gate | Audio.Envelope(Attack: 0.001 Decay: 0.15 Sustain: 0.0 Release: 0.1) = env
+
+    mix | Math.Multiply(env)
+  })
+  Pause(1.0)
+})
+
+@schedule(main demo-snare)
+@run(main)
+
+; Kick drum
+@wire(demo-kick {
+  Msg("Playing kick drum (sine + pitch envelope)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; Low sine for kick body
+    none | Audio.Oscillator(Frequency: 55.0 Waveform: Waveform::Sine Amplitude: 0.7) = vco
+
+    ; Punchy envelope
+    gate | Audio.Envelope(Attack: 0.001 Decay: 0.25 Sustain: 0.0 Release: 0.1) = env
+
+    vco | Math.Multiply(env)
+  })
+  Pause(1.0)
+})
+
+@schedule(main demo-kick)
+@run(main)
+
+; Atmospheric drone
+@wire(demo-drone {
+  Msg("Playing atmospheric drone (layered oscillators + filter)...")
+  Audio.Device
+  Audio.Channel(Shards: {
+    ; Gate
+    none | Audio.Oscillator(Frequency: 1.0 Amplitude: 1.0) = gate
+
+    ; Layer 1 - fundamental
+    none | Audio.Oscillator(Frequency: 55.0 Waveform: Waveform::Sawtooth Amplitude: 0.3) = osc1
+
+    ; Layer 2 - detuned for thickness
+    none | Audio.Oscillator(Frequency: 55.5 Waveform: Waveform::Sawtooth Amplitude: 0.3) = osc2
+
+    ; Layer 3 - octave up
+    none | Audio.Oscillator(Frequency: 110.0 Waveform: Waveform::Triangle Amplitude: 0.2) = osc3
+
+    ; Mix oscillators
+    osc1 | Math.Add(osc2) | Math.Add(osc3) = mix
+
+    ; Lowpass filter
+    mix | Audio.Filter(Type: FilterType::Lowpass Cutoff: 600.0 Resonance: 0.4) = filtered
+
+    ; Slow envelope
+    gate | Audio.Envelope(Attack: 1.5 Decay: 0.5 Sustain: 0.8 Release: 1.0) = env
+
+    filtered | Math.Multiply(env)
+  })
+  Pause(4.0)
+})
+
+@schedule(main demo-drone)
 @run(main)
 
 ; FM + Noise combo - synth pad with breath


### PR DESCRIPTION
Audio.Envelope:
- ADSR envelope generator with Attack, Decay, Sustain, Release params
- Linear and Exponential curve modes
- Per-channel state tracking for stereo gates
- Retrigger support (gate can restart attack from current level)

Audio.Filter:
- State Variable Filter (Cytomic/Vadim Zavalishin TPT implementation)
- Lowpass, Highpass, Bandpass, and Notch filter types
- Cutoff and Resonance parameters (modulatable)
- Stable at all resonance settings

Also expanded synth_demo.shs with demos for:
- All waveforms, exponential FM vibrato
- Filter types and resonance
- Envelope shapes (pluck, pad)
- Complete synth patches (bass, e-piano, drums, drone)


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
