### PR TITLE
Remove RTTI and add -fno-rtti compiler flag

### DIFF
--- a/.github/workflows/build-zig-cross.yml
+++ b/.github/workflows/build-zig-cross.yml
@@ -14,16 +14,18 @@ on:
           - riscv64-linux-musl
   push:
     branches:
-      - feature/zig-cross-compilation
+      - devel
     paths:
       - 'cmake/Zig.cmake'
       - 'cmake/Rust.cmake'
       - 'justfile'
+      - '.github/workflows/build-zig-cross.yml'
   pull_request:
     paths:
       - 'cmake/Zig.cmake'
       - 'cmake/Rust.cmake'
       - 'justfile'
+      - '.github/workflows/build-zig-cross.yml'
 
 jobs:
   build-cross:

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -224,6 +224,9 @@ if(EMSCRIPTEN)
   # Enable web simd
   add_compile_options(-msimd128)
 
+  # Required when RTTI is disabled with embind
+  add_compile_definitions(EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
+
   if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_link_options("-sASSERTIONS=2")
     add_link_options(-gsource-map)
@@ -370,6 +373,8 @@ if(NOT MSVC)
 else()
   # Disable RTTI on MSVC
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/GR->)
+  # Required for Boost.Asio when RTTI is disabled
+  add_compile_definitions(BOOST_ASIO_NO_TYPEID)
 endif()
 
 if(WIN32 AND(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND(CMAKE_BUILD_TYPE STREQUAL "Debug"))

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -369,10 +369,11 @@ if(NOT MSVC)
 else()
   # Disable RTTI on MSVC
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/GR->)
-  # Required for Boost.Asio when RTTI is disabled
-  # NO_TYPEID disables typeid usage, DISABLE_STD_ANY prevents std::any usage (requires RTTI)
-  add_compile_definitions(BOOST_ASIO_NO_TYPEID BOOST_ASIO_DISABLE_STD_ANY)
 endif()
+
+# Required for Boost.Asio when RTTI is disabled (all platforms)
+# NO_TYPEID disables typeid usage, DISABLE_STD_ANY prevents std::any usage (requires RTTI)
+add_compile_definitions(BOOST_ASIO_NO_TYPEID BOOST_ASIO_DISABLE_STD_ANY)
 
 if(WIN32 AND(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND(CMAKE_BUILD_TYPE STREQUAL "Debug"))
   set(USE_LLD_DEFAULT ON)

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -365,7 +365,11 @@ if(NOT MSVC)
     $<$<COMPILE_LANGUAGE:CXX>:-fno-finite-math-only>
     $<$<COMPILE_LANGUAGE:CXX>:-funroll-loops>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-multichar>
+    $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
   )
+else()
+  # Disable RTTI on MSVC
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/GR->)
 endif()
 
 if(WIN32 AND(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND(CMAKE_BUILD_TYPE STREQUAL "Debug"))

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -224,9 +224,6 @@ if(EMSCRIPTEN)
   # Enable web simd
   add_compile_options(-msimd128)
 
-  # Required when RTTI is disabled with embind
-  add_compile_definitions(EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
-
   if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_link_options("-sASSERTIONS=2")
     add_link_options(-gsource-map)
@@ -247,7 +244,6 @@ if(EMSCRIPTEN)
   add_link_options("-sDISABLE_EXCEPTION_CATCHING=0")
 
   add_compile_definitions(NO_FORCE_INLINE)
-  add_link_options(-lembind)
 
   # # if we wanted thread support...
   if(EMSCRIPTEN_PTHREADS)

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -374,7 +374,8 @@ else()
   # Disable RTTI on MSVC
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/GR->)
   # Required for Boost.Asio when RTTI is disabled
-  add_compile_definitions(BOOST_ASIO_NO_TYPEID)
+  # NO_TYPEID disables typeid usage, DISABLE_STD_ANY prevents std::any usage (requires RTTI)
+  add_compile_definitions(BOOST_ASIO_NO_TYPEID BOOST_ASIO_DISABLE_STD_ANY)
 endif()
 
 if(WIN32 AND(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND(CMAKE_BUILD_TYPE STREQUAL "Debug"))

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -97,6 +97,19 @@ EM_JS(void, sh_emscripten_init, (), {
     };
   }
 });
