### PR TITLE
Add custom assembly-based fcontext to replace boost::context dependency

### DIFF
--- a/shards/core/CMakeLists.txt
+++ b/shards/core/CMakeLists.txt
@@ -149,16 +149,9 @@ set(SH_USE_BOOST_CONTEXT OFF CACHE BOOL
 if(NOT EMSCRIPTEN)
   target_link_libraries(shards-core Boost::beast Boost::asio)
 
-  if(SH_USE_BOOST_CONTEXT)
-    # Use Boost.Context for coroutines
-    message(STATUS "Shards: Using Boost.Context for fiber support")
-    target_link_libraries(shards-core Boost::context)
-  else()
-    # Use custom assembly-based fcontext
-    message(STATUS "Shards: Using custom fcontext assembly for fiber support")
-    target_compile_definitions(shards-core PUBLIC SH_CUSTOM_FCONTEXT=1)
-
-    # Detect architecture and select appropriate assembly file
+  # Detect architecture and check if custom fcontext is supported
+  set(FCONTEXT_SUPPORTED OFF)
+  if(NOT SH_USE_BOOST_CONTEXT)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
       if(WIN32)
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_ms_pe.S")
@@ -170,6 +163,7 @@ if(NOT EMSCRIPTEN)
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_sysv_elf.S")
         message(STATUS "Shards: Selected x86_64 Linux fcontext assembly")
       endif()
+      set(FCONTEXT_SUPPORTED ON)
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
       if(APPLE)
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm64_aapcs_macho.S")
@@ -178,25 +172,39 @@ if(NOT EMSCRIPTEN)
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm64_aapcs_elf.S")
         message(STATUS "Shards: Selected ARM64 Linux fcontext assembly")
       endif()
+      set(FCONTEXT_SUPPORTED ON)
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64|riscv32|RISCV")
       set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_riscv_elf.S")
       message(STATUS "Shards: Selected RISC-V fcontext assembly")
+      set(FCONTEXT_SUPPORTED ON)
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM")
       set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm_aapcs_elf.S")
       message(STATUS "Shards: Selected ARM32 fcontext assembly")
+      set(FCONTEXT_SUPPORTED ON)
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[36]86|x86")
       set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_sysv_elf.S")
       message(STATUS "Shards: Selected x86 (32-bit) fcontext assembly")
+      set(FCONTEXT_SUPPORTED ON)
     else()
-      message(FATAL_ERROR "Unsupported architecture for custom fcontext: ${CMAKE_SYSTEM_PROCESSOR}. "
-        "Set SH_USE_BOOST_CONTEXT=ON to use Boost.Context instead.")
+      message(WARNING "Unsupported architecture for custom fcontext: ${CMAKE_SYSTEM_PROCESSOR}. "
+        "Falling back to Boost.Context.")
     endif()
+  endif()
+
+  if(FCONTEXT_SUPPORTED)
+    # Use custom assembly-based fcontext
+    message(STATUS "Shards: Using custom fcontext assembly for fiber support")
+    target_compile_definitions(shards-core PUBLIC SH_CUSTOM_FCONTEXT=1)
 
     # Add assembly file to sources
     target_sources(shards-core PRIVATE ${FCONTEXT_ASM_FILE})
 
     # Enable ASM language if not already enabled
     enable_language(ASM)
+  else()
+    # Use Boost.Context for coroutines
+    message(STATUS "Shards: Using Boost.Context for fiber support")
+    target_link_libraries(shards-core Boost::context)
   endif()
 else()
   target_include_directories(shards-core PUBLIC $<TARGET_PROPERTY:Boost::asio,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/shards/core/CMakeLists.txt
+++ b/shards/core/CMakeLists.txt
@@ -142,15 +142,9 @@ endif()
 target_link_libraries(shards-core Boost::filesystem Boost::lockfree Boost::foreach Boost::multiprecision Boost::atomic Boost::thread Boost::tti)
 
 # Custom fcontext implementation option
-# Default OFF (use custom assembly), ON for Windows (uses Boost::context)
-if(WIN32)
-  set(SH_USE_BOOST_CONTEXT_DEFAULT ON)
-else()
-  set(SH_USE_BOOST_CONTEXT_DEFAULT OFF)
-endif()
-
-set(SH_USE_BOOST_CONTEXT ${SH_USE_BOOST_CONTEXT_DEFAULT} CACHE BOOL
-  "Use Boost.Context instead of custom assembly for fiber support (required on Windows)")
+# Default OFF (use custom assembly) for all platforms including Windows
+set(SH_USE_BOOST_CONTEXT OFF CACHE BOOL
+  "Use Boost.Context instead of custom assembly for fiber support")
 
 if(NOT EMSCRIPTEN)
   target_link_libraries(shards-core Boost::beast Boost::asio)
@@ -166,19 +160,24 @@ if(NOT EMSCRIPTEN)
 
     # Detect architecture and select appropriate assembly file
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
-      if(APPLE)
+      if(WIN32)
+        set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_ms_pe.S")
+        message(STATUS "Shards: Selected x86_64 Windows fcontext assembly")
+      elseif(APPLE)
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_sysv_macho.S")
+        message(STATUS "Shards: Selected x86_64 macOS fcontext assembly")
       else()
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_sysv_elf.S")
+        message(STATUS "Shards: Selected x86_64 Linux fcontext assembly")
       endif()
-      message(STATUS "Shards: Selected x86_64 fcontext assembly")
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
       if(APPLE)
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm64_aapcs_macho.S")
+        message(STATUS "Shards: Selected ARM64 macOS fcontext assembly")
       else()
         set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm64_aapcs_elf.S")
+        message(STATUS "Shards: Selected ARM64 Linux fcontext assembly")
       endif()
-      message(STATUS "Shards: Selected ARM64 fcontext assembly")
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64|riscv32|RISCV")
       set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_riscv_elf.S")
       message(STATUS "Shards: Selected RISC-V fcontext assembly")

--- a/shards/core/CMakeLists.txt
+++ b/shards/core/CMakeLists.txt
@@ -141,8 +141,64 @@ endif()
 
 target_link_libraries(shards-core Boost::filesystem Boost::lockfree Boost::foreach Boost::multiprecision Boost::atomic Boost::thread Boost::tti)
 
+# Custom fcontext implementation option
+# Default OFF (use custom assembly), ON for Windows (uses Boost::context)
+if(WIN32)
+  set(SH_USE_BOOST_CONTEXT_DEFAULT ON)
+else()
+  set(SH_USE_BOOST_CONTEXT_DEFAULT OFF)
+endif()
+
+set(SH_USE_BOOST_CONTEXT ${SH_USE_BOOST_CONTEXT_DEFAULT} CACHE BOOL
+  "Use Boost.Context instead of custom assembly for fiber support (required on Windows)")
+
 if(NOT EMSCRIPTEN)
-  target_link_libraries(shards-core Boost::beast Boost::asio Boost::context)
+  target_link_libraries(shards-core Boost::beast Boost::asio)
+
+  if(SH_USE_BOOST_CONTEXT)
+    # Use Boost.Context for coroutines
+    message(STATUS "Shards: Using Boost.Context for fiber support")
+    target_link_libraries(shards-core Boost::context)
+  else()
+    # Use custom assembly-based fcontext
+    message(STATUS "Shards: Using custom fcontext assembly for fiber support")
+    target_compile_definitions(shards-core PUBLIC SH_CUSTOM_FCONTEXT=1)
+
+    # Detect architecture and select appropriate assembly file
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
+      if(APPLE)
+        set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_sysv_macho.S")
+      else()
+        set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_64_sysv_elf.S")
+      endif()
+      message(STATUS "Shards: Selected x86_64 fcontext assembly")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+      if(APPLE)
+        set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm64_aapcs_macho.S")
+      else()
+        set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm64_aapcs_elf.S")
+      endif()
+      message(STATUS "Shards: Selected ARM64 fcontext assembly")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64|riscv32|RISCV")
+      set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_riscv_elf.S")
+      message(STATUS "Shards: Selected RISC-V fcontext assembly")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM")
+      set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_arm_aapcs_elf.S")
+      message(STATUS "Shards: Selected ARM32 fcontext assembly")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[36]86|x86")
+      set(FCONTEXT_ASM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/asm/fcontext_x86_sysv_elf.S")
+      message(STATUS "Shards: Selected x86 (32-bit) fcontext assembly")
+    else()
+      message(FATAL_ERROR "Unsupported architecture for custom fcontext: ${CMAKE_SYSTEM_PROCESSOR}. "
+        "Set SH_USE_BOOST_CONTEXT=ON to use Boost.Context instead.")
+    endif()
+
+    # Add assembly file to sources
+    target_sources(shards-core PRIVATE ${FCONTEXT_ASM_FILE})
+
+    # Enable ASM language if not already enabled
+    enable_language(ASM)
+  endif()
 else()
   target_include_directories(shards-core PUBLIC $<TARGET_PROPERTY:Boost::asio,INTERFACE_INCLUDE_DIRECTORIES>)
 

--- a/shards/core/asm/fcontext_arm64_aapcs_elf.S
+++ b/shards/core/asm/fcontext_arm64_aapcs_elf.S
@@ -1,0 +1,228 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * ARM64 AAPCS context switching for ELF (Linux, Android)
+ *
+ * Based on boost::context by Edward Nevill + Oliver Kowalke (Boost Software License)
+ */
+
+/*******************************************************
+ *                                                     *
+ *  Context data layout (176 bytes = 0xb0):            *
+ *  -------------------------------------------------  *
+ *  | 0x00 - 0x3f |  d8-d15 (FP callee-saved)        |  *
+ *  -------------------------------------------------  *
+ *  | 0x40 - 0x8f |  x19-x28 (GP callee-saved)       |  *
+ *  -------------------------------------------------  *
+ *  | 0x90        |  FP (x29), LR (x30)              |  *
+ *  -------------------------------------------------  *
+ *  | 0xa0        |  PC (return address)             |  *
+ *  | 0xa8        |  alignment padding               |  *
+ *  -------------------------------------------------  *
+ *                                                     *
+ *******************************************************/
+
+.file "fcontext_arm64_aapcs_elf.S"
+.text
+
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+/* Mark this object as requiring BTI */
+    .pushsection .note.gnu.property, "a", %note
+    .p2align 3
+    .long 4
+    .long 16
+    .long 5
+    .asciz "GNU"
+    .p2align 3
+    .long 0xc0000000
+    .long 4
+    .long 1
+    .long 0
+    .popsection
+#endif
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * Arguments:
+ *   x0 - stack pointer (top of allocated stack)
+ *   x1 - stack size (unused)
+ *   x2 - pointer to context function
+ * Returns:
+ *   x0 - new context handle
+ */
+.align 2
+.global sh_make_fcontext
+.type sh_make_fcontext, %function
+sh_make_fcontext:
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+    hint #34  /* bti c */
+#endif
+    # align stack pointer to 16-byte boundary
+    and x0, x0, ~0xF
+
+    # reserve space for context-data (0xb0 = 176 bytes)
+    sub x0, x0, #0xb0
+
+    # store context-function address as PC
+    str x2, [x0, #0xa0]
+
+    # compute address of finish and store as LR
+    adr x1, .L_sh_finish
+    str x1, [x0, #0x98]
+
+    # return pointer to context-data
+    ret x30
+
+.L_sh_finish:
+    # context-function returned - exit with code 0
+    mov x0, #0
+    bl _exit
+
+.size sh_make_fcontext,.-sh_make_fcontext
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * Arguments:
+ *   x0 - target context to switch to
+ *   x1 - user data to pass to target
+ * Returns:
+ *   transfer_t { x0 = fctx, x1 = data }
+ */
+.align 2
+.global sh_jump_fcontext
+.type sh_jump_fcontext, %function
+sh_jump_fcontext:
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+    hint #34  /* bti c */
+#endif
+    # reserve stack for context-data
+    sub sp, sp, #0xb0
+
+    # save FP registers d8-d15
+    stp d8,  d9,  [sp, #0x00]
+    stp d10, d11, [sp, #0x10]
+    stp d12, d13, [sp, #0x20]
+    stp d14, d15, [sp, #0x30]
+
+    # save GP registers x19-x28
+    stp x19, x20, [sp, #0x40]
+    stp x21, x22, [sp, #0x50]
+    stp x23, x24, [sp, #0x60]
+    stp x25, x26, [sp, #0x70]
+    stp x27, x28, [sp, #0x80]
+    stp x29, x30, [sp, #0x90]
+
+    # save LR as PC (return address)
+    str x30, [sp, #0xa0]
+
+    # store current SP in x4 (will become return value)
+    mov x4, sp
+
+    # switch to target stack
+    mov sp, x0
+
+    # restore FP registers d8-d15
+    ldp d8,  d9,  [sp, #0x00]
+    ldp d10, d11, [sp, #0x10]
+    ldp d12, d13, [sp, #0x20]
+    ldp d14, d15, [sp, #0x30]
+
+    # restore GP registers x19-x28
+    ldp x19, x20, [sp, #0x40]
+    ldp x21, x22, [sp, #0x50]
+    ldp x23, x24, [sp, #0x60]
+    ldp x25, x26, [sp, #0x70]
+    ldp x27, x28, [sp, #0x80]
+    ldp x29, x30, [sp, #0x90]
+
+    # prepare return value: transfer_t { x0 = fctx, x1 = data }
+    # x1 already contains data, move saved SP to x0
+    mov x0, x4
+
+    # load PC (return address)
+    ldr x4, [sp, #0xa0]
+
+    # deallocate context-data from stack
+    add sp, sp, #0xb0
+
+    # jump to target
+    ret x4
+
+.size sh_jump_fcontext,.-sh_jump_fcontext
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * Arguments:
+ *   x0 - target context
+ *   x1 - user data
+ *   x2 - ontop function
+ * Returns:
+ *   transfer_t from ontop function
+ */
+.align 2
+.global sh_ontop_fcontext
+.type sh_ontop_fcontext, %function
+sh_ontop_fcontext:
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+    hint #34  /* bti c */
+#endif
+    # save ontop function pointer
+    mov x3, x2
+
+    # reserve stack for context-data
+    sub sp, sp, #0xb0
+
+    # save FP registers d8-d15
+    stp d8,  d9,  [sp, #0x00]
+    stp d10, d11, [sp, #0x10]
+    stp d12, d13, [sp, #0x20]
+    stp d14, d15, [sp, #0x30]
+
+    # save GP registers x19-x28
+    stp x19, x20, [sp, #0x40]
+    stp x21, x22, [sp, #0x50]
+    stp x23, x24, [sp, #0x60]
+    stp x25, x26, [sp, #0x70]
+    stp x27, x28, [sp, #0x80]
+    stp x29, x30, [sp, #0x90]
+
+    # save LR as PC
+    str x30, [sp, #0xa0]
+
+    # store current SP in x4
+    mov x4, sp
+
+    # switch to target stack
+    mov sp, x0
+
+    # restore FP registers d8-d15
+    ldp d8,  d9,  [sp, #0x00]
+    ldp d10, d11, [sp, #0x10]
+    ldp d12, d13, [sp, #0x20]
+    ldp d14, d15, [sp, #0x30]
+
+    # restore GP registers x19-x28
+    ldp x19, x20, [sp, #0x40]
+    ldp x21, x22, [sp, #0x50]
+    ldp x23, x24, [sp, #0x60]
+    ldp x25, x26, [sp, #0x70]
+    ldp x27, x28, [sp, #0x80]
+    ldp x29, x30, [sp, #0x90]
+
+    # prepare transfer_t argument: { x0 = fctx, x1 = data }
+    mov x0, x4
+
+    # deallocate context-data
+    add sp, sp, #0xb0
+
+    # jump to ontop function (x3)
+    br x3
+
+.size sh_ontop_fcontext,.-sh_ontop_fcontext
+
+/* Mark that we don't need executable stack */
+.section .note.GNU-stack,"",%progbits

--- a/shards/core/asm/fcontext_arm64_aapcs_elf.S
+++ b/shards/core/asm/fcontext_arm64_aapcs_elf.S
@@ -43,11 +43,11 @@
 #endif
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * Arguments:
  *   x0 - stack pointer (top of allocated stack)
- *   x1 - stack size (unused)
+ *   x1 - stack bottom (unused on this platform)
  *   x2 - pointer to context function
  * Returns:
  *   x0 - new context handle

--- a/shards/core/asm/fcontext_arm64_aapcs_macho.S
+++ b/shards/core/asm/fcontext_arm64_aapcs_macho.S
@@ -1,0 +1,193 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * ARM64 AAPCS context switching for Mach-O (macOS, iOS)
+ *
+ * Based on boost::context by Edward Nevill + Oliver Kowalke (Boost Software License)
+ */
+
+/*******************************************************
+ *                                                     *
+ *  Context data layout (176 bytes = 0xb0):            *
+ *  -------------------------------------------------  *
+ *  | 0x00 - 0x3f |  d8-d15 (FP callee-saved)        |  *
+ *  -------------------------------------------------  *
+ *  | 0x40 - 0x8f |  x19-x28 (GP callee-saved)       |  *
+ *  -------------------------------------------------  *
+ *  | 0x90        |  FP (x29), LR (x30)              |  *
+ *  -------------------------------------------------  *
+ *  | 0xa0        |  PC (return address)             |  *
+ *  | 0xa8        |  alignment padding               |  *
+ *  -------------------------------------------------  *
+ *                                                     *
+ *******************************************************/
+
+.text
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * Arguments:
+ *   x0 - stack pointer (top of allocated stack)
+ *   x1 - stack size (unused)
+ *   x2 - pointer to context function
+ * Returns:
+ *   x0 - new context handle
+ */
+.private_extern _sh_make_fcontext
+.globl _sh_make_fcontext
+.balign 16
+_sh_make_fcontext:
+    ; align stack pointer to 16-byte boundary
+    and x0, x0, ~0xF
+
+    ; reserve space for context-data (0xb0 = 176 bytes)
+    sub x0, x0, #0xb0
+
+    ; store context-function address as PC
+    str x2, [x0, #0xa0]
+
+    ; compute address of finish and store as LR
+    adr x1, L_sh_finish
+    str x1, [x0, #0x98]
+
+    ; return pointer to context-data
+    ret lr
+
+L_sh_finish:
+    ; context-function returned - exit with code 0
+    mov x0, #0
+    bl __exit
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * Arguments:
+ *   x0 - target context to switch to
+ *   x1 - user data to pass to target
+ * Returns:
+ *   transfer_t { x0 = fctx, x1 = data }
+ */
+.private_extern _sh_jump_fcontext
+.globl _sh_jump_fcontext
+.balign 16
+_sh_jump_fcontext:
+    ; reserve stack for context-data
+    sub sp, sp, #0xb0
+
+    ; save FP registers d8-d15
+    stp d8,  d9,  [sp, #0x00]
+    stp d10, d11, [sp, #0x10]
+    stp d12, d13, [sp, #0x20]
+    stp d14, d15, [sp, #0x30]
+
+    ; save GP registers x19-x28
+    stp x19, x20, [sp, #0x40]
+    stp x21, x22, [sp, #0x50]
+    stp x23, x24, [sp, #0x60]
+    stp x25, x26, [sp, #0x70]
+    stp x27, x28, [sp, #0x80]
+    stp fp,  lr,  [sp, #0x90]
+
+    ; save LR as PC (return address)
+    str lr, [sp, #0xa0]
+
+    ; store current SP in x4 (will become return value)
+    mov x4, sp
+
+    ; switch to target stack
+    mov sp, x0
+
+    ; restore FP registers d8-d15
+    ldp d8,  d9,  [sp, #0x00]
+    ldp d10, d11, [sp, #0x10]
+    ldp d12, d13, [sp, #0x20]
+    ldp d14, d15, [sp, #0x30]
+
+    ; restore GP registers x19-x28
+    ldp x19, x20, [sp, #0x40]
+    ldp x21, x22, [sp, #0x50]
+    ldp x23, x24, [sp, #0x60]
+    ldp x25, x26, [sp, #0x70]
+    ldp x27, x28, [sp, #0x80]
+    ldp fp,  lr,  [sp, #0x90]
+
+    ; prepare return value: transfer_t { x0 = fctx, x1 = data }
+    ; x1 already contains data, move saved SP to x0
+    mov x0, x4
+
+    ; load PC (return address)
+    ldr x4, [sp, #0xa0]
+
+    ; deallocate context-data from stack
+    add sp, sp, #0xb0
+
+    ; jump to target
+    ret x4
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * Arguments:
+ *   x0 - target context
+ *   x1 - user data
+ *   x2 - ontop function
+ * Returns:
+ *   transfer_t from ontop function
+ */
+.private_extern _sh_ontop_fcontext
+.globl _sh_ontop_fcontext
+.balign 16
+_sh_ontop_fcontext:
+    ; save ontop function pointer
+    mov x3, x2
+
+    ; reserve stack for context-data
+    sub sp, sp, #0xb0
+
+    ; save FP registers d8-d15
+    stp d8,  d9,  [sp, #0x00]
+    stp d10, d11, [sp, #0x10]
+    stp d12, d13, [sp, #0x20]
+    stp d14, d15, [sp, #0x30]
+
+    ; save GP registers x19-x28
+    stp x19, x20, [sp, #0x40]
+    stp x21, x22, [sp, #0x50]
+    stp x23, x24, [sp, #0x60]
+    stp x25, x26, [sp, #0x70]
+    stp x27, x28, [sp, #0x80]
+    stp fp,  lr,  [sp, #0x90]
+
+    ; save LR as PC
+    str lr, [sp, #0xa0]
+
+    ; store current SP in x4
+    mov x4, sp
+
+    ; switch to target stack
+    mov sp, x0
+
+    ; restore FP registers d8-d15
+    ldp d8,  d9,  [sp, #0x00]
+    ldp d10, d11, [sp, #0x10]
+    ldp d12, d13, [sp, #0x20]
+    ldp d14, d15, [sp, #0x30]
+
+    ; restore GP registers x19-x28
+    ldp x19, x20, [sp, #0x40]
+    ldp x21, x22, [sp, #0x50]
+    ldp x23, x24, [sp, #0x60]
+    ldp x25, x26, [sp, #0x70]
+    ldp x27, x28, [sp, #0x80]
+    ldp fp,  lr,  [sp, #0x90]
+
+    ; prepare transfer_t argument: { x0 = fctx, x1 = data }
+    mov x0, x4
+
+    ; deallocate context-data
+    add sp, sp, #0xb0
+
+    ; jump to ontop function (x3)
+    br x3

--- a/shards/core/asm/fcontext_arm64_aapcs_macho.S
+++ b/shards/core/asm/fcontext_arm64_aapcs_macho.S
@@ -26,11 +26,11 @@
 .text
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * Arguments:
  *   x0 - stack pointer (top of allocated stack)
- *   x1 - stack size (unused)
+ *   x1 - stack bottom (unused on this platform)
  *   x2 - pointer to context function
  * Returns:
  *   x0 - new context handle

--- a/shards/core/asm/fcontext_arm_aapcs_elf.S
+++ b/shards/core/asm/fcontext_arm_aapcs_elf.S
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * ARM (32-bit) AAPCS context switching for ELF (Linux, Android)
+ *
+ * Based on boost::context by Oliver Kowalke (Boost Software License)
+ */
+
+/*******************************************************
+ *                                                     *
+ *  Context data layout (128 bytes):                   *
+ *  -------------------------------------------------  *
+ *  | 0x00-0x3c | s16-s31 (VFP callee-saved)         |  *
+ *  -------------------------------------------------  *
+ *  | 0x40      | hidden (struct return ptr)         |  *
+ *  | 0x44-0x5c | v1-v7 (r4-r10)                     |  *
+ *  -------------------------------------------------  *
+ *  | 0x60      | v8 (r11/fp)                        |  *
+ *  | 0x64      | lr (r14)                           |  *
+ *  | 0x68      | pc (entry point)                   |  *
+ *  | 0x6c-0x74 | FCTX, DATA (transfer_t return)     |  *
+ *  -------------------------------------------------  *
+ *                                                     *
+ *  AAPCS register names:                              *
+ *  a1-a4 = r0-r3 (argument/scratch)                   *
+ *  v1-v8 = r4-r11 (callee-saved)                      *
+ *  ip = r12 (scratch)                                 *
+ *  sp = r13, lr = r14, pc = r15                       *
+ *                                                     *
+ *******************************************************/
+
+.file "fcontext_arm_aapcs_elf.S"
+.text
+.syntax unified
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * Arguments:
+ *   a1 (r0) - stack pointer (top of allocated stack)
+ *   a2 (r1) - stack size (unused)
+ *   a3 (r2) - pointer to context function
+ * Returns:
+ *   a1 (r0) - new context handle
+ */
+.globl sh_make_fcontext
+.type sh_make_fcontext,%function
+.align 2
+sh_make_fcontext:
+    @ Align stack pointer to 16-byte boundary
+    bic a1, a1, #15
+
+    @ Reserve space for context-data (0x7c = 124 bytes)
+    sub a1, a1, #124
+
+    @ Store context-function address as PC
+    str a3, [a1, #104]
+
+    @ Compute address for transfer_t return value
+    add a2, a1, #108
+    str a2, [a1, #64]
+
+    @ Compute address of finish and store as LR
+    adr a2, .L_sh_finish
+    str a2, [a1, #100]
+
+    @ Return pointer to context-data
+    bx lr
+
+.L_sh_finish:
+    @ Context-function returned - exit with code 0
+    mov a1, #0
+    bl _exit@PLT
+
+.size sh_make_fcontext,.-sh_make_fcontext
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * Arguments:
+ *   a1 (r0) - hidden pointer for struct return (implicit)
+ *   a2 (r1) - target context to switch to
+ *   a3 (r2) - user data to pass to target
+ * Returns:
+ *   transfer_t via hidden pointer
+ *
+ * Note: ARM AAPCS returns structs >4 bytes via hidden first argument
+ */
+.globl sh_jump_fcontext
+.type sh_jump_fcontext,%function
+.align 2
+sh_jump_fcontext:
+    @ Save PC (LR) on stack first
+    push {lr}
+    @ Save hidden pointer, v1-v8, lr
+    push {a1, v1-v8, lr}
+
+    @ Reserve space for VFP registers
+    sub sp, sp, #64
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+    @ Save VFP callee-saved registers s16-s31 (d8-d15)
+    vstmia sp, {d8-d15}
+#endif
+
+    @ Store current SP in a1 (will become return fctx)
+    mov a1, sp
+
+    @ Switch to target stack (a2 = target context)
+    mov sp, a2
+
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+    @ Restore VFP registers
+    vldmia sp, {d8-d15}
+#endif
+    @ Deallocate VFP space
+    add sp, sp, #64
+
+    @ Restore hidden pointer, v1-v8, lr
+    pop {a4, v1-v8, lr}
+
+    @ Write transfer_t to hidden pointer location
+    @ a4 = hidden pointer, a1 = source context, a3 = data
+    str a1, [a4, #0]
+    str a3, [a4, #4]
+
+    @ Set up arguments for context function
+    @ a1 = fctx (already set), a2 = data
+    mov a2, a3
+
+    @ Restore PC and jump to target
+    pop {pc}
+
+.size sh_jump_fcontext,.-sh_jump_fcontext
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * Arguments:
+ *   a1 (r0) - hidden pointer
+ *   a2 (r1) - target context
+ *   a3 (r2) - user data
+ *   a4 (r3) - ontop function
+ */
+.globl sh_ontop_fcontext
+.type sh_ontop_fcontext,%function
+.align 2
+sh_ontop_fcontext:
+    @ Save ontop function in ip (r12)
+    mov ip, a4
+
+    @ Save PC (LR) on stack first
+    push {lr}
+    @ Save hidden pointer, v1-v8, lr
+    push {a1, v1-v8, lr}
+
+    @ Reserve space for VFP registers
+    sub sp, sp, #64
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+    @ Save VFP registers
+    vstmia sp, {d8-d15}
+#endif
+
+    @ Store current SP in a1
+    mov a1, sp
+
+    @ Switch to target stack
+    mov sp, a2
+
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+    @ Restore VFP registers
+    vldmia sp, {d8-d15}
+#endif
+    add sp, sp, #64
+
+    @ Restore hidden pointer, v1-v8, lr
+    pop {a4, v1-v8, lr}
+
+    @ Write transfer_t to hidden pointer
+    str a1, [a4, #0]
+    str a3, [a4, #4]
+
+    @ Set up arguments
+    mov a2, a3
+
+    @ Deallocate PC slot
+    add sp, sp, #4
+
+    @ Jump to ontop function
+    bx ip
+
+.size sh_ontop_fcontext,.-sh_ontop_fcontext
+
+@ Mark that we don't need executable stack
+.section .note.GNU-stack,"",%progbits

--- a/shards/core/asm/fcontext_arm_aapcs_elf.S
+++ b/shards/core/asm/fcontext_arm_aapcs_elf.S
@@ -35,11 +35,11 @@
 .syntax unified
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * Arguments:
  *   a1 (r0) - stack pointer (top of allocated stack)
- *   a2 (r1) - stack size (unused)
+ *   a2 (r1) - stack bottom (unused on this platform)
  *   a3 (r2) - pointer to context function
  * Returns:
  *   a1 (r0) - new context handle

--- a/shards/core/asm/fcontext_riscv_elf.S
+++ b/shards/core/asm/fcontext_riscv_elf.S
@@ -11,16 +11,14 @@
 /*******************************************************
  *                                                     *
  *  Context data layout:                               *
- *  RV64: 104 bytes (13 registers * 8 bytes)           *
- *  RV32: 52 bytes (13 registers * 4 bytes)            *
+ *  RV64: 208 bytes (26 registers * 8 bytes)           *
+ *  RV32: 104 bytes (26 registers * 4 bytes)           *
  *                                                     *
  *  Saved registers (callee-saved):                    *
  *  - s0-s11 (x8-x9, x18-x27): 12 GP registers         *
  *  - ra (x1): return address                          *
- *                                                     *
- *  Note: FP registers (fs0-fs11) not saved by default *
- *  to reduce context size. Enable SH_FCONTEXT_FP if   *
- *  needed for your application.                       *
+ *  - pc slot: entry point                             *
+ *  - fs0-fs11 (f8-f9, f18-f27): 12 FP registers       *
  *                                                     *
  *******************************************************/
 
@@ -31,17 +29,23 @@
 #  define SZREG  8
 #  define REG_S  sd
 #  define REG_L  ld
-#  define CTX_SIZE  0x70   /* 14 registers * 8 = 112 bytes (aligned to 16) */
+#  define SZFREG 8
+#  define FREG_S fsd
+#  define FREG_L fld
+#  define CTX_SIZE  0xd0   /* 26 registers * 8 = 208 bytes (aligned to 16) */
 #elif __riscv_xlen == 32
 #  define SZREG  4
 #  define REG_S  sw
 #  define REG_L  lw
-#  define CTX_SIZE  0x40   /* 14 registers * 4 = 56 bytes (aligned to 16 = 64) */
+#  define SZFREG 4
+#  define FREG_S fsw
+#  define FREG_L flw
+#  define CTX_SIZE  0x70   /* 26 registers * 4 = 104 bytes (aligned to 16 = 112) */
 #else
 #  error "Unsupported RISC-V XLEN"
 #endif
 
-/* Register offsets in context */
+/* GP Register offsets in context */
 #define CTX_RA   (0 * SZREG)
 #define CTX_S0   (1 * SZREG)
 #define CTX_S1   (2 * SZREG)
@@ -56,6 +60,20 @@
 #define CTX_S10  (11 * SZREG)
 #define CTX_S11  (12 * SZREG)
 #define CTX_PC   (13 * SZREG)  /* Entry point / return address */
+
+/* FP Register offsets in context (fs0-fs11, callee-saved) */
+#define CTX_FS0  (14 * SZREG)
+#define CTX_FS1  (15 * SZREG)
+#define CTX_FS2  (16 * SZREG)
+#define CTX_FS3  (17 * SZREG)
+#define CTX_FS4  (18 * SZREG)
+#define CTX_FS5  (19 * SZREG)
+#define CTX_FS6  (20 * SZREG)
+#define CTX_FS7  (21 * SZREG)
+#define CTX_FS8  (22 * SZREG)
+#define CTX_FS9  (23 * SZREG)
+#define CTX_FS10 (24 * SZREG)
+#define CTX_FS11 (25 * SZREG)
 
 .text
 
@@ -130,6 +148,22 @@ sh_jump_fcontext:
     REG_S s10, CTX_S10(sp)
     REG_S s11, CTX_S11(sp)
 
+#if defined(__riscv_flen)
+    /* Save callee-saved FP registers fs0-fs11 */
+    FREG_S fs0, CTX_FS0(sp)
+    FREG_S fs1, CTX_FS1(sp)
+    FREG_S fs2, CTX_FS2(sp)
+    FREG_S fs3, CTX_FS3(sp)
+    FREG_S fs4, CTX_FS4(sp)
+    FREG_S fs5, CTX_FS5(sp)
+    FREG_S fs6, CTX_FS6(sp)
+    FREG_S fs7, CTX_FS7(sp)
+    FREG_S fs8, CTX_FS8(sp)
+    FREG_S fs9, CTX_FS9(sp)
+    FREG_S fs10, CTX_FS10(sp)
+    FREG_S fs11, CTX_FS11(sp)
+#endif
+
     /* Save current SP as PC slot (return point for when we're resumed) */
     REG_S ra, CTX_PC(sp)
 
@@ -158,6 +192,22 @@ sh_jump_fcontext:
     REG_L s9, CTX_S9(sp)
     REG_L s10, CTX_S10(sp)
     REG_L s11, CTX_S11(sp)
+
+#if defined(__riscv_flen)
+    /* Restore callee-saved FP registers fs0-fs11 */
+    FREG_L fs0, CTX_FS0(sp)
+    FREG_L fs1, CTX_FS1(sp)
+    FREG_L fs2, CTX_FS2(sp)
+    FREG_L fs3, CTX_FS3(sp)
+    FREG_L fs4, CTX_FS4(sp)
+    FREG_L fs5, CTX_FS5(sp)
+    FREG_L fs6, CTX_FS6(sp)
+    FREG_L fs7, CTX_FS7(sp)
+    FREG_L fs8, CTX_FS8(sp)
+    FREG_L fs9, CTX_FS9(sp)
+    FREG_L fs10, CTX_FS10(sp)
+    FREG_L fs11, CTX_FS11(sp)
+#endif
 
     /* Deallocate context-data from stack */
     addi sp, sp, CTX_SIZE
@@ -208,6 +258,22 @@ sh_ontop_fcontext:
     REG_S s10, CTX_S10(sp)
     REG_S s11, CTX_S11(sp)
 
+#if defined(__riscv_flen)
+    /* Save callee-saved FP registers fs0-fs11 */
+    FREG_S fs0, CTX_FS0(sp)
+    FREG_S fs1, CTX_FS1(sp)
+    FREG_S fs2, CTX_FS2(sp)
+    FREG_S fs3, CTX_FS3(sp)
+    FREG_S fs4, CTX_FS4(sp)
+    FREG_S fs5, CTX_FS5(sp)
+    FREG_S fs6, CTX_FS6(sp)
+    FREG_S fs7, CTX_FS7(sp)
+    FREG_S fs8, CTX_FS8(sp)
+    FREG_S fs9, CTX_FS9(sp)
+    FREG_S fs10, CTX_FS10(sp)
+    FREG_S fs11, CTX_FS11(sp)
+#endif
+
     /* Save current SP as PC slot */
     REG_S ra, CTX_PC(sp)
 
@@ -233,6 +299,22 @@ sh_ontop_fcontext:
     REG_L s9, CTX_S9(sp)
     REG_L s10, CTX_S10(sp)
     REG_L s11, CTX_S11(sp)
+
+#if defined(__riscv_flen)
+    /* Restore callee-saved FP registers fs0-fs11 */
+    FREG_L fs0, CTX_FS0(sp)
+    FREG_L fs1, CTX_FS1(sp)
+    FREG_L fs2, CTX_FS2(sp)
+    FREG_L fs3, CTX_FS3(sp)
+    FREG_L fs4, CTX_FS4(sp)
+    FREG_L fs5, CTX_FS5(sp)
+    FREG_L fs6, CTX_FS6(sp)
+    FREG_L fs7, CTX_FS7(sp)
+    FREG_L fs8, CTX_FS8(sp)
+    FREG_L fs9, CTX_FS9(sp)
+    FREG_L fs10, CTX_FS10(sp)
+    FREG_L fs11, CTX_FS11(sp)
+#endif
 
     /* Deallocate context-data */
     addi sp, sp, CTX_SIZE

--- a/shards/core/asm/fcontext_riscv_elf.S
+++ b/shards/core/asm/fcontext_riscv_elf.S
@@ -1,0 +1,249 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * RISC-V context switching for ELF (Linux)
+ * Unified implementation for both rv32 and rv64
+ *
+ * Inspired by corosensei (MIT License) and boost::context patterns
+ */
+
+/*******************************************************
+ *                                                     *
+ *  Context data layout:                               *
+ *  RV64: 104 bytes (13 registers * 8 bytes)           *
+ *  RV32: 52 bytes (13 registers * 4 bytes)            *
+ *                                                     *
+ *  Saved registers (callee-saved):                    *
+ *  - s0-s11 (x8-x9, x18-x27): 12 GP registers         *
+ *  - ra (x1): return address                          *
+ *                                                     *
+ *  Note: FP registers (fs0-fs11) not saved by default *
+ *  to reduce context size. Enable SH_FCONTEXT_FP if   *
+ *  needed for your application.                       *
+ *                                                     *
+ *******************************************************/
+
+.file "fcontext_riscv_elf.S"
+
+/* Macros for rv32/rv64 portability */
+#if __riscv_xlen == 64
+#  define SZREG  8
+#  define REG_S  sd
+#  define REG_L  ld
+#  define CTX_SIZE  0x70   /* 14 registers * 8 = 112 bytes (aligned to 16) */
+#elif __riscv_xlen == 32
+#  define SZREG  4
+#  define REG_S  sw
+#  define REG_L  lw
+#  define CTX_SIZE  0x40   /* 14 registers * 4 = 56 bytes (aligned to 16 = 64) */
+#else
+#  error "Unsupported RISC-V XLEN"
+#endif
+
+/* Register offsets in context */
+#define CTX_RA   (0 * SZREG)
+#define CTX_S0   (1 * SZREG)
+#define CTX_S1   (2 * SZREG)
+#define CTX_S2   (3 * SZREG)
+#define CTX_S3   (4 * SZREG)
+#define CTX_S4   (5 * SZREG)
+#define CTX_S5   (6 * SZREG)
+#define CTX_S6   (7 * SZREG)
+#define CTX_S7   (8 * SZREG)
+#define CTX_S8   (9 * SZREG)
+#define CTX_S9   (10 * SZREG)
+#define CTX_S10  (11 * SZREG)
+#define CTX_S11  (12 * SZREG)
+#define CTX_PC   (13 * SZREG)  /* Entry point / return address */
+
+.text
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * RISC-V calling convention:
+ *   a0 - stack pointer (top of allocated stack)
+ *   a1 - stack size (unused)
+ *   a2 - pointer to context function
+ * Returns:
+ *   a0 - new context handle
+ */
+.global sh_make_fcontext
+.type sh_make_fcontext, @function
+.align 2
+sh_make_fcontext:
+    /* Align stack pointer to 16-byte boundary */
+    andi a0, a0, -16
+
+    /* Reserve space for context data */
+    addi a0, a0, -CTX_SIZE
+
+    /* Store context-function address as PC (entry point) */
+    REG_S a2, CTX_PC(a0)
+
+    /* Compute address of finish routine and store as RA */
+    /* When context-function returns, it will jump to finish */
+    la t0, .L_sh_finish
+    REG_S t0, CTX_RA(a0)
+
+    /* Return pointer to context-data */
+    ret
+
+.L_sh_finish:
+    /* Context-function returned - exit with code 0 */
+    li a0, 0
+    call _exit
+
+.size sh_make_fcontext, .-sh_make_fcontext
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * RISC-V calling convention:
+ *   a0 - target context to switch to
+ *   a1 - user data to pass to target
+ * Returns:
+ *   transfer_t { a0 = fctx, a1 = data }
+ */
+.global sh_jump_fcontext
+.type sh_jump_fcontext, @function
+.align 2
+sh_jump_fcontext:
+    /* Reserve stack for context-data */
+    addi sp, sp, -CTX_SIZE
+
+    /* Save return address */
+    REG_S ra, CTX_RA(sp)
+
+    /* Save callee-saved GP registers s0-s11 */
+    REG_S s0, CTX_S0(sp)
+    REG_S s1, CTX_S1(sp)
+    REG_S s2, CTX_S2(sp)
+    REG_S s3, CTX_S3(sp)
+    REG_S s4, CTX_S4(sp)
+    REG_S s5, CTX_S5(sp)
+    REG_S s6, CTX_S6(sp)
+    REG_S s7, CTX_S7(sp)
+    REG_S s8, CTX_S8(sp)
+    REG_S s9, CTX_S9(sp)
+    REG_S s10, CTX_S10(sp)
+    REG_S s11, CTX_S11(sp)
+
+    /* Save current SP as PC slot (return point for when we're resumed) */
+    REG_S ra, CTX_PC(sp)
+
+    /* Store current SP in t0 (will become return value a0) */
+    mv t0, sp
+
+    /* Switch to target stack */
+    mv sp, a0
+
+    /* Load PC (entry point / return address) */
+    REG_L t1, CTX_PC(sp)
+
+    /* Restore return address */
+    REG_L ra, CTX_RA(sp)
+
+    /* Restore callee-saved GP registers s0-s11 */
+    REG_L s0, CTX_S0(sp)
+    REG_L s1, CTX_S1(sp)
+    REG_L s2, CTX_S2(sp)
+    REG_L s3, CTX_S3(sp)
+    REG_L s4, CTX_S4(sp)
+    REG_L s5, CTX_S5(sp)
+    REG_L s6, CTX_S6(sp)
+    REG_L s7, CTX_S7(sp)
+    REG_L s8, CTX_S8(sp)
+    REG_L s9, CTX_S9(sp)
+    REG_L s10, CTX_S10(sp)
+    REG_L s11, CTX_S11(sp)
+
+    /* Deallocate context-data from stack */
+    addi sp, sp, CTX_SIZE
+
+    /* Prepare return value: transfer_t { a0 = fctx, a1 = data } */
+    /* a1 already contains data, move saved SP to a0 */
+    mv a0, t0
+
+    /* Jump to target (entry point or return address) */
+    jr t1
+
+.size sh_jump_fcontext, .-sh_jump_fcontext
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * RISC-V calling convention:
+ *   a0 - target context
+ *   a1 - user data
+ *   a2 - ontop function
+ * Returns:
+ *   transfer_t from ontop function
+ */
+.global sh_ontop_fcontext
+.type sh_ontop_fcontext, @function
+.align 2
+sh_ontop_fcontext:
+    /* Save ontop function pointer in t2 */
+    mv t2, a2
+
+    /* Reserve stack for context-data */
+    addi sp, sp, -CTX_SIZE
+
+    /* Save return address */
+    REG_S ra, CTX_RA(sp)
+
+    /* Save callee-saved GP registers s0-s11 */
+    REG_S s0, CTX_S0(sp)
+    REG_S s1, CTX_S1(sp)
+    REG_S s2, CTX_S2(sp)
+    REG_S s3, CTX_S3(sp)
+    REG_S s4, CTX_S4(sp)
+    REG_S s5, CTX_S5(sp)
+    REG_S s6, CTX_S6(sp)
+    REG_S s7, CTX_S7(sp)
+    REG_S s8, CTX_S8(sp)
+    REG_S s9, CTX_S9(sp)
+    REG_S s10, CTX_S10(sp)
+    REG_S s11, CTX_S11(sp)
+
+    /* Save current SP as PC slot */
+    REG_S ra, CTX_PC(sp)
+
+    /* Store current SP in t0 */
+    mv t0, sp
+
+    /* Switch to target stack */
+    mv sp, a0
+
+    /* Restore return address */
+    REG_L ra, CTX_RA(sp)
+
+    /* Restore callee-saved GP registers s0-s11 */
+    REG_L s0, CTX_S0(sp)
+    REG_L s1, CTX_S1(sp)
+    REG_L s2, CTX_S2(sp)
+    REG_L s3, CTX_S3(sp)
+    REG_L s4, CTX_S4(sp)
+    REG_L s5, CTX_S5(sp)
+    REG_L s6, CTX_S6(sp)
+    REG_L s7, CTX_S7(sp)
+    REG_L s8, CTX_S8(sp)
+    REG_L s9, CTX_S9(sp)
+    REG_L s10, CTX_S10(sp)
+    REG_L s11, CTX_S11(sp)
+
+    /* Deallocate context-data */
+    addi sp, sp, CTX_SIZE
+
+    /* Prepare transfer_t argument: { a0 = fctx, a1 = data } */
+    mv a0, t0
+
+    /* Jump to ontop function */
+    jr t2
+
+.size sh_ontop_fcontext, .-sh_ontop_fcontext
+
+/* Mark that we don't need executable stack */
+.section .note.GNU-stack,"",@progbits

--- a/shards/core/asm/fcontext_riscv_elf.S
+++ b/shards/core/asm/fcontext_riscv_elf.S
@@ -78,11 +78,11 @@
 .text
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * RISC-V calling convention:
  *   a0 - stack pointer (top of allocated stack)
- *   a1 - stack size (unused)
+ *   a1 - stack bottom (unused on this platform)
  *   a2 - pointer to context function
  * Returns:
  *   a0 - new context handle

--- a/shards/core/asm/fcontext_riscv_elf.S
+++ b/shards/core/asm/fcontext_riscv_elf.S
@@ -11,14 +11,16 @@
 /*******************************************************
  *                                                     *
  *  Context data layout:                               *
- *  RV64: 208 bytes (26 registers * 8 bytes)           *
- *  RV32: 104 bytes (26 registers * 4 bytes)           *
+ *  With FP (rv64f/d): 208 bytes (14 GP + 12 FP) * 8   *
+ *  With FP (rv32f/d): 112 bytes (14 GP + 12 FP) * 4   *
+ *  Without FP (rv64): 112 bytes (14 GP) * 8           *
+ *  Without FP (rv32): 64 bytes (14 GP) * 4, pad to 64 *
  *                                                     *
  *  Saved registers (callee-saved):                    *
  *  - s0-s11 (x8-x9, x18-x27): 12 GP registers         *
  *  - ra (x1): return address                          *
  *  - pc slot: entry point                             *
- *  - fs0-fs11 (f8-f9, f18-f27): 12 FP registers       *
+ *  - fs0-fs11 (f8-f9, f18-f27): 12 FP registers (if F)*
  *                                                     *
  *******************************************************/
 
@@ -29,18 +31,26 @@
 #  define SZREG  8
 #  define REG_S  sd
 #  define REG_L  ld
-#  define SZFREG 8
-#  define FREG_S fsd
-#  define FREG_L fld
-#  define CTX_SIZE  0xd0   /* 26 registers * 8 = 208 bytes (aligned to 16) */
+#  if defined(__riscv_flen)
+#    define SZFREG 8
+#    define FREG_S fsd
+#    define FREG_L fld
+#    define CTX_SIZE  0xd0   /* (14 GP + 12 FP) * 8 = 208 bytes */
+#  else
+#    define CTX_SIZE  0x70   /* 14 GP * 8 = 112 bytes */
+#  endif
 #elif __riscv_xlen == 32
 #  define SZREG  4
 #  define REG_S  sw
 #  define REG_L  lw
-#  define SZFREG 4
-#  define FREG_S fsw
-#  define FREG_L flw
-#  define CTX_SIZE  0x70   /* 26 registers * 4 = 104 bytes (aligned to 16 = 112) */
+#  if defined(__riscv_flen)
+#    define SZFREG 4
+#    define FREG_S fsw
+#    define FREG_L flw
+#    define CTX_SIZE  0x70   /* (14 GP + 12 FP) * 4 = 104, rounded to 112 */
+#  else
+#    define CTX_SIZE  0x40   /* 14 GP * 4 = 56, rounded to 64 for alignment */
+#  endif
 #else
 #  error "Unsupported RISC-V XLEN"
 #endif
@@ -61,6 +71,7 @@
 #define CTX_S11  (12 * SZREG)
 #define CTX_PC   (13 * SZREG)  /* Entry point / return address */
 
+#if defined(__riscv_flen)
 /* FP Register offsets in context (fs0-fs11, callee-saved) */
 #define CTX_FS0  (14 * SZREG)
 #define CTX_FS1  (15 * SZREG)
@@ -74,6 +85,7 @@
 #define CTX_FS9  (23 * SZREG)
 #define CTX_FS10 (24 * SZREG)
 #define CTX_FS11 (25 * SZREG)
+#endif
 
 .text
 

--- a/shards/core/asm/fcontext_x86_64_ms_pe.S
+++ b/shards/core/asm/fcontext_x86_64_ms_pe.S
@@ -1,0 +1,398 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * x86_64 Windows ABI context switching (PE/COFF)
+ *
+ * Based on boost::context by Oliver Kowalke and Thomas Sailer (Boost Software License)
+ * Includes TEB (Thread Environment Block) management for proper Windows fiber support
+ */
+
+/*************************************************************************************
+ *                                                                                   *
+ *  Context data layout on stack (336 bytes = 0x150):                                *
+ *                                                                                   *
+ *  0x00 - 0x9f:  XMM6-XMM15 (160 bytes) - callee-saved on Windows                   *
+ *  0xa0:         fc_mxcsr, fc_x87_cw                                                *
+ *  0xa8:         alignment                                                          *
+ *  0xb0:         fiber local storage                                                *
+ *  0xb8:         deallocation stack (from TEB)                                      *
+ *  0xc0:         stack limit (from TEB)                                             *
+ *  0xc8:         stack base (from TEB)                                              *
+ *  0xd0 - 0xff:  R12, R13, R14, R15, RDI, RSI, RBX, RBP                              *
+ *  0x100:        RBX                                                                *
+ *  0x108:        RBP                                                                *
+ *  0x110:        hidden (transport_t address)                                       *
+ *  0x118:        RIP (return address)                                               *
+ *  0x120 - 0x13f: parameter area (32-byte shadow space)                             *
+ *  0x140:        FCTX, DATA (transport_t)                                           *
+ *                                                                                   *
+ *************************************************************************************/
+
+.file "fcontext_x86_64_ms_pe.S"
+.text
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * Windows x64 calling convention:
+ *   RCX - stack pointer (top of allocated stack)
+ *   RDX - stack size
+ *   R8  - pointer to context function
+ * Returns:
+ *   RAX - new context handle
+ */
+.p2align 4,,15
+.globl sh_make_fcontext
+.def sh_make_fcontext; .scl 2; .type 32; .endef
+.seh_proc sh_make_fcontext
+sh_make_fcontext:
+.seh_endprologue
+
+    /* first arg == top of context-stack */
+    movq  %rcx, %rax
+
+    /* align stack pointer to 16-byte boundary */
+    andq  $-16, %rax
+
+    /* reserve space for context-data on stack */
+    /* on context-function entry: (RSP - 0x8) % 16 == 0 */
+    leaq  -0x150(%rax), %rax
+
+    /* save context-function address in RBX slot (will be jumped to via trampoline) */
+    movq  %r8, 0x100(%rax)
+
+    /* save top address of context stack as 'base' for TEB */
+    movq  %rcx, 0xc8(%rax)
+
+    /* compute bottom address of context stack (limit) */
+    negq  %rdx
+    leaq  (%rcx,%rdx), %rcx
+
+    /* save bottom address as 'limit' for TEB */
+    movq  %rcx, 0xc0(%rax)
+
+    /* save as 'deallocation stack' for TEB */
+    movq  %rcx, 0xb8(%rax)
+
+    /* set fiber local storage to zero */
+    xorq  %rcx, %rcx
+    movq  %rcx, 0xb0(%rax)
+
+    /* save MMX control and status word */
+    stmxcsr 0xa0(%rax)
+    /* save x87 control word */
+    fnstcw  0xa4(%rax)
+
+    /* compute address of transport_t and store in hidden field */
+    leaq  0x140(%rax), %rcx
+    movq  %rcx, 0x110(%rax)
+
+    /* compute address of trampoline */
+    leaq  .L_sh_trampoline(%rip), %rcx
+    /* save as return address (entered after first jump_fcontext) */
+    movq  %rcx, 0x118(%rax)
+
+    /* compute address of finish */
+    leaq  .L_sh_finish(%rip), %rcx
+    /* save as RBP (pushed by trampoline for return after context-function) */
+    movq  %rcx, 0x108(%rax)
+
+    /* return pointer to context-data */
+    ret
+
+.L_sh_trampoline:
+    /* fix stack alignment */
+    pushq %rbp
+    /* jump to context-function (address in RBX) */
+    jmp  *%rbx
+
+.L_sh_finish:
+    /* align stack for _exit call (32-byte shadow space already reserved) */
+    andq  $-32, %rsp
+    /* exit code is zero */
+    xorq  %rcx, %rcx
+    /* exit application */
+    call  _exit
+    hlt
+
+.seh_endproc
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * Windows x64 calling convention:
+ *   RCX - hidden pointer for struct return (implicit)
+ *   RDX - target context to switch to
+ *   R8  - user data to pass
+ * Returns:
+ *   transfer_t via hidden pointer in RCX
+ */
+.p2align 4,,15
+.globl sh_jump_fcontext
+.def sh_jump_fcontext; .scl 2; .type 32; .endef
+.seh_proc sh_jump_fcontext
+sh_jump_fcontext:
+.seh_endprologue
+
+    /* reserve space for context-data */
+    leaq  -0x118(%rsp), %rsp
+
+    /* save XMM registers (callee-saved on Windows) */
+    movaps  %xmm6,  0x00(%rsp)
+    movaps  %xmm7,  0x10(%rsp)
+    movaps  %xmm8,  0x20(%rsp)
+    movaps  %xmm9,  0x30(%rsp)
+    movaps  %xmm10, 0x40(%rsp)
+    movaps  %xmm11, 0x50(%rsp)
+    movaps  %xmm12, 0x60(%rsp)
+    movaps  %xmm13, 0x70(%rsp)
+    movaps  %xmm14, 0x80(%rsp)
+    movaps  %xmm15, 0x90(%rsp)
+
+    /* save MMX control and status word */
+    stmxcsr 0xa0(%rsp)
+    /* save x87 control word */
+    fnstcw  0xa4(%rsp)
+
+    /* load NT_TIB from TEB */
+    movq  %gs:(0x30), %r10
+
+    /* save fiber local storage */
+    movq  0x20(%r10), %rax
+    movq  %rax, 0xb0(%rsp)
+    /* save current deallocation stack */
+    movq  0x1478(%r10), %rax
+    movq  %rax, 0xb8(%rsp)
+    /* save current stack limit */
+    movq  0x10(%r10), %rax
+    movq  %rax, 0xc0(%rsp)
+    /* save current stack base */
+    movq  0x08(%r10), %rax
+    movq  %rax, 0xc8(%rsp)
+
+    /* save callee-saved GP registers */
+    movq  %r12, 0xd0(%rsp)
+    movq  %r13, 0xd8(%rsp)
+    movq  %r14, 0xe0(%rsp)
+    movq  %r15, 0xe8(%rsp)
+    movq  %rdi, 0xf0(%rsp)
+    movq  %rsi, 0xf8(%rsp)
+    movq  %rbx, 0x100(%rsp)
+    movq  %rbp, 0x108(%rsp)
+
+    /* save hidden address of transport_t */
+    movq  %rcx, 0x110(%rsp)
+
+    /* preserve current RSP in R9 (will be returned as fctx) */
+    movq  %rsp, %r9
+
+    /* switch to target stack (RDX = target context) */
+    movq  %rdx, %rsp
+
+    /* restore XMM registers */
+    movaps  0x00(%rsp), %xmm6
+    movaps  0x10(%rsp), %xmm7
+    movaps  0x20(%rsp), %xmm8
+    movaps  0x30(%rsp), %xmm9
+    movaps  0x40(%rsp), %xmm10
+    movaps  0x50(%rsp), %xmm11
+    movaps  0x60(%rsp), %xmm12
+    movaps  0x70(%rsp), %xmm13
+    movaps  0x80(%rsp), %xmm14
+    movaps  0x90(%rsp), %xmm15
+
+    /* restore MMX control and status word */
+    ldmxcsr 0xa0(%rsp)
+    /* restore x87 control word */
+    fldcw   0xa4(%rsp)
+
+    /* load NT_TIB from TEB */
+    movq  %gs:(0x30), %r10
+
+    /* restore fiber local storage */
+    movq  0xb0(%rsp), %rax
+    movq  %rax, 0x20(%r10)
+    /* restore deallocation stack */
+    movq  0xb8(%rsp), %rax
+    movq  %rax, 0x1478(%r10)
+    /* restore stack limit */
+    movq  0xc0(%rsp), %rax
+    movq  %rax, 0x10(%r10)
+    /* restore stack base */
+    movq  0xc8(%rsp), %rax
+    movq  %rax, 0x08(%r10)
+
+    /* restore callee-saved GP registers */
+    movq  0xd0(%rsp), %r12
+    movq  0xd8(%rsp), %r13
+    movq  0xe0(%rsp), %r14
+    movq  0xe8(%rsp), %r15
+    movq  0xf0(%rsp), %rdi
+    movq  0xf8(%rsp), %rsi
+    movq  0x100(%rsp), %rbx
+    movq  0x108(%rsp), %rbp
+
+    /* restore hidden address of transport_t */
+    movq  0x110(%rsp), %rax
+
+    /* deallocate context-data */
+    leaq  0x118(%rsp), %rsp
+
+    /* pop return address */
+    popq  %r10
+
+    /* write transport_t to hidden pointer location */
+    /* return source context (R9) */
+    movq  %r9, 0x0(%rax)
+    /* return data (R8) */
+    movq  %r8, 0x8(%rax)
+
+    /* pass transport_t address as first arg to context-function */
+    movq  %rax, %rcx
+
+    /* jump to target */
+    jmp  *%r10
+
+.seh_endproc
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * Windows x64 calling convention:
+ *   RCX - hidden pointer for struct return
+ *   RDX - target context
+ *   R8  - user data
+ *   R9  - ontop function
+ */
+.p2align 4,,15
+.globl sh_ontop_fcontext
+.def sh_ontop_fcontext; .scl 2; .type 32; .endef
+.seh_proc sh_ontop_fcontext
+sh_ontop_fcontext:
+.seh_endprologue
+
+    /* reserve space for context-data */
+    leaq  -0x118(%rsp), %rsp
+
+    /* save XMM registers */
+    movaps  %xmm6,  0x00(%rsp)
+    movaps  %xmm7,  0x10(%rsp)
+    movaps  %xmm8,  0x20(%rsp)
+    movaps  %xmm9,  0x30(%rsp)
+    movaps  %xmm10, 0x40(%rsp)
+    movaps  %xmm11, 0x50(%rsp)
+    movaps  %xmm12, 0x60(%rsp)
+    movaps  %xmm13, 0x70(%rsp)
+    movaps  %xmm14, 0x80(%rsp)
+    movaps  %xmm15, 0x90(%rsp)
+
+    /* save MMX control and status word */
+    stmxcsr 0xa0(%rsp)
+    /* save x87 control word */
+    fnstcw  0xa4(%rsp)
+
+    /* load NT_TIB from TEB */
+    movq  %gs:(0x30), %r10
+
+    /* save fiber local storage */
+    movq  0x20(%r10), %rax
+    movq  %rax, 0xb0(%rsp)
+    /* save current deallocation stack */
+    movq  0x1478(%r10), %rax
+    movq  %rax, 0xb8(%rsp)
+    /* save current stack limit */
+    movq  0x10(%r10), %rax
+    movq  %rax, 0xc0(%rsp)
+    /* save current stack base */
+    movq  0x08(%r10), %rax
+    movq  %rax, 0xc8(%rsp)
+
+    /* save callee-saved GP registers */
+    movq  %r12, 0xd0(%rsp)
+    movq  %r13, 0xd8(%rsp)
+    movq  %r14, 0xe0(%rsp)
+    movq  %r15, 0xe8(%rsp)
+    movq  %rdi, 0xf0(%rsp)
+    movq  %rsi, 0xf8(%rsp)
+    movq  %rbx, 0x100(%rsp)
+    movq  %rbp, 0x108(%rsp)
+
+    /* save hidden address of transport_t */
+    movq  %rcx, 0x110(%rsp)
+
+    /* preserve current RSP in RCX */
+    movq  %rsp, %rcx
+
+    /* switch to target stack */
+    movq  %rdx, %rsp
+
+    /* restore XMM registers */
+    movaps  0x00(%rsp), %xmm6
+    movaps  0x10(%rsp), %xmm7
+    movaps  0x20(%rsp), %xmm8
+    movaps  0x30(%rsp), %xmm9
+    movaps  0x40(%rsp), %xmm10
+    movaps  0x50(%rsp), %xmm11
+    movaps  0x60(%rsp), %xmm12
+    movaps  0x70(%rsp), %xmm13
+    movaps  0x80(%rsp), %xmm14
+    movaps  0x90(%rsp), %xmm15
+
+    /* restore MMX control and status word */
+    ldmxcsr 0xa0(%rsp)
+    /* restore x87 control word */
+    fldcw   0xa4(%rsp)
+
+    /* load NT_TIB from TEB */
+    movq  %gs:(0x30), %r10
+
+    /* restore fiber local storage */
+    movq  0xb0(%rsp), %rax
+    movq  %rax, 0x20(%r10)
+    /* restore deallocation stack */
+    movq  0xb8(%rsp), %rax
+    movq  %rax, 0x1478(%r10)
+    /* restore stack limit */
+    movq  0xc0(%rsp), %rax
+    movq  %rax, 0x10(%r10)
+    /* restore stack base */
+    movq  0xc8(%rsp), %rax
+    movq  %rax, 0x08(%r10)
+
+    /* restore callee-saved GP registers */
+    movq  0xd0(%rsp), %r12
+    movq  0xd8(%rsp), %r13
+    movq  0xe0(%rsp), %r14
+    movq  0xe8(%rsp), %r15
+    movq  0xf0(%rsp), %rdi
+    movq  0xf8(%rsp), %rsi
+    movq  0x100(%rsp), %rbx
+    movq  0x108(%rsp), %rbp
+
+    /* restore hidden address of transport_t */
+    movq  0x110(%rsp), %rax
+
+    /* deallocate context-data */
+    leaq  0x118(%rsp), %rsp
+
+    /* keep return-address on stack */
+
+    /* write transport_t */
+    movq  %rcx, 0x0(%rax)
+    movq  %r8, 0x8(%rax)
+
+    /* transport_t as first arg */
+    movq  %rax, %rcx
+    movq  %rax, %rdx
+
+    /* jump to ontop function (R9) */
+    jmp  *%r9
+
+.seh_endproc
+
+/* Export symbols for Windows linker */
+.section .drectve
+.ascii " -export:\"sh_make_fcontext\""
+.ascii " -export:\"sh_jump_fcontext\""
+.ascii " -export:\"sh_ontop_fcontext\""

--- a/shards/core/asm/fcontext_x86_64_ms_pe.S
+++ b/shards/core/asm/fcontext_x86_64_ms_pe.S
@@ -33,11 +33,11 @@
 .text
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * Windows x64 calling convention:
  *   RCX - stack pointer (top of allocated stack)
- *   RDX - stack size
+ *   RDX - stack bottom (used for TEB setup)
  *   R8  - pointer to context function
  * Returns:
  *   RAX - new context handle
@@ -65,15 +65,11 @@ sh_make_fcontext:
     /* save top address of context stack as 'base' for TEB */
     movq  %rcx, 0xc8(%rax)
 
-    /* compute bottom address of context stack (limit) */
-    negq  %rdx
-    leaq  (%rcx,%rdx), %rcx
-
-    /* save bottom address as 'limit' for TEB */
-    movq  %rcx, 0xc0(%rax)
+    /* save bottom address (from stack_bottom param) as 'limit' for TEB */
+    movq  %rdx, 0xc0(%rax)
 
     /* save as 'deallocation stack' for TEB */
-    movq  %rcx, 0xb8(%rax)
+    movq  %rdx, 0xb8(%rax)
 
     /* set fiber local storage to zero */
     xorq  %rcx, %rcx

--- a/shards/core/asm/fcontext_x86_64_sysv_elf.S
+++ b/shards/core/asm/fcontext_x86_64_sysv_elf.S
@@ -31,12 +31,12 @@
 .text
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * Creates a new context on the given stack.
  * Arguments:
  *   rdi - stack pointer (top of allocated stack)
- *   rsi - stack size (unused, kept for API compatibility)
+ *   rsi - stack bottom (unused on this platform)
  *   rdx - pointer to context function
  * Returns:
  *   rax - new context handle (pointer to context data on stack)
@@ -121,6 +121,11 @@ sh_jump_fcontext:
     movq  %rbx, 0x28(%rsp)
     movq  %rbp, 0x30(%rsp)
 
+    /* save return address at RIP slot for consistent layout with make_fcontext */
+    /* return address from call is at RSP+0x40, we save it at RSP+0x38 */
+    movq  0x40(%rsp), %rcx
+    movq  %rcx, 0x38(%rsp)
+
     /* save current stack pointer (our context) in rax for return */
     movq  %rsp, %rax
 
@@ -189,6 +194,10 @@ sh_ontop_fcontext:
     movq  %r15, 0x20(%rsp)
     movq  %rbx, 0x28(%rsp)
     movq  %rbp, 0x30(%rsp)
+
+    /* save return address at RIP slot for consistent layout with make_fcontext */
+    movq  0x40(%rsp), %rcx
+    movq  %rcx, 0x38(%rsp)
 
     /* save current stack pointer (our context) in rax for return */
     movq  %rsp, %rax

--- a/shards/core/asm/fcontext_x86_64_sysv_elf.S
+++ b/shards/core/asm/fcontext_x86_64_sysv_elf.S
@@ -1,0 +1,226 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * x86_64 System V ABI context switching for ELF (Linux, BSD)
+ *
+ * Based on boost::context by Oliver Kowalke (Boost Software License)
+ * Note: Does not include TLS stack guard or CET shadow stack support
+ */
+
+/****************************************************************************************
+ *                                                                                      *
+ *  Context data layout on stack (64 bytes = 0x40):                                     *
+ *  ----------------------------------------------------------------------------------  *
+ *  |   0x00  |   0x04  |   0x08  |   0x0c  |   0x10   |  0x14   |  0x18   |  0x1c   |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  | fc_mxcsr|fc_x87_cw|        R12        |         R13        |        R14        |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  |   0x20  |   0x24  |   0x28  |   0x2c  |   0x30   |  0x34   |  0x38   |  0x3c   |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  |        R15        |        RBX        |         RBP        |        RIP        |  *
+ *  ----------------------------------------------------------------------------------  *
+ *                                                                                      *
+ ****************************************************************************************/
+
+#ifdef __i386__
+# include "fcontext_x86_sysv_elf.S"
+#else
+
+.file "fcontext_x86_64_sysv_elf.S"
+.text
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * Creates a new context on the given stack.
+ * Arguments:
+ *   rdi - stack pointer (top of allocated stack)
+ *   rsi - stack size (unused, kept for API compatibility)
+ *   rdx - pointer to context function
+ * Returns:
+ *   rax - new context handle (pointer to context data on stack)
+ */
+.globl sh_make_fcontext
+.type sh_make_fcontext,@function
+.align 16
+sh_make_fcontext:
+    /* first arg == top of context-stack */
+    movq  %rdi, %rax
+
+    /* align stack pointer to 16-byte boundary */
+    andq  $-16, %rax
+
+    /* reserve space for context-data on stack */
+    /* 0x40 bytes for context + 0x8 for alignment = 0x48 */
+    /* on context-function entry: (RSP - 0x8) % 16 == 0 */
+    leaq  -0x48(%rax), %rax
+
+    /* save address of context-function in RBX slot */
+    movq  %rdx, 0x28(%rax)
+
+    /* save MMX control and status word */
+    stmxcsr  (%rax)
+    /* save x87 control word */
+    fnstcw   0x4(%rax)
+
+    /* compute address of trampoline */
+    leaq  .L_sh_trampoline(%rip), %rcx
+    /* save trampoline as return address (called after first jump) */
+    movq  %rcx, 0x38(%rax)
+
+    /* compute address of finish routine */
+    leaq  .L_sh_finish(%rip), %rcx
+    /* save finish as RBP (will be pushed by trampoline) */
+    movq  %rcx, 0x30(%rax)
+
+    /* return pointer to context-data */
+    ret
+
+.L_sh_trampoline:
+    /* push finish address to stack (for return from context function) */
+    push %rbp
+    /* jump to context-function (address in RBX) */
+    jmp *%rbx
+
+.L_sh_finish:
+    /* context-function returned - exit with code 0 */
+    xorq  %rdi, %rdi
+    call  _exit@PLT
+    hlt
+
+.size sh_make_fcontext,.-sh_make_fcontext
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * Switches to another context.
+ * Arguments:
+ *   rdi - target context to switch to
+ *   rsi - user data to pass to target
+ * Returns:
+ *   transfer_t { fctx = source context, data = passed data }
+ *   (rax = fctx, rdx = data)
+ */
+.globl sh_jump_fcontext
+.type sh_jump_fcontext,@function
+.align 16
+sh_jump_fcontext:
+    /* reserve space for context-data on current stack */
+    leaq  -0x40(%rsp), %rsp
+
+    /* save FPU state */
+    stmxcsr  (%rsp)
+    fnstcw   0x4(%rsp)
+
+    /* save callee-saved registers */
+    movq  %r12, 0x8(%rsp)
+    movq  %r13, 0x10(%rsp)
+    movq  %r14, 0x18(%rsp)
+    movq  %r15, 0x20(%rsp)
+    movq  %rbx, 0x28(%rsp)
+    movq  %rbp, 0x30(%rsp)
+
+    /* save current stack pointer (our context) in rax for return */
+    movq  %rsp, %rax
+
+    /* switch to target stack */
+    movq  %rdi, %rsp
+
+    /* load return address from target context */
+    movq  0x38(%rsp), %r8
+
+    /* restore FPU state */
+    ldmxcsr  (%rsp)
+    fldcw    0x4(%rsp)
+
+    /* restore callee-saved registers */
+    movq  0x8(%rsp), %r12
+    movq  0x10(%rsp), %r13
+    movq  0x18(%rsp), %r14
+    movq  0x20(%rsp), %r15
+    movq  0x28(%rsp), %rbx
+    movq  0x30(%rsp), %rbp
+
+    /* deallocate context-data from target stack */
+    leaq  0x48(%rsp), %rsp
+
+    /* prepare return value: transfer_t { fctx = rax, data = rdx } */
+    movq  %rsi, %rdx
+
+    /* pass transfer_t as first argument to context function */
+    /* RDI = fctx (source context), RSI = data */
+    movq  %rax, %rdi
+
+    /* jump to target */
+    jmp  *%r8
+
+.size sh_jump_fcontext,.-sh_jump_fcontext
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * Switches to another context and executes a function on top of it.
+ * Arguments:
+ *   rdi - target context to switch to
+ *   rsi - user data to pass
+ *   rdx - function to execute on target stack
+ * Returns:
+ *   transfer_t from the ontop function
+ */
+.globl sh_ontop_fcontext
+.type sh_ontop_fcontext,@function
+.align 16
+sh_ontop_fcontext:
+    /* save ontop-function in r8 */
+    movq  %rdx, %r8
+
+    /* reserve space for context-data on current stack */
+    leaq  -0x40(%rsp), %rsp
+
+    /* save FPU state */
+    stmxcsr  (%rsp)
+    fnstcw   0x4(%rsp)
+
+    /* save callee-saved registers */
+    movq  %r12, 0x8(%rsp)
+    movq  %r13, 0x10(%rsp)
+    movq  %r14, 0x18(%rsp)
+    movq  %r15, 0x20(%rsp)
+    movq  %rbx, 0x28(%rsp)
+    movq  %rbp, 0x30(%rsp)
+
+    /* save current stack pointer (our context) in rax for return */
+    movq  %rsp, %rax
+
+    /* switch to target stack */
+    movq  %rdi, %rsp
+
+    /* restore FPU state */
+    ldmxcsr  (%rsp)
+    fldcw    0x4(%rsp)
+
+    /* restore callee-saved registers */
+    movq  0x8(%rsp), %r12
+    movq  0x10(%rsp), %r13
+    movq  0x18(%rsp), %r14
+    movq  0x20(%rsp), %r15
+    movq  0x28(%rsp), %rbx
+    movq  0x30(%rsp), %rbp
+
+    /* deallocate context-data from target stack */
+    leaq  0x40(%rsp), %rsp
+
+    /* prepare transfer_t argument: { fctx = rax, data = rsi } */
+    movq  %rsi, %rdx
+    movq  %rax, %rdi
+
+    /* keep return-address on stack and jump to ontop-function */
+    jmp  *%r8
+
+.size sh_ontop_fcontext,.-sh_ontop_fcontext
+
+/* Mark that we don't need executable stack */
+.section .note.GNU-stack,"",%progbits
+
+#endif

--- a/shards/core/asm/fcontext_x86_64_sysv_macho.S
+++ b/shards/core/asm/fcontext_x86_64_sysv_macho.S
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * x86_64 System V ABI context switching for Mach-O (macOS)
+ *
+ * Based on boost::context by Oliver Kowalke (Boost Software License)
+ */
+
+/****************************************************************************************
+ *                                                                                      *
+ *  Context data layout on stack (64 bytes = 0x40):                                     *
+ *  ----------------------------------------------------------------------------------  *
+ *  |   0x00  |   0x04  |   0x08  |   0x0c  |   0x10   |  0x14   |  0x18   |  0x1c   |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  | fc_mxcsr|fc_x87_cw|        R12        |         R13        |        R14        |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  |   0x20  |   0x24  |   0x28  |   0x2c  |   0x30   |  0x34   |  0x38   |  0x3c   |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  |        R15        |        RBX        |         RBP        |        RIP        |  *
+ *  ----------------------------------------------------------------------------------  *
+ *                                                                                      *
+ ****************************************************************************************/
+
+.text
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * Creates a new context on the given stack.
+ * Arguments:
+ *   rdi - stack pointer (top of allocated stack)
+ *   rsi - stack size (unused, kept for API compatibility)
+ *   rdx - pointer to context function
+ * Returns:
+ *   rax - new context handle (pointer to context data on stack)
+ */
+.private_extern _sh_make_fcontext
+.globl _sh_make_fcontext
+.align 8
+_sh_make_fcontext:
+    /* first arg == top of context-stack */
+    movq  %rdi, %rax
+
+    /* align stack pointer to 16-byte boundary */
+    andq  $-16, %rax
+
+    /* reserve space for context-data on stack */
+    /* 0x40 bytes for context + 0x8 for alignment = 0x48 */
+    /* on context-function entry: (RSP - 0x8) % 16 == 0 */
+    leaq  -0x48(%rax), %rax
+
+    /* save address of context-function in RBX slot */
+    movq  %rdx, 0x28(%rax)
+
+    /* save MMX control and status word */
+    stmxcsr  (%rax)
+    /* save x87 control word */
+    fnstcw   0x4(%rax)
+
+    /* compute address of trampoline */
+    leaq  L_sh_trampoline(%rip), %rcx
+    /* save trampoline as return address (called after first jump) */
+    movq  %rcx, 0x38(%rax)
+
+    /* compute address of finish routine */
+    leaq  L_sh_finish(%rip), %rcx
+    /* save finish as RBP (will be pushed by trampoline) */
+    movq  %rcx, 0x30(%rax)
+
+    /* return pointer to context-data */
+    ret
+
+L_sh_trampoline:
+    /* push finish address to stack (for return from context function) */
+    push %rbp
+    /* jump to context-function (address in RBX) */
+    jmp *%rbx
+
+L_sh_finish:
+    /* context-function returned - exit with code 0 */
+    xorq  %rdi, %rdi
+    call  __exit
+    hlt
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * Switches to another context.
+ * Arguments:
+ *   rdi - target context to switch to
+ *   rsi - user data to pass to target
+ * Returns:
+ *   transfer_t { fctx = source context, data = passed data }
+ *   (rax = fctx, rdx = data)
+ */
+.private_extern _sh_jump_fcontext
+.globl _sh_jump_fcontext
+.align 8
+_sh_jump_fcontext:
+    /* reserve space for context-data on current stack */
+    leaq  -0x40(%rsp), %rsp
+
+    /* save FPU state */
+    stmxcsr  (%rsp)
+    fnstcw   0x4(%rsp)
+
+    /* save callee-saved registers */
+    movq  %r12, 0x8(%rsp)
+    movq  %r13, 0x10(%rsp)
+    movq  %r14, 0x18(%rsp)
+    movq  %r15, 0x20(%rsp)
+    movq  %rbx, 0x28(%rsp)
+    movq  %rbp, 0x30(%rsp)
+
+    /* save current stack pointer (our context) in rax for return */
+    movq  %rsp, %rax
+
+    /* switch to target stack */
+    movq  %rdi, %rsp
+
+    /* load return address from target context */
+    movq  0x38(%rsp), %r8
+
+    /* restore FPU state */
+    ldmxcsr  (%rsp)
+    fldcw    0x4(%rsp)
+
+    /* restore callee-saved registers */
+    movq  0x8(%rsp), %r12
+    movq  0x10(%rsp), %r13
+    movq  0x18(%rsp), %r14
+    movq  0x20(%rsp), %r15
+    movq  0x28(%rsp), %rbx
+    movq  0x30(%rsp), %rbp
+
+    /* deallocate context-data from target stack */
+    leaq  0x48(%rsp), %rsp
+
+    /* prepare return value: transfer_t { fctx = rax, data = rdx } */
+    movq  %rsi, %rdx
+
+    /* pass transfer_t as first argument to context function */
+    /* RDI = fctx (source context), RSI = data */
+    movq  %rax, %rdi
+
+    /* jump to target */
+    jmp  *%r8
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ *
+ * Switches to another context and executes a function on top of it.
+ * Arguments:
+ *   rdi - target context to switch to
+ *   rsi - user data to pass
+ *   rdx - function to execute on target stack
+ * Returns:
+ *   transfer_t from the ontop function
+ */
+.private_extern _sh_ontop_fcontext
+.globl _sh_ontop_fcontext
+.align 8
+_sh_ontop_fcontext:
+    /* save ontop-function in r8 */
+    movq  %rdx, %r8
+
+    /* reserve space for context-data on current stack */
+    leaq  -0x40(%rsp), %rsp
+
+    /* save FPU state */
+    stmxcsr  (%rsp)
+    fnstcw   0x4(%rsp)
+
+    /* save callee-saved registers */
+    movq  %r12, 0x8(%rsp)
+    movq  %r13, 0x10(%rsp)
+    movq  %r14, 0x18(%rsp)
+    movq  %r15, 0x20(%rsp)
+    movq  %rbx, 0x28(%rsp)
+    movq  %rbp, 0x30(%rsp)
+
+    /* save current stack pointer (our context) in rax for return */
+    movq  %rsp, %rax
+
+    /* switch to target stack */
+    movq  %rdi, %rsp
+
+    /* restore FPU state */
+    ldmxcsr  (%rsp)
+    fldcw    0x4(%rsp)
+
+    /* restore callee-saved registers */
+    movq  0x8(%rsp), %r12
+    movq  0x10(%rsp), %r13
+    movq  0x18(%rsp), %r14
+    movq  0x20(%rsp), %r15
+    movq  0x28(%rsp), %rbx
+    movq  0x30(%rsp), %rbp
+
+    /* deallocate context-data from target stack */
+    leaq  0x40(%rsp), %rsp
+
+    /* prepare transfer_t argument: { fctx = rax, data = rsi } */
+    movq  %rsi, %rdx
+    movq  %rax, %rdi
+
+    /* keep return-address on stack and jump to ontop-function */
+    jmp  *%r8

--- a/shards/core/asm/fcontext_x86_64_sysv_macho.S
+++ b/shards/core/asm/fcontext_x86_64_sysv_macho.S
@@ -25,12 +25,12 @@
 .text
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * Creates a new context on the given stack.
  * Arguments:
  *   rdi - stack pointer (top of allocated stack)
- *   rsi - stack size (unused, kept for API compatibility)
+ *   rsi - stack bottom (unused on this platform)
  *   rdx - pointer to context function
  * Returns:
  *   rax - new context handle (pointer to context data on stack)
@@ -113,6 +113,11 @@ _sh_jump_fcontext:
     movq  %rbx, 0x28(%rsp)
     movq  %rbp, 0x30(%rsp)
 
+    /* save return address at RIP slot for consistent layout with make_fcontext */
+    /* return address from call is at RSP+0x40, we save it at RSP+0x38 */
+    movq  0x40(%rsp), %rcx
+    movq  %rcx, 0x38(%rsp)
+
     /* save current stack pointer (our context) in rax for return */
     movq  %rsp, %rax
 
@@ -179,6 +184,10 @@ _sh_ontop_fcontext:
     movq  %r15, 0x20(%rsp)
     movq  %rbx, 0x28(%rsp)
     movq  %rbp, 0x30(%rsp)
+
+    /* save return address at RIP slot for consistent layout with make_fcontext */
+    movq  0x40(%rsp), %rcx
+    movq  %rcx, 0x38(%rsp)
 
     /* save current stack pointer (our context) in rax for return */
     movq  %rsp, %rax

--- a/shards/core/asm/fcontext_x86_sysv_elf.S
+++ b/shards/core/asm/fcontext_x86_sysv_elf.S
@@ -1,0 +1,237 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+/*
+ * x86 (32-bit) System V ABI context switching for ELF (Linux, BSD)
+ *
+ * Based on boost::context by Oliver Kowalke (Boost Software License)
+ */
+
+/****************************************************************************************
+ *                                                                                      *
+ *  Context data layout (32 bytes = 0x20):                                              *
+ *  ----------------------------------------------------------------------------------  *
+ *  |   0x0   |   0x4   |   0x8   |   0xc   |   0x10  |  0x14   |  0x18   |  0x1c   |  *
+ *  ----------------------------------------------------------------------------------  *
+ *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX   |   EBP   |   EIP   | hidden  |  *
+ *  ----------------------------------------------------------------------------------  *
+ *                                                                                      *
+ *  The 'hidden' slot stores the address where transfer_t should be written            *
+ *  (struct return ABI on i386)                                                         *
+ *                                                                                      *
+ ****************************************************************************************/
+
+#ifndef __x86_64__
+
+.file "fcontext_x86_sysv_elf.S"
+.text
+
+/*
+ * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ *
+ * i386 calling convention: args on stack
+ *   [esp+4]  - stack pointer (top of allocated stack)
+ *   [esp+8]  - stack size (unused)
+ *   [esp+12] - pointer to context function
+ * Returns:
+ *   eax - new context handle
+ */
+.globl sh_make_fcontext
+.type sh_make_fcontext,@function
+.align 16
+sh_make_fcontext:
+    /* first arg == top of context-stack */
+    movl 0x4(%esp), %eax
+
+    /* reserve space for first argument of context-function */
+    leal -0x8(%eax), %eax
+
+    /* align stack pointer to 16-byte boundary */
+    andl $-16, %eax
+
+    /* reserve space for context-data (0x24 bytes) + alignment */
+    leal -0x28(%eax), %eax
+
+    /* save address of context-function in EBX slot */
+    movl 0xc(%esp), %ecx
+    movl %ecx, 0x10(%eax)
+
+    /* save MMX control and status word */
+    stmxcsr (%eax)
+    /* save x87 control word */
+    fnstcw 0x4(%eax)
+
+    /* store address for transfer_t return value */
+    leal 0x8(%eax), %ecx
+    movl %ecx, 0x1c(%eax)
+
+    /* compute address of trampoline */
+    call 1f
+1:  popl %ecx
+    addl $.L_sh_trampoline-1b, %ecx
+    /* save trampoline as return address */
+    movl %ecx, 0x18(%eax)
+
+    /* compute address of finish */
+    call 2f
+2:  popl %ecx
+    addl $.L_sh_finish-2b, %ecx
+    /* save finish as EBP (will be pushed by trampoline) */
+    movl %ecx, 0x14(%eax)
+
+    /* return pointer to context-data */
+    ret
+
+.L_sh_trampoline:
+    /* transfer_t is on stack at esp, esp+4 */
+    /* EDI = fctx, ESI = data from jump_fcontext */
+    movl %edi, (%esp)
+    movl %esi, 0x4(%esp)
+    /* push finish address as return address */
+    pushl %ebp
+    /* jump to context-function (address in EBX) */
+    jmp *%ebx
+
+.L_sh_finish:
+    /* compute GOT address for PIC */
+    call 3f
+3:  popl %ebx
+    addl $_GLOBAL_OFFSET_TABLE_+[.-3b], %ebx
+    /* exit with code 0 */
+    xorl %eax, %eax
+    movl %eax, (%esp)
+    call _exit@PLT
+    hlt
+
+.size sh_make_fcontext,.-sh_make_fcontext
+
+/*
+ * transfer_t sh_jump_fcontext(fcontext_t to, void* vp)
+ *
+ * i386 calling convention: args on stack
+ *   [esp+4] - target context
+ *   [esp+8] - user data
+ * Returns:
+ *   transfer_t { eax = fctx, edx = data } via hidden pointer
+ */
+.globl sh_jump_fcontext
+.type sh_jump_fcontext,@function
+.align 16
+sh_jump_fcontext:
+    /* reserve space for context-data */
+    leal -0x1c(%esp), %esp
+
+    /* save FPU state */
+    stmxcsr (%esp)
+    fnstcw 0x4(%esp)
+
+    /* save callee-saved registers */
+    movl %edi, 0x8(%esp)
+    movl %esi, 0xc(%esp)
+    movl %ebx, 0x10(%esp)
+    movl %ebp, 0x14(%esp)
+
+    /* store current ESP in ECX (our context) */
+    movl %esp, %ecx
+
+    /* load target context (arg 1) */
+    movl 0x24(%esp), %eax
+    /* load user data (arg 2) */
+    movl 0x28(%esp), %edx
+
+    /* switch to target stack */
+    movl %eax, %esp
+
+    /* get hidden pointer for struct return */
+    movl 0x1c(%esp), %eax
+    /* write transfer_t: fctx = ecx, data = edx */
+    movl %ecx, (%eax)
+    movl %edx, 0x4(%eax)
+
+    /* load return address */
+    movl 0x18(%esp), %ecx
+
+    /* restore FPU state */
+    ldmxcsr (%esp)
+    fldcw 0x4(%esp)
+
+    /* restore callee-saved registers */
+    movl 0x8(%esp), %edi
+    movl 0xc(%esp), %esi
+    movl 0x10(%esp), %ebx
+    movl 0x14(%esp), %ebp
+
+    /* deallocate context-data */
+    leal 0x20(%esp), %esp
+
+    /* jump to target */
+    jmp *%ecx
+
+.size sh_jump_fcontext,.-sh_jump_fcontext
+
+/*
+ * transfer_t sh_ontop_fcontext(fcontext_t to, void* vp, transfer_t (*fn)(transfer_t))
+ */
+.globl sh_ontop_fcontext
+.type sh_ontop_fcontext,@function
+.align 16
+sh_ontop_fcontext:
+    /* load ontop function pointer */
+    movl 0xc(%esp), %eax
+    movl %eax, -0x4(%esp)
+
+    /* reserve space for context-data */
+    leal -0x1c(%esp), %esp
+
+    /* save FPU state */
+    stmxcsr (%esp)
+    fnstcw 0x4(%esp)
+
+    /* save callee-saved registers */
+    movl %edi, 0x8(%esp)
+    movl %esi, 0xc(%esp)
+    movl %ebx, 0x10(%esp)
+    movl %ebp, 0x14(%esp)
+
+    /* store current ESP in ECX */
+    movl %esp, %ecx
+
+    /* load target context */
+    movl 0x24(%esp), %eax
+    /* load user data */
+    movl 0x28(%esp), %edx
+
+    /* switch to target stack */
+    movl %eax, %esp
+
+    /* restore FPU state */
+    ldmxcsr (%esp)
+    fldcw 0x4(%esp)
+
+    /* restore callee-saved registers */
+    movl 0x8(%esp), %edi
+    movl 0xc(%esp), %esi
+    movl 0x10(%esp), %ebx
+    movl 0x14(%esp), %ebp
+
+    /* deallocate context-data */
+    leal 0x1c(%esp), %esp
+
+    /* get hidden pointer */
+    movl (%esp), %eax
+    /* write transfer_t */
+    movl %ecx, (%eax)
+    movl %edx, 0x4(%eax)
+
+    /* load ontop function */
+    movl 0x4(%esp), %ecx
+
+    /* jump to ontop function */
+    jmp *%ecx
+
+.size sh_ontop_fcontext,.-sh_ontop_fcontext
+
+/* Mark that we don't need executable stack */
+.section .note.GNU-stack,"",%progbits
+
+#endif

--- a/shards/core/asm/fcontext_x86_sysv_elf.S
+++ b/shards/core/asm/fcontext_x86_sysv_elf.S
@@ -27,11 +27,11 @@
 .text
 
 /*
- * fcontext_t sh_make_fcontext(void* sp, size_t size, void (*fn)(transfer_t))
+ * fcontext_t sh_make_fcontext(void* sp, void* stack_bottom, void (*fn)(transfer_t))
  *
  * i386 calling convention: args on stack
  *   [esp+4]  - stack pointer (top of allocated stack)
- *   [esp+8]  - stack size (unused)
+ *   [esp+8]  - stack bottom (unused on this platform)
  *   [esp+12] - pointer to context function
  * Returns:
  *   eax - new context handle

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -105,8 +105,179 @@ void ThreadFiber::switchToThread() {
 
 ThreadFiber::operator bool() const { return !finished; }
 
-#else // SH_USE_THREAD_FIBER
-#ifndef __EMSCRIPTEN__
+#elif SH_CUSTOM_FCONTEXT
+// Custom fcontext-based fiber implementation
+
+#if SH_DEBUG_CONSISTENT_RESUMER
+static bool checkForConsistentResumerCustom() {
+  static bool check = []() {
+    if (std::getenv("SH_IGNORE_CONSISTENT_RESUMER"))
+      return false;
+    return true;
+  }();
+  return check;
+}
+#endif
+
+#ifdef SH_USE_TSAN
+// Thread-local storage for the main TSAN fiber handle
+static thread_local void *tsan_main_fiber_custom = nullptr;
+
+static ALWAYS_INLINE void *getTsanMainFiberCustom() {
+  if (!tsan_main_fiber_custom) {
+    tsan_main_fiber_custom = __tsan_get_current_fiber();
+  }
+  return tsan_main_fiber_custom;
+}
+#endif
+
+Fiber::Fiber(SHStackAllocator allocator) : allocator(allocator) {}
+
+Fiber::~Fiber() {
+#ifdef SH_USE_TSAN
+  if (tsan_fiber) {
+    void *current_fiber = __tsan_get_current_fiber();
+    if (current_fiber == tsan_fiber) {
+      __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
+    }
+    __tsan_destroy_fiber(tsan_fiber);
+    tsan_fiber = nullptr;
+  }
+#endif
+}
+
+void Fiber::fcontextEntry(fcontext::transfer_t t) {
+  // The transfer contains the Fiber pointer and the caller's context
+  Fiber *self = static_cast<Fiber *>(t.data);
+
+  // Store the caller's context so we can return to it
+  self->ctx = t.fctx;
+
+#ifdef SH_USE_ASAN
+  // We just switched TO this fiber, finish the switch
+  __sanitizer_finish_switch_fiber(self->asan_init_fake_stack, nullptr, nullptr);
+#endif
+
+  // Run the user's function
+  self->func();
+
+  // Function returned - switch back to caller
+#ifdef SH_USE_ASAN
+  __sanitizer_start_switch_fiber(nullptr, nullptr, 0);
+#endif
+
+#ifdef SH_USE_TSAN
+  __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
+#endif
+
+  // Jump back to caller - this will terminate the fiber
+  fcontext::sh_jump_fcontext(self->ctx, nullptr);
+}
+
+void Fiber::init(std::function<void()> fn) {
+#if SH_DEBUG_CONSISTENT_RESUMER
+  consistentResumer.emplace(std::this_thread::get_id());
+#endif
+
+  func = std::move(fn);
+
+#ifdef SH_USE_ASAN
+  asan_stack_bottom = allocator.mem;
+  asan_stack_size = allocator.size;
+  __asan_unpoison_memory_region(asan_stack_bottom, asan_stack_size);
+#endif
+
+#ifdef SH_USE_TSAN
+  getTsanMainFiberCustom();
+  shassert(!tsan_fiber && "Fiber::init() called twice");
+  tsan_fiber = __tsan_create_fiber(0);
+#endif
+
+  // Create the context - sp points to top of stack (base + size)
+  void *sp = allocator.mem + allocator.size;
+  ctx = fcontext::sh_make_fcontext(sp, allocator.size, &Fiber::fcontextEntry);
+
+#ifdef SH_USE_ASAN
+  void *init_fake_stack = nullptr;
+  __sanitizer_start_switch_fiber(&init_fake_stack, asan_stack_bottom, asan_stack_size);
+  asan_init_fake_stack = init_fake_stack;
+#endif
+
+#ifdef SH_USE_TSAN
+  __tsan_switch_to_fiber(tsan_fiber, 0);
+#endif
+
+  // Do initial resume to run until first suspend
+  fcontext::transfer_t t = fcontext::sh_jump_fcontext(ctx, this);
+  ctx = t.fctx;
+
+#ifdef SH_USE_ASAN
+  __sanitizer_finish_switch_fiber(init_fake_stack, nullptr, nullptr);
+#endif
+
+#ifdef SH_USE_TSAN
+  __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
+#endif
+}
+
+void Fiber::resume() {
+  shassert(ctx);
+#if SH_DEBUG_CONSISTENT_RESUMER
+  if (checkForConsistentResumerCustom() && (!consistentResumer || *consistentResumer != std::this_thread::get_id()))
+    throw std::runtime_error("Fiber::resume() called from different thread");
+#endif
+
+#ifdef SH_USE_ASAN
+  void *fake_stack = nullptr;
+  __sanitizer_start_switch_fiber(&fake_stack, asan_stack_bottom, asan_stack_size);
+#endif
+
+#ifdef SH_USE_TSAN
+  __tsan_switch_to_fiber(tsan_fiber, 0);
+#endif
+
+  fcontext::transfer_t t = fcontext::sh_jump_fcontext(ctx, this);
+  ctx = t.fctx;
+
+#ifdef SH_USE_ASAN
+  __sanitizer_finish_switch_fiber(fake_stack, nullptr, nullptr);
+#endif
+
+#ifdef SH_USE_TSAN
+  __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
+#endif
+}
+
+void Fiber::suspend() {
+  shassert(ctx);
+#if SH_DEBUG_CONSISTENT_RESUMER
+  if (checkForConsistentResumerCustom() && (!consistentResumer || *consistentResumer != std::this_thread::get_id()))
+    throw std::runtime_error("Fiber::suspend() called from different thread");
+#endif
+
+#ifdef SH_USE_ASAN
+  void *fake_stack = nullptr;
+  __sanitizer_start_switch_fiber(&fake_stack, nullptr, 0);
+#endif
+
+#ifdef SH_USE_TSAN
+  __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
+#endif
+
+  fcontext::transfer_t t = fcontext::sh_jump_fcontext(ctx, nullptr);
+  ctx = t.fctx;
+
+#ifdef SH_USE_ASAN
+  __sanitizer_finish_switch_fiber(fake_stack, nullptr, nullptr);
+#endif
+}
+
+Fiber::operator bool() const {
+  return ctx != nullptr;
+}
+
+#elif !defined(__EMSCRIPTEN__)
+// Boost.Context based fiber implementation (fallback)
 
 #if SH_DEBUG_CONSISTENT_RESUMER
 static bool checkForConsistentResumer() {
@@ -382,6 +553,5 @@ NO_INLINE void Fiber::suspend() {
   emscripten_fiber_swap(&em_fiber, em_parent_fiber);
 }
 
-#endif
-#endif
+#endif // SH_USE_THREAD_FIBER / SH_CUSTOM_FCONTEXT / __EMSCRIPTEN__ chain
 } // namespace shards

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -202,9 +202,11 @@ void Fiber::init(std::function<void()> fn) {
 
   func = std::move(fn);
 
+  // sp points to top of stack (base + size)
+  void *sp = allocator.mem + allocator.size;
+
 #if defined(BOOST_USE_VALGRIND) || defined(SHARDS_VALGRIND)
   // Register stack with Valgrind for proper stack tracking
-  void *sp = allocator.mem + allocator.size;
   valgrind_stack_id = VALGRIND_STACK_REGISTER(sp, allocator.mem);
 #endif
 
@@ -220,8 +222,7 @@ void Fiber::init(std::function<void()> fn) {
   tsan_fiber = __tsan_create_fiber(0);
 #endif
 
-  // Create the context - sp points to top of stack (base + size)
-  void *sp = allocator.mem + allocator.size;
+  // Create the context
   ctx = fcontext::sh_make_fcontext(sp, allocator.mem, &Fiber::fcontextEntry);
 
 #ifdef SH_USE_ASAN

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -176,12 +176,10 @@ void Fiber::fcontextEntry(fcontext::transfer_t t) {
   __sanitizer_start_switch_fiber(nullptr, nullptr, 0);
 #endif
 
-#ifdef SH_USE_TSAN
-  // Switch TSAN tracking to main fiber before final jump.
-  // The fiber will be destroyed after resume() returns, and the
-  // destructor properly checks and handles the TSAN state.
-  __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
-#endif
+  // Note: No TSAN switch here - resume() handles it after the actual context
+  // switch completes. Switching TSAN state before the jump would cause a
+  // temporal inconsistency where TSAN thinks we're on main but we're still
+  // executing on the fiber's stack.
 
   // Jump back to caller - after this the fiber should not be resumed.
   // Note: ctx remains valid after this; the caller should not resume

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -167,14 +167,25 @@ void Fiber::fcontextEntry(fcontext::transfer_t t) {
 #endif
 
 #ifdef SH_USE_TSAN
+  // Switch TSAN tracking to main fiber before final jump.
+  // The fiber will be destroyed after resume() returns, and the
+  // destructor properly checks and handles the TSAN state.
   __tsan_switch_to_fiber(getTsanMainFiberCustom(), 0);
 #endif
 
-  // Jump back to caller - this will terminate the fiber
+  // Jump back to caller - after this the fiber should not be resumed.
+  // Note: ctx remains valid after this; the caller should not resume
+  // the fiber once the function has returned.
   fcontext::sh_jump_fcontext(self->ctx, nullptr);
 }
 
 void Fiber::init(std::function<void()> fn) {
+  // Validate allocator before use
+  shassert(allocator.mem != nullptr && "Stack memory is null");
+  shassert(allocator.size >= 4096 && "Stack size too small (minimum 4096)");
+  // Prevent double-init
+  shassert(!ctx && "Fiber::init() called twice");
+
 #if SH_DEBUG_CONSISTENT_RESUMER
   consistentResumer.emplace(std::this_thread::get_id());
 #endif

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -211,6 +211,9 @@ void Fiber::init(std::function<void()> fn) {
 #ifdef SH_USE_ASAN
   asan_stack_bottom = allocator.mem;
   asan_stack_size = allocator.size;
+  // Unpoison the entire fiber stack. This is necessary because ASAN tracks
+  // stack usage and would otherwise report errors when the fiber accesses
+  // its stack. Also required for exception unwinding to work correctly.
   __asan_unpoison_memory_region(asan_stack_bottom, asan_stack_size);
 #endif
 
@@ -233,7 +236,11 @@ void Fiber::init(std::function<void()> fn) {
   __tsan_switch_to_fiber(tsan_fiber, 0);
 #endif
 
-  // Do initial resume to run until first suspend
+  // Do initial resume to run until first suspend.
+  // The jump switches to the new context, which runs fcontextEntry until it
+  // suspends. When it suspends, control returns here with a new context handle
+  // in t.fctx - this is the suspended fiber's context, which replaces the
+  // initial context created by sh_make_fcontext.
   fcontext::transfer_t t = fcontext::sh_jump_fcontext(ctx, this);
   ctx = t.fctx;
 

--- a/shards/core/coro.cpp
+++ b/shards/core/coro.cpp
@@ -10,6 +10,10 @@
 #include <cstdlib>
 #endif
 
+#if defined(BOOST_USE_VALGRIND) || defined(SHARDS_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
 // Enable for verbose fiber logging
 #ifndef SH_EM_FIBER_TRACE_LOGS
 #define SH_EM_FIBER_TRACE_LOGS 0
@@ -134,6 +138,12 @@ static ALWAYS_INLINE void *getTsanMainFiberCustom() {
 Fiber::Fiber(SHStackAllocator allocator) : allocator(allocator) {}
 
 Fiber::~Fiber() {
+#if defined(BOOST_USE_VALGRIND) || defined(SHARDS_VALGRIND)
+  if (valgrind_stack_id) {
+    VALGRIND_STACK_DEREGISTER(valgrind_stack_id);
+  }
+#endif
+
 #ifdef SH_USE_TSAN
   if (tsan_fiber) {
     void *current_fiber = __tsan_get_current_fiber();
@@ -192,6 +202,12 @@ void Fiber::init(std::function<void()> fn) {
 
   func = std::move(fn);
 
+#if defined(BOOST_USE_VALGRIND) || defined(SHARDS_VALGRIND)
+  // Register stack with Valgrind for proper stack tracking
+  void *sp = allocator.mem + allocator.size;
+  valgrind_stack_id = VALGRIND_STACK_REGISTER(sp, allocator.mem);
+#endif
+
 #ifdef SH_USE_ASAN
   asan_stack_bottom = allocator.mem;
   asan_stack_size = allocator.size;
@@ -206,7 +222,7 @@ void Fiber::init(std::function<void()> fn) {
 
   // Create the context - sp points to top of stack (base + size)
   void *sp = allocator.mem + allocator.size;
-  ctx = fcontext::sh_make_fcontext(sp, allocator.size, &Fiber::fcontextEntry);
+  ctx = fcontext::sh_make_fcontext(sp, allocator.mem, &Fiber::fcontextEntry);
 
 #ifdef SH_USE_ASAN
   void *init_fake_stack = nullptr;

--- a/shards/core/coro.hpp
+++ b/shards/core/coro.hpp
@@ -30,13 +30,6 @@
 #define SH_DEBUG_CONSISTENT_RESUMER 0
 #endif
 
-// Enable to assert on consistent resuming
-// this is required to pass for the emscripten version to work correctly
-// since fiber state is stored on the calling JS stack
-#ifndef SH_DEBUG_CONSISTENT_RESUMER
-#define SH_DEBUG_CONSISTENT_RESUMER 0
-#endif
-
 // Defining SH_USE_THREAD_FIBER uses threads as fibers to aid in debugging
 // Set SHARDS_THREAD_FIBER=ON in cmake to enable
 #if SH_USE_THREAD_FIBER
@@ -87,6 +80,11 @@ using Fiber = ThreadFiber;
 #include "fcontext.hpp"
 #include <shards/log/log.hpp>
 
+// Valgrind stack registration support
+#if defined(BOOST_USE_VALGRIND) || defined(SHARDS_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
 // ASAN fiber support
 #ifdef SH_USE_ASAN
 #include <sanitizer/asan_interface.h>
@@ -122,6 +120,10 @@ private:
 
 #if SH_DEBUG_CONSISTENT_RESUMER
   std::optional<std::thread::id> consistentResumer;
+#endif
+
+#if defined(BOOST_USE_VALGRIND) || defined(SHARDS_VALGRIND)
+  unsigned valgrind_stack_id{0};
 #endif
 
 #ifdef SH_USE_ASAN

--- a/shards/core/coro.hpp
+++ b/shards/core/coro.hpp
@@ -81,8 +81,76 @@ private:
 };
 using Fiber = ThreadFiber;
 } // namespace shards
-#else // SH_USE_THREAD_FIBER
-#ifndef __EMSCRIPTEN__
+#elif SH_CUSTOM_FCONTEXT
+// Custom assembly-based fiber implementation
+#define SH_CORO_NEED_STACK_MEM 1
+#include "fcontext.hpp"
+#include <shards/log/log.hpp>
+
+// ASAN fiber support
+#ifdef SH_USE_ASAN
+#include <sanitizer/asan_interface.h>
+extern "C" {
+void __sanitizer_start_switch_fiber(void **fake_stack_save, const void *stack_bottom, size_t stack_size);
+void __sanitizer_finish_switch_fiber(void *fake_stack_save, const void **stack_bottom_old, size_t *stack_size_old);
+}
+#endif
+
+// TSAN fiber support
+#ifdef SH_USE_TSAN
+extern "C" {
+void *__tsan_get_current_fiber(void);
+void *__tsan_create_fiber(unsigned flags);
+void __tsan_destroy_fiber(void *fiber);
+void __tsan_switch_to_fiber(void *fiber, unsigned flags);
+void __tsan_set_fiber_name(void *fiber, const char *name);
+}
+#endif
+
+namespace shards {
+// Stack allocator for custom fcontext
+struct SHStackAllocator {
+  size_t size{SH_BASE_STACK_SIZE};
+  uint8_t *mem{nullptr};
+};
+
+struct Fiber {
+private:
+  SHStackAllocator allocator;
+  fcontext::fcontext_t ctx{nullptr};
+  std::function<void()> func;
+
+#if SH_DEBUG_CONSISTENT_RESUMER
+  std::optional<std::thread::id> consistentResumer;
+#endif
+
+#ifdef SH_USE_ASAN
+  const void *asan_stack_bottom{nullptr};
+  size_t asan_stack_size{0};
+  void *asan_init_fake_stack{nullptr};
+#endif
+
+#ifdef SH_USE_TSAN
+  void *tsan_fiber{nullptr};
+#endif
+
+  // Trampoline function called by fcontext on first resume
+  static void fcontextEntry(fcontext::transfer_t t);
+
+public:
+  Fiber(SHStackAllocator allocator);
+  ~Fiber();
+  Fiber(const Fiber &) = delete;
+  Fiber &operator=(const Fiber &) = delete;
+  void init(std::function<void()> fn);
+  void resume();
+  void suspend();
+  operator bool() const;
+};
+} // namespace shards
+
+#elif !defined(__EMSCRIPTEN__)
+// Boost.Context based fiber (fallback)
 #define SH_CORO_NEED_STACK_MEM 1
 #define SH_BOOST_COROUTINE 1
 #include <boost/context/continuation.hpp>
@@ -245,8 +313,7 @@ struct Fiber {
   uint8_t *c_stack{nullptr};
 };
 } // namespace shards
-#endif // SHARDS_USE_JSPI
-#endif // SH_USE_THREAD_FIBER
+#endif // SH_USE_THREAD_FIBER / SH_CUSTOM_FCONTEXT / __EMSCRIPTEN__ chain
 
 namespace shards {
 using Coroutine = std::optional<Fiber>;

--- a/shards/core/fcontext.hpp
+++ b/shards/core/fcontext.hpp
@@ -22,7 +22,11 @@ struct transfer_t {
 
 // Create a new fiber context on the given stack
 // sp: Stack pointer (top of allocated stack memory, i.e., base + size)
-// stack_bottom: Bottom of the stack (used for TEB setup on Windows, ignored elsewhere)
+// stack_bottom: Bottom of the stack. On Windows, this is used to set up the
+//               Thread Environment Block (TEB) stack limit/base fields for
+//               proper SEH and stack overflow detection. On other platforms
+//               this parameter is ignored but should still be passed for API
+//               consistency.
 // fn: Entry function to call when context is first resumed
 // Returns: New context handle
 extern "C" fcontext_t sh_make_fcontext(void *sp, void *stack_bottom, void (*fn)(transfer_t));

--- a/shards/core/fcontext.hpp
+++ b/shards/core/fcontext.hpp
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2020 Fragcolor Pte. Ltd. */
+
+#ifndef SH_CORE_FCONTEXT_HPP
+#define SH_CORE_FCONTEXT_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+namespace shards {
+namespace fcontext {
+
+// Opaque context handle - points to saved register state on stack
+typedef void *fcontext_t;
+
+// Transfer structure returned by jump_fcontext
+// Contains the context we came from and optional user data
+struct transfer_t {
+  fcontext_t fctx; // Context that yielded to us
+  void *data;      // User data passed through the switch
+};
+
+// Create a new fiber context on the given stack
+// sp: Stack pointer (top of allocated stack memory, i.e., base + size)
+// size: Size of the allocated stack in bytes
+// fn: Entry function to call when context is first resumed
+// Returns: New context handle, or nullptr on failure
+extern "C" fcontext_t sh_make_fcontext(void *sp, std::size_t size, void (*fn)(transfer_t));
+
+// Switch to target context
+// to: Context to switch to
+// vp: User data to pass to the target context
+// Returns: transfer_t containing the context we came from and data it passed
+extern "C" transfer_t sh_jump_fcontext(fcontext_t const to, void *vp);
+
+// Switch to target context and execute function on its stack
+// to: Context to switch to
+// vp: User data to pass
+// fn: Function to execute on target's stack before resuming target
+// Returns: transfer_t from the eventual return
+extern "C" transfer_t sh_ontop_fcontext(fcontext_t const to, void *vp, transfer_t (*fn)(transfer_t));
+
+} // namespace fcontext
+} // namespace shards
+
+#endif // SH_CORE_FCONTEXT_HPP

--- a/shards/core/fcontext.hpp
+++ b/shards/core/fcontext.hpp
@@ -22,10 +22,10 @@ struct transfer_t {
 
 // Create a new fiber context on the given stack
 // sp: Stack pointer (top of allocated stack memory, i.e., base + size)
-// size: Size of the allocated stack in bytes
+// stack_bottom: Bottom of the stack (used for TEB setup on Windows, ignored elsewhere)
 // fn: Entry function to call when context is first resumed
-// Returns: New context handle, or nullptr on failure
-extern "C" fcontext_t sh_make_fcontext(void *sp, std::size_t size, void (*fn)(transfer_t));
+// Returns: New context handle
+extern "C" fcontext_t sh_make_fcontext(void *sp, void *stack_bottom, void (*fn)(transfer_t));
 
 // Switch to target context
 // to: Context to switch to


### PR DESCRIPTION
Implements custom context switching assembly for multiple architectures:
- x86_64 (ELF and Mach-O)
- x86 32-bit (ELF)
- ARM64 (ELF and Mach-O)
- ARM32 (ELF)
- RISC-V rv32/rv64 unified (ELF)

Key changes:
- New fcontext.hpp with low-level API (sh_make_fcontext, sh_jump_fcontext)
- Architecture-specific assembly in shards/core/asm/
- CMake auto-detection selects correct assembly per platform
- SH_USE_BOOST_CONTEXT option for fallback
- Preserves ASAN/TSAN sanitizer support

Based on boost::context patterns (x86/ARM) and corosensei (RISC-V).


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->
