### PR TITLE
Restore ASAN and TSAN sanitizer support for coroutines

### DIFF
--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -19,7 +19,7 @@ set(CMAKE_C_FLAGS_ASAN
   CACHE STRING "Flags used by the C compiler during AddressSanitizer builds."
   FORCE)
 set(CMAKE_CXX_FLAGS_ASAN
-  "-DBOOST_USE_ASAN -fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
+  "-DSH_USE_ASAN -DBOOST_USE_ASAN -fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
   CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds."
   FORCE)
 

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -119,7 +119,34 @@ static bool checkForConsistentResumer() {
 }
 #endif
 
+#ifdef SH_USE_TSAN
+// Thread-local storage for the main TSAN fiber handle (the fiber that resumes coroutines)
+static thread_local void *tsan_main_fiber = nullptr;
+
+static ALWAYS_INLINE void *getTsanMainFiber() {
+  if (!tsan_main_fiber) {
+    tsan_main_fiber = __tsan_get_current_fiber();
+  }
+  return tsan_main_fiber;
+}
+#endif
+
 Fiber::Fiber(SHStackAllocator allocator) : allocator(allocator) {}
+
+Fiber::~Fiber() {
+#ifdef SH_USE_TSAN
+  if (tsan_fiber) {
+    // Ensure we're not on this fiber's context before destroying
+    // (handles edge case where fiber function returned instead of suspending)
+    void *current_fiber = __tsan_get_current_fiber();
+    if (current_fiber == tsan_fiber) {
+      __tsan_switch_to_fiber(getTsanMainFiber(), 0);
+    }
+    __tsan_destroy_fiber(tsan_fiber);
+    tsan_fiber = nullptr;
+  }
+#endif
+}
 void Fiber::init(std::function<void()> fn) {
 #if SH_DEBUG_CONSISTENT_RESUMER
   consistentResumer.emplace(std::this_thread::get_id());
@@ -127,11 +154,77 @@ void Fiber::init(std::function<void()> fn) {
   creatorStack = getThreadNameStack();
 #endif
 #endif
+
+#ifdef SH_USE_ASAN
+  // Store stack information for ASAN
+  // Stack bottom is the base of the allocated memory (lowest address)
+  // Stack grows downward, so sp (stack pointer) points to the top (highest address)
+  asan_stack_bottom = allocator.mem;
+  asan_stack_size = allocator.size;
+
+  // Unpoison the entire fiber stack to support exception unwinding
+  // Without this, ASAN reports "stack-use-after-return" when exceptions
+  // are thrown because the unwinder accesses stack frames ASAN thinks are invalid
+  __asan_unpoison_memory_region(asan_stack_bottom, asan_stack_size);
+#endif
+
+#ifdef SH_USE_TSAN
+  // Ensure main fiber is captured before we create child fibers
+  getTsanMainFiber();
+
+  // Create TSAN fiber handle for this coroutine
+  // init() should only be called once per Fiber object
+  shassert(!tsan_fiber && "Fiber::init() called twice - this is not supported");
+  tsan_fiber = __tsan_create_fiber(0);
+#endif
+
+#ifdef SH_USE_ASAN
+  // Use a local for the initial switch, then store in member for the lambda
+  void *init_fake_stack = nullptr;
+
+  // Tell ASAN we're about to switch to the fiber's stack
+  __sanitizer_start_switch_fiber(&init_fake_stack, asan_stack_bottom, asan_stack_size);
+
+  // Store in member so lambda can access it safely (local would be dangling after init() returns)
+  asan_init_fake_stack = init_fake_stack;
+#endif
+
+#ifdef SH_USE_TSAN
+  // Switch TSAN tracking to this fiber
+  __tsan_switch_to_fiber(tsan_fiber, 0);
+#endif
+
   continuation.emplace(boost::context::callcc(std::allocator_arg, allocator, [this, fn](boost::context::continuation &&sink) {
     continuation.emplace(std::move(sink));
+
+#ifdef SH_USE_ASAN
+    // We just switched TO this fiber, finish the switch (use member, not captured local)
+    __sanitizer_finish_switch_fiber(asan_init_fake_stack, nullptr, nullptr);
+#endif
+
     fn();
+
+    // The fiber function should never return - it should always suspend
+    // But if it does, we need to clean up sanitizer state
+#ifdef SH_USE_ASAN
+    // Before returning, start switch back to caller (nullptr = main stack)
+    __sanitizer_start_switch_fiber(nullptr, nullptr, 0);
+#endif
+    // Note: TSAN switch is NOT done here - it's handled after callcc returns (line 229)
+    // to avoid duplicate switches when fiber returns vs suspends
+
     return std::move(continuation.value());
   }));
+
+#ifdef SH_USE_ASAN
+  // After callcc returns (fiber yielded back to us), finish the switch back to main stack
+  __sanitizer_finish_switch_fiber(init_fake_stack, nullptr, nullptr);
+#endif
+
+#ifdef SH_USE_TSAN
+  // Switch TSAN tracking back to main fiber after the initial yield
+  __tsan_switch_to_fiber(getTsanMainFiber(), 0);
+#endif
 }
 void Fiber::resume() {
   shassert(continuation);
@@ -139,7 +232,30 @@ void Fiber::resume() {
   if (checkForConsistentResumer() && (!consistentResumer || *consistentResumer != std::this_thread::get_id()))
     throw std::runtime_error("Fiber::resume() called from different thread");
 #endif
+
+#ifdef SH_USE_ASAN
+  // Each context switch needs its own fake_stack (local variable on caller's stack)
+  void *fake_stack = nullptr;
+  // Tell ASAN we're about to switch to the fiber's stack
+  __sanitizer_start_switch_fiber(&fake_stack, asan_stack_bottom, asan_stack_size);
+#endif
+
+#ifdef SH_USE_TSAN
+  // Switch TSAN tracking to this fiber
+  __tsan_switch_to_fiber(tsan_fiber, 0);
+#endif
+
   continuation = continuation->resume();
+
+#ifdef SH_USE_ASAN
+  // Fiber yielded back to us, finish the switch back to main stack
+  __sanitizer_finish_switch_fiber(fake_stack, nullptr, nullptr);
+#endif
+
+#ifdef SH_USE_TSAN
+  // Switch TSAN tracking back to main fiber after fiber yields
+  __tsan_switch_to_fiber(getTsanMainFiber(), 0);
+#endif
 }
 void Fiber::suspend() {
   shassert(continuation);
@@ -147,7 +263,25 @@ void Fiber::suspend() {
   if (checkForConsistentResumer() && (!consistentResumer || *consistentResumer != std::this_thread::get_id()))
     throw std::runtime_error("Fiber::suspend() called from different thread");
 #endif
+
+#ifdef SH_USE_ASAN
+  // Each context switch needs its own fake_stack (local variable on fiber's stack)
+  void *fake_stack = nullptr;
+  // Tell ASAN we're about to switch back to the main stack (nullptr = main stack)
+  __sanitizer_start_switch_fiber(&fake_stack, nullptr, 0);
+#endif
+
+#ifdef SH_USE_TSAN
+  // Switch TSAN tracking back to the main fiber
+  __tsan_switch_to_fiber(getTsanMainFiber(), 0);
+#endif
+
   continuation = continuation->resume();
+
+#ifdef SH_USE_ASAN
+  // We're back on the fiber's stack, finish the switch
+  __sanitizer_finish_switch_fiber(fake_stack, nullptr, nullptr);
+#endif
 }
 Fiber::operator bool() const { return continuation.has_value() && (bool)continuation.value(); }
 

--- a/shards/core/coro.hpp
+++ b/shards/core/coro.hpp
@@ -87,6 +87,38 @@ using Fiber = ThreadFiber;
 #define SH_BOOST_COROUTINE 1
 #include <boost/context/continuation.hpp>
 #include <shards/log/log.hpp>
+
+// ASAN (Address Sanitizer) fiber support
+// These functions inform ASAN about stack switching so it can track the correct stack bounds
+#ifdef SH_USE_ASAN
+#include <sanitizer/asan_interface.h>
+extern "C" {
+// Called before switching to a new fiber stack
+// fake_stack_save: output parameter to save fake stack state (can be nullptr)
+// stack_bottom: bottom of the new fiber's stack
+// stack_size: size of the new fiber's stack
+void __sanitizer_start_switch_fiber(void **fake_stack_save, const void *stack_bottom, size_t stack_size);
+
+// Called after returning from a fiber switch
+// fake_stack_save: the value saved by start_switch_fiber
+// stack_bottom_old: output parameter for the old stack bottom (can be nullptr)
+// stack_size_old: output parameter for the old stack size (can be nullptr)
+void __sanitizer_finish_switch_fiber(void *fake_stack_save, const void **stack_bottom_old, size_t *stack_size_old);
+}
+#endif
+
+// TSAN (Thread Sanitizer) fiber support
+// These functions inform TSAN about fiber context switches to prevent false positive race reports
+#ifdef SH_USE_TSAN
+extern "C" {
+void *__tsan_get_current_fiber(void);
+void *__tsan_create_fiber(unsigned flags);
+void __tsan_destroy_fiber(void *fiber);
+void __tsan_switch_to_fiber(void *fiber, unsigned flags);
+void __tsan_set_fiber_name(void *fiber, const char *name);
+}
+#endif
+
 namespace shards {
 struct SHStackAllocator {
   size_t size{SH_BASE_STACK_SIZE};
@@ -120,8 +152,21 @@ private:
 #endif
 #endif
 
+#ifdef SH_USE_ASAN
+  // ASAN fiber state for stack tracking during context switches
+  const void *asan_stack_bottom{nullptr}; // Bottom of fiber's stack
+  size_t asan_stack_size{0};              // Size of fiber's stack
+  void *asan_init_fake_stack{nullptr};    // Fake stack for init() - accessed by lambda
+#endif
+
+#ifdef SH_USE_TSAN
+  // TSAN fiber handle for tracking fiber context switches
+  void *tsan_fiber{nullptr};
+#endif
+
 public:
   Fiber(SHStackAllocator allocator);
+  ~Fiber();
   Fiber(const Fiber &) = delete;
   Fiber &operator=(const Fiber &) = delete;
   void init(std::function<void()> fn);


### PR DESCRIPTION
Add fiber stack tracking hooks for Address Sanitizer (ASAN) and Thread Sanitizer (TSAN) in the boost::context Fiber implementation:

ASAN support:
- Add __sanitizer_start_switch_fiber/__sanitizer_finish_switch_fiber calls
- Track fiber stack bounds (bottom, size) and fake stack state
- Properly notify ASAN about stack switches in init/resume/suspend

TSAN support:
- Add __tsan_create_fiber/__tsan_destroy_fiber for fiber lifecycle
- Add __tsan_switch_to_fiber calls to track context switches
- Use thread-local main fiber handle for suspend operations

The sanitizer hooks are conditionally compiled with SH_USE_ASAN and SH_USE_TSAN flags, adding zero overhead when sanitizers are disabled.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