+
+EM_JS(void, sh_setup_core_interface, (uintptr_t log, uintptr_t createMesh, uintptr_t destroyMesh,
+                                       uintptr_t schedule, uintptr_t unschedule, uintptr_t tick, uintptr_t sleep), {
+  Module["SHCore"] = {
+    log: log,
+    createMesh: createMesh,
+    destroyMesh: destroyMesh,
+    schedule: schedule,
+    unschedule: unschedule,
+    tick: tick,
+    sleep: sleep
+  };
+});
 // clang-format on
 #endif
 
@@ -2666,16 +2679,15 @@ void shInit() {
 #if SH_EMSCRIPTEN
   sh_emscripten_init();
   // fill up some interface so we don't need to know mem offsets JS side
-  EM_ASM({ Module["SHCore"] = {}; });
-  emscripten::val shInterface = emscripten::val::module_property("SHCore");
   SHCore *iface = shardsInterface(SHARDS_CURRENT_ABI);
-  shInterface.set("log", emscripten::val(reinterpret_cast<uintptr_t>(iface->log)));
-  shInterface.set("createMesh", emscripten::val(reinterpret_cast<uintptr_t>(iface->createMesh)));
-  shInterface.set("destroyMesh", emscripten::val(reinterpret_cast<uintptr_t>(iface->destroyMesh)));
-  shInterface.set("schedule", emscripten::val(reinterpret_cast<uintptr_t>(iface->schedule)));
-  shInterface.set("unschedule", emscripten::val(reinterpret_cast<uintptr_t>(iface->unschedule)));
-  shInterface.set("tick", emscripten::val(reinterpret_cast<uintptr_t>(iface->tick)));
-  shInterface.set("sleep", emscripten::val(reinterpret_cast<uintptr_t>(iface->sleep)));
+  sh_setup_core_interface(
+    reinterpret_cast<uintptr_t>(iface->log),
+    reinterpret_cast<uintptr_t>(iface->createMesh),
+    reinterpret_cast<uintptr_t>(iface->destroyMesh),
+    reinterpret_cast<uintptr_t>(iface->schedule),
+    reinterpret_cast<uintptr_t>(iface->unschedule),
+    reinterpret_cast<uintptr_t>(iface->tick),
+    reinterpret_cast<uintptr_t>(iface->sleep));
   emscripten_get_now(); // force emscripten to link this call
 #endif
 }

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -51,7 +51,6 @@ using SHTimeDiff = decltype(SHClock::now() - SHDuration(0.0));
 
 #if SH_EMSCRIPTEN
 #include <emscripten.h>
-#include <emscripten/val.h>
 #endif
 
 #ifdef SH_USE_TSAN
@@ -1106,25 +1105,6 @@ template <typename L, typename V = std::enable_if_t<std::is_invocable_v<L>>> voi
     std::rethrow_exception(l.exp);
   }
 }
-
-#ifdef __EMSCRIPTEN__
-template <typename T> inline T emscripten_wait(SHContext *context, emscripten::val promise) {
-  const static emscripten::val futs = emscripten::val::global("ShardsBonder");
-  emscripten::val fut = futs.new_(promise);
-  fut.call<void>("run");
-
-  while (!fut["finished"].as<bool>()) {
-    suspend(context, 0.0);
-  }
-
-  if (fut["hadErrors"].as<bool>()) {
-    throw ActivationError("A javascript async task has failed, check the "
-                          "console for more informations.");
-  }
-
-  return fut["result"].as<T>();
-}
-#endif
 
 #if SH_IOS
 // such as: auto &container = entt::locator<UIViewControllerContainer>::value();

--- a/shards/gfx/drawable.hpp
+++ b/shards/gfx/drawable.hpp
@@ -18,8 +18,15 @@ struct PipelineHashCollector;
 
 typedef detail::DrawableProcessorPtr (*DrawableProcessorConstructor)(Context &);
 
