### PR TITLE
Add SOCKS proxy support to HTTP module

### DIFF
--- a/shards/modules/http/CMakeLists.txt
+++ b/shards/modules/http/CMakeLists.txt
@@ -15,7 +15,7 @@ if(HTTP_SUPPORTED)
     # Rust-only build with rustls
     add_rust_library(NAME shards-http
       PROJECT_PATH ${CMAKE_CURRENT_LIST_DIR}
-      FEATURES rustls)
+      FEATURES rustls socks)
 
     add_shards_module(http
       RUST_TARGETS shards-http-rust
@@ -29,7 +29,7 @@ if(HTTP_SUPPORTED)
     if(NOT EMSCRIPTEN)
       add_rust_library(NAME shards-http
         PROJECT_PATH ${CMAKE_CURRENT_LIST_DIR}
-        FEATURES native-tls)
+        FEATURES native-tls socks)
       set(RUST_TARGETS_ARG RUST_TARGETS shards-http-rust)
       list(APPEND REGISTER_SHARDS_ARG rust)
     endif()

--- a/shards/modules/http/Cargo.toml
+++ b/shards/modules/http/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["rlib", "staticlib"]
 # No default - must explicitly choose native-tls or rustls
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
+socks = ["reqwest/socks"]
 
 [dependencies]
 lazy_static = "1.5.0"

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -223,7 +223,7 @@ static HEADERS_TYPES: &[Type] = &[
   common_type::string_table,
   common_type::string_table_var,
 ];
-static PROXY_TYPES: &[Type] = &[common_type::none, common_type::string, common_type::string_var];
+static PROXY_TYPES: &[Type] = &[common_type::none, common_type::string];
 
 struct RequestBase {
   client: Option<our_client::OurClient>,
@@ -335,16 +335,6 @@ impl RequestBase {
       };
       self.required.push(exp_info);
     }
-    if self.proxy.is_variable() {
-      let exp_info = ExposedInfo {
-        exposedType: common_type::string,
-        name: self.proxy.get_name(),
-        help: shccstr!("The proxy URL."),
-        ..ExposedInfo::default()
-      };
-      self.required.push(exp_info);
-    }
-
     Some(&self.required)
   }
 
@@ -356,24 +346,19 @@ impl RequestBase {
     self.url.warmup(context);
     self.headers.warmup(context);
     self.proxy.warmup(context);
-    Ok(())
-  }
 
-  fn _ensure_client(&mut self, context: &Context) -> Result<(), &'static str> {
-    // Build config signature for dynamic cache key based on current proxy value
+    // Read proxy value (static, resolved at warmup)
     let proxy_url = {
       let p = self.proxy.get();
       if p.is_none() {
         None
       } else {
         let s: &str = p.try_into().map_err(|_| "Invalid proxy URL")?;
-        if s.is_empty() {
-          None
-        } else {
-          Some(s.to_string())
-        }
+        if s.is_empty() { None } else { Some(s.to_string()) }
       }
     };
+
+    // Build config signature for cache key (proxy and invalid_certs are static)
     let config = ClientConfig {
       proxy_url: proxy_url.clone(),
       invalid_certs: self.invalid_certs,
@@ -692,7 +677,6 @@ macro_rules! get_like {
       }
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &'static str> {
-        self.rb._ensure_client(context)?;
         let request = self.rb.url.get();
         let request_string: &str = request.try_into()?;
         let mut request = self.rb.client.as_ref().ok_or("No HTTP client")?.0.$call(request_string);
@@ -870,7 +854,6 @@ macro_rules! post_like {
       }
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &'static str> {
-        self.rb._ensure_client(context)?;
         let request = self.rb.url.get();
         let request_string: &str = request.try_into()?;
 

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -174,6 +174,12 @@ lazy_static! {
       INT_TYPES_SLICE
     )
       .into(),
+    (
+      cstr!("Proxy"),
+      shccstr!("Proxy URL (http://host:port, socks5://host:port, or socks5h://host:port for remote DNS)."),
+      PROXY_TYPES
+    )
+      .into(),
   ];
 }
 
@@ -197,12 +203,27 @@ mod our_client {
   }
 }
 
+struct ClientConfig {
+  proxy_url: Option<String>,
+  invalid_certs: bool,
+}
+
+impl ClientConfig {
+  fn cache_key(&self) -> String {
+    match &self.proxy_url {
+      Some(url) => format!("Http.Client.{}.{}", url, self.invalid_certs),
+      None => format!("Http.Client.none.{}", self.invalid_certs),
+    }
+  }
+}
+
 static URL_TYPES: &[Type] = &[common_type::string, common_type::string_var];
 static HEADERS_TYPES: &[Type] = &[
   common_type::none,
   common_type::string_table,
   common_type::string_table_var,
 ];