+struct IDebugVisualize;
+
+enum class DrawableType { Unknown, Mesh, MeshTree };
+
 struct IDrawable {
   virtual ~IDrawable() = default;
+
+  virtual DrawableType getDrawableType() const { return DrawableType::Unknown; }
+  virtual IDebugVisualize* asDebugVisualize() { return nullptr; }
 
   // Duplicate self
   virtual DrawablePtr clone() const = 0;

--- a/shards/gfx/drawables/mesh_drawable.hpp
+++ b/shards/gfx/drawables/mesh_drawable.hpp
@@ -26,6 +26,8 @@ private:
   size_t version{};
 
 public:
+  DrawableType getDrawableType() const override { return DrawableType::Mesh; }
+
   MeshPtr mesh;
   MaterialPtr material;
   std::vector<FeaturePtr> features;

--- a/shards/gfx/drawables/mesh_tree_drawable.cpp
+++ b/shards/gfx/drawables/mesh_tree_drawable.cpp
@@ -65,7 +65,8 @@ bool MeshTreeDrawable::expand(shards::pmr::vector<const IDrawable *> &outDrawabl
   TransformUpdaterCollector collector(alloc);
   collector.collector = [&](const DrawablePtr &drawable, const float4x4 &transform) {
     outDrawables.push_back(drawable.get());
-    if (MeshDrawable *md = dynamic_cast<MeshDrawable *>(drawable.get())) {
+    if (drawable->getDrawableType() == DrawableType::Mesh) {
+      MeshDrawable *md = static_cast<MeshDrawable *>(drawable.get());
       if (md->skin) {
         drawablesWithSkinsToUpdate.push_back(md);
       }

--- a/shards/gfx/drawables/mesh_tree_drawable.hpp
+++ b/shards/gfx/drawables/mesh_tree_drawable.hpp
@@ -30,6 +30,9 @@ private:
   size_t lastUpdateVersion = size_t(~0);
 
 public:
+  DrawableType getDrawableType() const override { return DrawableType::MeshTree; }
+  IDebugVisualize* asDebugVisualize() override { return this; }
+
   std::vector<MeshDrawable::Ptr> drawables;
   float4x4 resolvedTransform;
   TRS trs;

--- a/shards/gfx/features/velocity.cpp
+++ b/shards/gfx/features/velocity.cpp
@@ -66,7 +66,8 @@ FeaturePtr Velocity::create(bool applyView, bool applyProjection) {
       auto &drawable = ctx.getDrawable(i);
 
       // Update cached data
-      if (const MeshDrawable *md = dynamic_cast<const MeshDrawable *>(&drawable)) {
+      if (drawable.getDrawableType() == DrawableType::Mesh) {
+        const MeshDrawable *md = static_cast<const MeshDrawable *>(&drawable);
         auto &entry = detail::getCacheEntry(cache->cache, drawable.getId());
         entry.touch(md->transform, ctx.frameCounter);
         if (md->previousTransform) {

--- a/shards/gfx/gfx_events.js
+++ b/shards/gfx/gfx_events.js
@@ -53,8 +53,25 @@ var LibraryGFXEvents = {
   },
   $gfxSetup__deps: ["$Browser", "$callNonAsync"],
   $gfxSetup(canvasContainer, canvas) {
-    const eh = this.getEventHandler();
-    this.eventHandlerSetCanvas(eh, canvas.id, canvasContainer.id);
+    // Use direct C function calls instead of embind
+    const eh = Module._gfxGetEventHandler();
+
+    // For strings, use ccall which handles string conversion
+    Module.ccall('gfxEventHandlerSetCanvas', null, ['number', 'string', 'string'], [eh, canvas.id, canvasContainer.id]);
+
+    // Helper functions that call C directly with individual parameters
+    const postKeyEvent = (type, domKey, key, ctrlKey, altKey, shiftKey, repeat) => {
+      Module._gfxEventHandlerPostKeyEvent(eh, type, domKey, key, ctrlKey ? 1 : 0, altKey ? 1 : 0, shiftKey ? 1 : 0, repeat ? 1 : 0);
+    };
+    const postMouseEvent = (type, x, y, button, movementX, movementY) => {
+      Module._gfxEventHandlerPostMouseEvent(eh, type, x, y, button, movementX, movementY);
+    };
+    const postWheelEvent = (deltaY) => {
+      Module._gfxEventHandlerPostWheelEvent(eh, deltaY);
+    };
+    const postDisplayFormat = (width, height, cwidth, cheight, pixelRatio) => {
+      Module._gfxEventHandlerPostDisplayFormat(eh, width, height, cwidth, cheight, pixelRatio);
+    };
 
     // Send initial display format synchronously before graphics starts
     // IMPORTANT: Must set canvas.width/height (intrinsic size) for WebGPU surface
@@ -66,23 +83,20 @@ var LibraryGFXEvents = {
       let canvasHeight = rect.height * pixelRatio;
       canvas.width = canvasWidth;
       canvas.height = canvasHeight;
-      this.eventHandlerPostDisplayFormat(eh, rect.width, rect.height, canvasWidth, canvasHeight, pixelRatio);
+      postDisplayFormat(rect.width, rect.height, canvasWidth, canvasHeight, pixelRatio);
     }
 
     canvasContainer.onmousemove = (e) => {
-      e.type_ = 0;
-      callNonAsync(() => this.eventHandlerPostMouseEvent(eh, e));
+      callNonAsync(() => postMouseEvent(0, e.x, e.y, e.button, e.movementX, e.movementY));
     };
-    const handleMouseEvent = (e) => {
-      callNonAsync(() => this.eventHandlerPostMouseEvent(eh, e));
+    const handleMouseEvent = (e, type) => {
+      callNonAsync(() => postMouseEvent(type, e.x, e.y, e.button, e.movementX, e.movementY));
     };
     canvasContainer.onmousedown = (e) => {
-      e.type_ = 1;
-      handleMouseEvent(e);
+      handleMouseEvent(e, 1);
     };
     canvasContainer.onmouseup = (e) => {
-      e.type_ = 2;
-      handleMouseEvent(e);
+      handleMouseEvent(e, 2);
     };
     canvasContainer.oncontextmenu = (e) => {
       e.preventDefault();
@@ -96,25 +110,19 @@ var LibraryGFXEvents = {
       state.cursorInPage = true;
     };
     const trapKeyEvents = (code) => { return state.cursorInPage; };
-    const handleKeyEvent = (event) => {
-      event.domKey_ = event.keyCode;
-      if (event.key.length == 1) {
-        event.key_ = event.key.codePointAt(0);
-      } else {
-        event.key_ = 0;
-      }
-      callNonAsync(() => this.eventHandlerPostKeyEvent(eh, event));
+    const handleKeyEvent = (event, type) => {
+      const domKey = event.keyCode;
+      const key = (event.key.length == 1) ? event.key.codePointAt(0) : 0;
+      callNonAsync(() => postKeyEvent(type, domKey, key, event.ctrlKey, event.altKey, event.shiftKey, event.repeat));
     };
     window.addEventListener('keydown', (event) => {
       if (trapKeyEvents(event.code)) {
-        event.type_ = 0;
-        handleKeyEvent(event);
+        handleKeyEvent(event, 0);
         event.preventDefault();
       }
     }, true);
     window.addEventListener('keyup', (event) => {
-      event.type_ = 1;
-      handleKeyEvent(event);
+      handleKeyEvent(event, 1);
       if (trapKeyEvents(event.code)) {
         event.preventDefault();
       }
@@ -128,7 +136,7 @@ var LibraryGFXEvents = {
       // Quantize to integer so that minimum scroll is at least +/- 1.
       deltaY = (deltaY == 0) ? 0 : (deltaY > 0 ? Math.max(deltaY, 1) : Math.min(deltaY, -1));
 
-      callNonAsync(() => this.eventHandlerPostWheelEvent(eh, { deltaY: deltaY }));
+      callNonAsync(() => postWheelEvent(deltaY));
     });
 
     (async function resizeCanvasLoop() {
@@ -143,14 +151,14 @@ var LibraryGFXEvents = {
           // Update canvas intrinsic size for WebGPU surface
           canvas.width = canvasWidth;
           canvas.height = canvasHeight;
-          callNonAsync(() => this.eventHandlerPostDisplayFormat(eh, rect.width, rect.height, canvasWidth, canvasHeight, pixelRatio));
+          callNonAsync(() => postDisplayFormat(rect.width, rect.height, canvasWidth, canvasHeight, pixelRatio));
           lastW = rect.width;
           lastH = rect.height;
           lastPixelRatio = pixelRatio;
         }
         await new Promise(done => setTimeout(done, 1));
       }
-    }.bind(this))();
+    })();
   }
 };
 

--- a/shards/gfx/gfx_events_em.cpp
+++ b/shards/gfx/gfx_events_em.cpp
@@ -1,5 +1,5 @@
 #include "gfx_events_em.hpp"
-#include <emscripten/bind.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 
 namespace gfx::em {
@@ -27,32 +27,60 @@ void eventHandlerPostDisplayFormat(EventHandler *eh, int32_t width, int32_t heig
   SPDLOG_INFO("Display format: {}x{}, canvas: {}x{}, pixelRatio: {}", width, height, cwidth, cheight, pixelRatio);
 }
 
-EMSCRIPTEN_BINDINGS(gfx_events) {
-  emscripten::class_<EventHandler>("EventHandler");
-  emscripten::value_object<KeyEvent>("KeyEvent") //
-      .field("type_", &KeyEvent::type_)
-      .field("domKey_", &KeyEvent::domKey_)
-      .field("key_", &KeyEvent::key_)
-      .field("ctrlKey", &KeyEvent::ctrlKey)
-      .field("altKey", &KeyEvent::altKey)
-      .field("shiftKey", &KeyEvent::shiftKey)
-      .field("repeat", &KeyEvent::repeat);
-  emscripten::value_object<MouseEvent>("MouseEvent") //
-      .field("type_", &MouseEvent::type_)
-      .field("x", &MouseEvent::x)
-      .field("y", &MouseEvent::y)
-      .field("button", &MouseEvent::button)
-      .field("movementX", &MouseEvent::movementX)
-      .field("movementY", &MouseEvent::movementY);
-  emscripten::value_object<MouseWheelEvent>("MouseWheelEvent") //
-      .field("deltaY", &MouseWheelEvent::deltaY);
-
-  emscripten::function("getEventHandler", &getEventHandler, emscripten::allow_raw_pointers());
-  emscripten::function("eventHandlerSetCanvas", &eventHandlerSetCanvas, emscripten::allow_raw_pointers());
-  emscripten::function("eventHandlerPostKeyEvent", &eventHandlerPostKeyEvent, emscripten::allow_raw_pointers());
-  emscripten::function("eventHandlerPostMouseEvent", &eventHandlerPostMouseEvent, emscripten::allow_raw_pointers());
-  emscripten::function("eventHandlerPostWheelEvent", &eventHandlerPostWheelEvent, emscripten::allow_raw_pointers());
-  emscripten::function("eventHandlerPostDisplayFormat", &eventHandlerPostDisplayFormat, emscripten::allow_raw_pointers());
-  emscripten::function("eventHandlerTryFlush", &eventHandlerTryFlush, emscripten::allow_raw_pointers());
-}
 } // namespace gfx::em
+
+// C API for JavaScript - replaces embind
+extern "C" {
+
+EMSCRIPTEN_KEEPALIVE
+gfx::em::EventHandler *gfxGetEventHandler() { return gfx::em::getEventHandler(); }
+
+EMSCRIPTEN_KEEPALIVE
+void gfxEventHandlerSetCanvas(gfx::em::EventHandler *eh, const char *canvasId, const char *containerId) {
+  gfx::em::eventHandlerSetCanvas(eh, canvasId, containerId);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void gfxEventHandlerTryFlush(gfx::em::EventHandler *eh) { gfx::em::eventHandlerTryFlush(eh); }
+
+EMSCRIPTEN_KEEPALIVE
+void gfxEventHandlerPostKeyEvent(gfx::em::EventHandler *eh, int32_t type, int32_t domKey, uint32_t key,
+                                  bool ctrlKey, bool altKey, bool shiftKey, bool repeat) {
+  gfx::em::KeyEvent ke{};
+  ke.type_ = type;
+  ke.domKey_ = domKey;
+  ke.key_ = key;
+  ke.ctrlKey = ctrlKey;
+  ke.altKey = altKey;
+  ke.shiftKey = shiftKey;
+  ke.repeat = repeat;
+  gfx::em::eventHandlerPostKeyEvent(eh, ke);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void gfxEventHandlerPostMouseEvent(gfx::em::EventHandler *eh, int32_t type, int32_t x, int32_t y,
+                                    int32_t button, int32_t movementX, int32_t movementY) {
+  gfx::em::MouseEvent me{};
+  me.type_ = type;
+  me.x = x;
+  me.y = y;
+  me.button = button;
+  me.movementX = movementX;
+  me.movementY = movementY;
+  gfx::em::eventHandlerPostMouseEvent(eh, me);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void gfxEventHandlerPostWheelEvent(gfx::em::EventHandler *eh, float deltaY) {
+  gfx::em::MouseWheelEvent we{};
+  we.deltaY = deltaY;
+  gfx::em::eventHandlerPostWheelEvent(eh, we);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void gfxEventHandlerPostDisplayFormat(gfx::em::EventHandler *eh, int32_t width, int32_t height,
+                                       int32_t cwidth, int32_t cheight, float pixelRatio) {
+  gfx::em::eventHandlerPostDisplayFormat(eh, width, height, cwidth, cheight, pixelRatio);
+}
+
+}

--- a/shards/gfx/gizmos/wireframe.cpp
+++ b/shards/gfx/gizmos/wireframe.cpp
@@ -75,15 +75,17 @@ void WireframeRenderer::reset(size_t frameCounter) {
   currentFrameCounter = frameCounter;
 }
 void WireframeRenderer::overlayWireframe(DrawQueue &queue, IDrawable &drawable, float4 color) {
-  if (MeshDrawable *meshDrawable = dynamic_cast<MeshDrawable *>(&drawable)) {
-    auto drawable = getWireframeDrawable(meshDrawable->mesh, color);
-    drawable->skin = meshDrawable->skin; // Make sure to copy source skin so the wireframe can be animated
-    drawable->transform = meshDrawable->transform;
-    queue.add(drawable);
-  } else if (MeshTreeDrawable *treeDrawable = dynamic_cast<MeshTreeDrawable *>(&drawable)) {
+  if (drawable.getDrawableType() == DrawableType::Mesh) {
+    MeshDrawable *meshDrawable = static_cast<MeshDrawable *>(&drawable);
+    auto wireframeDrawable = getWireframeDrawable(meshDrawable->mesh, color);
+    wireframeDrawable->skin = meshDrawable->skin; // Make sure to copy source skin so the wireframe can be animated
+    wireframeDrawable->transform = meshDrawable->transform;
+    queue.add(wireframeDrawable);
+  } else if (drawable.getDrawableType() == DrawableType::MeshTree) {
+    MeshTreeDrawable *treeDrawable = static_cast<MeshTreeDrawable *>(&drawable);
     allocator->reset();
     TransformUpdaterCollector collector(*allocator.get());
-    collector.collector = [&](DrawablePtr drawable, const float4x4 &) { overlayWireframe(queue, *drawable.get(), color); };
+    collector.collector = [&](DrawablePtr d, const float4x4 &) { overlayWireframe(queue, *d.get(), color); };
     collector.update(*treeDrawable);
   }
 }

--- a/shards/gfx/render_step_impl.cpp
+++ b/shards/gfx/render_step_impl.cpp
@@ -193,7 +193,7 @@ void renderDrawables(RenderGraphEncodeContext &evaluateContext, DrawQueuePtr que
     if (storage.debug && queue->trace) {
       for (auto &drawable : drawables) {
         auto ptr = drawable->self();
-        if (auto debug = dynamic_cast<IDebugVisualize *>(const_cast<IDrawable *>(drawable))) {
+        if (auto debug = const_cast<IDrawable *>(drawable)->asDebugVisualize()) {
           storage.debugVisualize([ptr, debug](auto &sr) { debug->debugVisualize(sr); });
         }
       }

--- a/shards/input/master.hpp
+++ b/shards/input/master.hpp
@@ -16,6 +16,11 @@ struct Window;
 }
 
 namespace shards::input {
+
+namespace debug {
+struct IDebug;
+}
+
 struct FocusTracker {
   void *previous{};
   void *current{};
@@ -52,6 +57,7 @@ struct InputMaster;
 
 struct IInputHandler {
   virtual ~IInputHandler() = default;
+  virtual debug::IDebug* asDebug() { return nullptr; }
   virtual int getPriority() const { return 0; }
   virtual void handle(InputMaster &master) = 0;
 };

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -3008,58 +3008,6 @@ SHVar emscriptenEvalActivation(const SHVar &input) {
   return Var(str);
 }
 
-/*
-using embind fails inside workers... that's why we implemented it using js
-yet using async in workers is still broken so let's use embind for now
-*/
-struct EmscriptenAsyncEval {
-  static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
-  static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
-
-  SHVar activate(SHContext *context, const SHVar &input) {
-    static thread_local std::string str;
-    const static emscripten::val eval = emscripten::val::global("eval");
-    str = emscripten_wait<std::string>(context, eval(emscripten::val(input.payload.stringValue)));
-    return Var(str);
-  }
-};
-
-// struct EmscriptenAsyncEval {
-//   static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
-//   static SHTypesInfo outputTypes() { return CoreInfo::StringType; }
-
-//   SHVar activate(SHContext *context, const SHVar &input) {
-//     static thread_local std::string str;
-//     static thread_local size_t slots;
-
-//     size_t slot = ++slots;
-//     const auto startCheck = emEvalAsyncRun(input.payload.stringValue, slot);
-//     if (!startCheck) {
-//       throw ActivationError("Failed to start a javascript async task.");
-//     }
-
-//     while (true) {
-//       const auto runCheck = emEvalAsyncCheck(slot);
-//       if (runCheck == 0) {
-//         suspend(context, 0.0);
-//       } else if (runCheck == -1) {
-//         throw ActivationError("Failure on the javascript side, check
-//         console");
-//       } else {
-//         break;
-//       }
-//     }
-
-//     const auto res = emEvalAsyncGet(slot);
-//     str.clear();
-//     if (res) {
-//       str.assign(res);
-//       free(res);
-//     }
-//     return Var(str);
-//   }
-// };
-
 SHVar emscriptenBrowseActivation(const SHVar &input) {
   emBrowsePage(input.payload.stringValue);
   return Var(input);
@@ -3850,8 +3798,6 @@ SHARDS_REGISTER_FN(core) {
   using EmscriptenEvalShard = LambdaShard<emscriptenEvalActivation, CoreInfo::StringType, CoreInfo::StringType>;
   // _ prefix = internal shard
   REGISTER_SHARD("_Emscripten.Eval", EmscriptenEvalShard);
-  // _ prefix = internal shard
-  REGISTER_SHARD("_Emscripten.EvalAsync", EmscriptenAsyncEval);
   using EmscriptenBrowseShard = LambdaShard<emscriptenBrowseActivation, CoreInfo::StringType, CoreInfo::StringType>;
   REGISTER_SHARD("Browse", EmscriptenBrowseShard);
 #else

--- a/shards/modules/egui/debug_ui.cpp
+++ b/shards/modules/egui/debug_ui.cpp
@@ -34,7 +34,7 @@ size_t shards_input_eventType(shards::input::debug::OpaqueEvent opaque) {
   return evt.event.index();
 }
 const char *shards_input_layerName(shards::input::debug::OpaqueLayer opaque) {
-  auto layer = dynamic_cast<shards::input::debug::IDebug *>((shards::input::IInputHandler *)opaque);
+  auto layer = ((shards::input::IInputHandler *)opaque)->asDebug();
   if (layer) {
     return shards_strdup(layer->getDebugName());
   } else {
@@ -145,7 +145,7 @@ struct DebugUI {
       auto &layer = _layers.emplace_back();
       layer.priority = handler->getPriority();
 
-      if (debug::IDebug *debug = dynamic_cast<debug::IDebug *>(handler.get())) {
+      if (debug::IDebug *debug = handler->asDebug()) {
         auto &str = _strings.emplace_back(debug->getDebugName());
         layer.name = str.c_str();
         layer.hasFocus = master.getFocusTracker().hasFocus(handler.get());

--- a/shards/modules/gfx/gfx.hpp
+++ b/shards/modules/gfx/gfx.hpp
@@ -38,10 +38,10 @@ struct SHDrawable {
   bool rootNodeWrapped{};
 
   void assign(const std::shared_ptr<IDrawable> &generic) {
-    if (auto mesh = std::dynamic_pointer_cast<MeshDrawable>(generic)) {
-      this->drawable = mesh;
-    } else if (auto meshTree = std::dynamic_pointer_cast<MeshTreeDrawable>(generic)) {
-      this->drawable = meshTree;
+    if (generic->getDrawableType() == DrawableType::Mesh) {
+      this->drawable = std::static_pointer_cast<MeshDrawable>(generic);
+    } else if (generic->getDrawableType() == DrawableType::MeshTree) {
+      this->drawable = std::static_pointer_cast<MeshTreeDrawable>(generic);
     } else {
       throw std::logic_error("unsupported");
     }

--- a/shards/modules/inputs/detached.cpp
+++ b/shards/modules/inputs/detached.cpp
@@ -161,6 +161,7 @@ struct InputThreadHandler : public std::enable_shared_from_this<InputThreadHandl
   }
 
   const char *getDebugName() override { return name.c_str(); }
+  debug::IDebug* asDebug() override { return this; }
 
   int getPriority() const override { return priority; }
 

--- a/shards/modules/physics/debug.cpp
+++ b/shards/modules/physics/debug.cpp
@@ -102,7 +102,7 @@ struct DebugRenderer : public JPH::DebugRenderer {
     shassert(lodIdx >= 0 && lodIdx < inGeometry->mLODs.size() && "Invalid LOD index");
 
     auto lod = inGeometry->mLODs[lodIdx].mTriangleBatch;
-    GFXBatch *gfxBatch = dynamic_cast<GFXBatch *>(lod.GetPtr());
+    GFXBatch *gfxBatch = static_cast<GFXBatch *>(lod.GetPtr());
     float4x4 transform{
         toLinalg(inModelMatrix.GetColumn4(0)),
         toLinalg(inModelMatrix.GetColumn4(1)),

--- a/shards/modules/physics/shapes.cpp
+++ b/shards/modules/physics/shapes.cpp
@@ -183,7 +183,8 @@ struct PointsBuilder {
     gfx::TransformUpdaterCollector collector(tempAllocator.getAllocator());
     collector.ignoreRootTransform = true;
     collector.collector = [&](const gfx::DrawablePtr &drawable, const float4x4 &worldTransform) {
-      if (gfx::MeshDrawable::Ptr ptr = std::dynamic_pointer_cast<gfx::MeshDrawable>(drawable)) {
+      if (drawable->getDrawableType() == gfx::DrawableType::Mesh) {
+        gfx::MeshDrawable::Ptr ptr = std::static_pointer_cast<gfx::MeshDrawable>(drawable);
         this->addDrawable(ptr, worldTransform);
       }
     };

--- a/shards/modules/physics/soft_body.cpp
+++ b/shards/modules/physics/soft_body.cpp
@@ -308,7 +308,8 @@ struct SoftBodyBuilder {
     gfx::TransformUpdaterCollector collector(tempAllocator.getAllocator());
     collector.ignoreRootTransform = true;
     collector.collector = [&](const gfx::DrawablePtr &drawable, const float4x4 &worldTransform) {
-      if (gfx::MeshDrawable::Ptr ptr = std::dynamic_pointer_cast<gfx::MeshDrawable>(drawable)) {
+      if (drawable->getDrawableType() == gfx::DrawableType::Mesh) {
+        gfx::MeshDrawable::Ptr ptr = std::static_pointer_cast<gfx::MeshDrawable>(drawable);
         this->addDrawable(ptr, worldTransform);
       }
     };


### PR DESCRIPTION
Replace all dynamic_cast usages with type-based dispatch:
- Add DrawableType enum and getDrawableType() to IDrawable
- Add asDebugVisualize() for optional interface access
- Add asDebug() to IInputHandler for debug naming interface
- Replace dynamic_pointer_cast with type checks + static_pointer_cast

Enable -fno-rtti globally in cmake/Platform.cmake for all platforms. Dependencies (oneTBB, CLI11) handle RTTI conditionally and work correctly.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