+static PROXY_TYPES: &[Type] = &[common_type::none, common_type::string, common_type::string_var];
 
 struct RequestBase {
   client: Option<our_client::OurClient>,
@@ -219,6 +240,7 @@ struct RequestBase {
   streaming: bool,
   task_cancel: Option<CancellationToken>,
   global_client: Option<VarRef>,
+  proxy: ParamVar,
 }
 
 impl Default for RequestBase {
@@ -238,6 +260,7 @@ impl Default for RequestBase {
       streaming: false,
       task_cancel: None,
       global_client: None,
+      proxy: ParamVar::new(().into()),
     }
   }
 }
@@ -270,6 +293,7 @@ impl RequestBase {
       6 => Ok(self.retry = value.try_into().map_err(|_x| "Failed to set retry")?),
       7 => Ok(self.streaming = value.try_into().map_err(|_x| "Failed to set streaming")?),
       8 => Ok(self.backoff = value.try_into().map_err(|_x| "Failed to set backoff")?),
+      9 => self.proxy.set_param(value),
       _ => unreachable!(),
     }
   }
@@ -285,6 +309,7 @@ impl RequestBase {
       6 => self.retry.try_into().expect("A valid integer in range"),
       7 => self.streaming.into(),
       8 => self.backoff.try_into().expect("A valid integer in range"),
+      9 => self.proxy.get_param(),
       _ => unreachable!(),
     }
   }
@@ -310,6 +335,15 @@ impl RequestBase {
       };
       self.required.push(exp_info);
     }
+    if self.proxy.is_variable() {
+      let exp_info = ExposedInfo {
+        exposedType: common_type::string,
+        name: self.proxy.get_name(),
+        help: shccstr!("The proxy URL."),
+        ..ExposedInfo::default()
+      };
+      self.required.push(exp_info);
+    }
 
     Some(&self.required)
   }
@@ -319,22 +353,57 @@ impl RequestBase {
   }
 
   fn _warmup(&mut self, context: &Context) -> Result<(), &'static str> {
-    let mut global_client = VarRef::referenceGlobal(context, "Http.Client");
+    self.url.warmup(context);
+    self.headers.warmup(context);
+    self.proxy.warmup(context);
+
+    // Build config signature for dynamic cache key
+    let proxy_url = {
+      let p = self.proxy.get();
+      if p.is_none() {
+        None
+      } else {
+        let s: &str = p.try_into().map_err(|_| "Invalid proxy URL")?;
+        if s.is_empty() {
+          None
+        } else {
+          Some(s.to_string())
+        }
+      }
+    };
+    let config = ClientConfig {
+      proxy_url: proxy_url.clone(),
+      invalid_certs: self.invalid_certs,
+    };
+    let cache_key = config.cache_key();
+
+    // Use VarRef::referenceGlobal with dynamic key (per-mesh caching)
+    let mut global_client = VarRef::referenceGlobal(context, &cache_key);
+
     if global_client.as_mut().is_none() {
-      // Create a new client
-      let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(self.invalid_certs)
-        .build()
-        .map_err(|e| {
-          print_error(&e);
-          "Failed to create client"
+      // Create new client with proxy config
+      let mut builder = reqwest::Client::builder()
+        .danger_accept_invalid_certs(self.invalid_certs);
+
+      if let Some(ref proxy_url) = proxy_url {
+        let proxy = reqwest::Proxy::all(proxy_url).map_err(|e| {
+          shlog_error!("Invalid proxy URL '{}': {}. Supported formats: http://host:port, socks5://host:port, socks5h://host:port", proxy_url, e);
+          "Invalid proxy URL (supported: http://, socks5://, socks5h://)"
         })?;
+        builder = builder.proxy(proxy);
+      }
+
+      let client = builder.build().map_err(|e| {
+        print_error(&e);
+        "Failed to create HTTP client"
+      })?;
       let client = our_client::OurClient(client);
       let client_var = Var::new_ref_counted(client.clone(), &*CLIENT_TYPE);
       cloneVar(&mut global_client.as_mut(), &client_var);
-      self.client = Some(client); // internally already Arc-ed
+      self.client = Some(client);
       self.global_client = Some(global_client);
     } else {
+      // Reuse existing client from mesh-global storage
       let client = unsafe {
         Var::from_ref_counted_object::<our_client::OurClient>(global_client.as_mut(), &*CLIENT_TYPE)
       };
@@ -343,8 +412,6 @@ impl RequestBase {
       self.global_client = Some(global_client);
     }
 
-    self.url.warmup(context);
-    self.headers.warmup(context);
     Ok(())
   }
 
@@ -358,6 +425,7 @@ impl RequestBase {
 
     self.url.cleanup(ctx);
     self.headers.cleanup(ctx);
+    self.proxy.cleanup(ctx);
     self._close_client();
     self.output = ClonedVar::default();
 
@@ -860,6 +928,9 @@ macro_rules! post_like {
             request = request.header(hname, hvalue);
           }
         }
+
+        let timeout = Duration::from_secs(self.rb.timeout);
+        request = request.timeout(timeout);
 
         if self.rb.retry == 0 {
           let _ = self.rb._finalize(context, request)?;

--- a/shards/modules/http/src/lib.rs
+++ b/shards/modules/http/src/lib.rs
@@ -356,8 +356,11 @@ impl RequestBase {
     self.url.warmup(context);
     self.headers.warmup(context);
     self.proxy.warmup(context);
+    Ok(())
+  }
 
-    // Build config signature for dynamic cache key
+  fn _ensure_client(&mut self, context: &Context) -> Result<(), &'static str> {
+    // Build config signature for dynamic cache key based on current proxy value
     let proxy_url = {
       let p = self.proxy.get();
       if p.is_none() {
@@ -689,9 +692,10 @@ macro_rules! get_like {
       }
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &'static str> {
+        self.rb._ensure_client(context)?;
         let request = self.rb.url.get();
         let request_string: &str = request.try_into()?;
-        let mut request = self.rb.client.as_ref().unwrap().0.$call(request_string);
+        let mut request = self.rb.client.as_ref().ok_or("No HTTP client")?.0.$call(request_string);
 
         let headers = self.rb.headers.get();
         if !headers.is_none() {
@@ -866,10 +870,11 @@ macro_rules! post_like {
       }
 
       fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &'static str> {
+        self.rb._ensure_client(context)?;
         let request = self.rb.url.get();
         let request_string: &str = request.try_into()?;
 
-        let mut request = self.rb.client.as_ref().unwrap().0.$call(request_string);
+        let mut request = self.rb.client.as_ref().ok_or("No HTTP client")?.0.$call(request_string);
 
         let headers = self.rb.headers.get();
 


### PR DESCRIPTION
Add Proxy parameter to Http.Get/Post/etc shards supporting:
- HTTP proxies (http://host:port)
- SOCKS5 proxies (socks5://host:port)
- SOCKS5 with remote DNS (socks5h://host:port)

Implements signature-based client caching using VarRef::referenceGlobal with dynamic keys based on (proxy_url, invalid_certs) config hash. Different proxy configurations get different cached clients within the same mesh while maintaining per-mesh isolation.


<!--
Before submitting your PR, please review the following checklist:

- [ ] **DO NOT** submit a PR without having discussed the change first in a related issue. If none exist, create one first.
- [ ] **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] **DO** keep pull requests small so they can be easily reviewed.
- [ ] **DO** make sure all unit tests pass.
- [ ] **DO** make sure not to introduce any new compiler warnings.
- [ ] **AVOID** breaking the continuous integration build.
- [ ] **AVOID** making significant changes to the overall architecture.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a Proxy parameter (http/socks5/socks5h) and cache HTTP clients per (proxy_url, invalid_certs); enable socks feature in builds and apply timeouts with safer client handling.
> 
> - **HTTP module**:
>   - **Proxy support**: New `Proxy` parameter for `Http.Get/Post/Put/Patch/Delete/Head` accepting `http://`, `socks5://`, and `socks5h://`; validates and applies proxy to the `reqwest` client.
>   - **Client caching**: Introduce `ClientConfig` and cache keying via `VarRef::referenceGlobal` based on `proxy_url` and `invalid_certs`, enabling per-mesh, per-config client reuse.
>   - **Timeouts & safety**: Apply per-request `timeout`; replace `unwrap()` with explicit client check/errors; warmup/cleanup now handle `Proxy` param.
> - **Build/Deps**:
>   - Enable `reqwest` `socks` feature in `Cargo.toml` and CMake (`FEATURES ... socks`) for both `rustls` and `native-tls` targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa597e0d83a334dc8b192056d29c10b4137eb2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->