### PR TITLE
Fix false requires_interaction detection in shell completion

### DIFF
--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -166,9 +166,11 @@ fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
 
         // Check sentinel marker first (most reliable)
         if let Some(m) = marker {
-            if trimmed.contains(m) {
-                return true;
-            }
+            // When sentinel marker is set, ONLY trust the sentinel.
+            // Generic prompt patterns ($ # > %) cause false positives with
+            // heredoc continuation prompts and command output that happens
+            // to end with these characters.
+            return trimmed.contains(m);
         }
 
         // Exclude interactive program prompts like >>> (Python), >> (continuation)
@@ -176,7 +178,7 @@ fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
             return false;
         }
 
-        // Check for common SHELL prompt patterns
+        // Check for common SHELL prompt patterns (fallback when no sentinel)
         trimmed.ends_with("$ ")
             || trimmed.ends_with("$")
             || trimmed.ends_with("# ")
@@ -790,8 +792,17 @@ impl BlockingShard for ExecuteShard {
         let mut no_data_count = 0;
         let mut prompt_detected = false;
         let mut was_truncated = false;
+        let mut seen_command_echo = false;
 
-        shlog_trace!("Starting to read command output from shared buffer");
+        // Scale silence threshold with timeout: at least 1/3 of max_iterations,
+        // but no less than the default 3 seconds. This prevents false
+        // requires_interaction on slow commands (network I/O, compilation, etc.)
+        let silence_threshold = std::cmp::max(
+            INTERACTIVE_DETECTION_ITERATIONS,
+            max_iterations / 3,
+        );
+
+        shlog_trace!("Starting to read command output from shared buffer (silence_threshold={})", silence_threshold);
         std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
 
         for iteration in 0..max_iterations {
@@ -818,6 +829,16 @@ impl BlockingShard for ExecuteShard {
 
                 let output_str = String::from_utf8_lossy(&output_buffer);
 
+                // Track whether the command echo-back has been received.
+                // The PTY echoes the command text followed by a newline before
+                // producing actual output. Don't start counting silence until
+                // we've seen this echo, to avoid false requires_interaction on
+                // commands that are slow to produce their first real output.
+                if !seen_command_echo && output_str.contains('\n') {
+                    seen_command_echo = true;
+                    shlog_trace!("Command echo-back detected");
+                }
+
                 shlog_trace!(
                     "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
                     iteration,
@@ -833,7 +854,7 @@ impl BlockingShard for ExecuteShard {
                     break;
                 }
 
-                // Bug 3 fix: check for interactive prompt IMMEDIATELY when we have data
+                // Check for interactive prompt IMMEDIATELY when we have data
                 if is_interactive_prompt(&output_str) {
                     shlog_trace!("Interactive prompt pattern detected early: {:?}", output_str.lines().last());
                     break;
@@ -843,14 +864,17 @@ impl BlockingShard for ExecuteShard {
             } else {
                 no_data_count += 1;
                 shlog_trace!(
-                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}",
+                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}, seen_echo: {}",
                     iteration,
                     no_data_count,
-                    output_buffer.is_empty()
+                    output_buffer.is_empty(),
+                    seen_command_echo
                 );
 
-                // Fallback interactive detection after 3 seconds of silence with some output
-                if no_data_count >= INTERACTIVE_DETECTION_ITERATIONS && !output_buffer.is_empty() && iteration >= INTERACTIVE_DETECTION_ITERATIONS / 2 {
+                // Fallback interactive detection after silence threshold expires.
+                // Only trigger if we've seen the command echo-back — before that,
+                // the command hasn't had a chance to produce output yet.
+                if no_data_count >= silence_threshold && !output_buffer.is_empty() && seen_command_echo {
                     let output_str = String::from_utf8_lossy(&output_buffer);
 
                     if is_prompt_or_marker(&output_str, marker) {
@@ -864,7 +888,8 @@ impl BlockingShard for ExecuteShard {
                         break;
                     }
 
-                    shlog_trace!("Command appears to be interactive (no new data for 3s, no prompt detected)");
+                    shlog_trace!("Command appears to be interactive (no new data for {}ms, no prompt detected)",
+                        silence_threshold as u64 * ITERATION_SLEEP_MS);
                     break;
                 }
             }

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -811,6 +811,14 @@ impl BlockingShard for ExecuteShard {
             let has_new_data = current_total > last_total_bytes;
 
             if has_new_data {
+                // Mark that the command has started producing output.
+                // Done before truncation so that small MaxOutputBytes or
+                // fast/large output can't cause us to miss the signal.
+                if !seen_command_echo {
+                    seen_command_echo = true;
+                    shlog_trace!("Command has started producing output");
+                }
+
                 // New data arrived — snapshot the buffer contents
                 let snapshot = {
                     let shared_buffer = local_shell.output_buffer.lock()
@@ -828,16 +836,6 @@ impl BlockingShard for ExecuteShard {
                 }
 
                 let output_str = String::from_utf8_lossy(&output_buffer);
-
-                // Track whether the command echo-back has been received.
-                // The PTY echoes the command text followed by a newline before
-                // producing actual output. Don't start counting silence until
-                // we've seen this echo, to avoid false requires_interaction on
-                // commands that are slow to produce their first real output.
-                if !seen_command_echo && output_str.contains('\n') {
-                    seen_command_echo = true;
-                    shlog_trace!("Command echo-back detected");
-                }
 
                 shlog_trace!(
                     "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
@@ -872,9 +870,9 @@ impl BlockingShard for ExecuteShard {
                 );
 
                 // Fallback interactive detection after silence threshold expires.
-                // Only trigger if we've seen the command echo-back — before that,
-                // the command hasn't had a chance to produce output yet.
-                if no_data_count >= silence_threshold && !output_buffer.is_empty() && seen_command_echo {
+                // Only trigger if the command has started producing output —
+                // before that, the command hasn't had a chance to run yet.
+                if no_data_count >= silence_threshold && seen_command_echo {
                     let output_str = String::from_utf8_lossy(&output_buffer);
 
                     if is_prompt_or_marker(&output_str, marker) {

--- a/shards/modules/ssh/src/lib.rs
+++ b/shards/modules/ssh/src/lib.rs
@@ -1003,6 +1003,14 @@ impl BlockingShard for ExecuteShard {
             let has_new_data = current_total > last_total_bytes;
 
             if has_new_data {
+                // Mark that the command has started producing output.
+                // Done before truncation so that small MaxOutputBytes or
+                // fast/large output can't cause us to miss the signal.
+                if !seen_command_echo {
+                    seen_command_echo = true;
+                    shlog_trace!("Command has started producing output");
+                }
+
                 let snapshot = {
                     let shared_buffer = ssh_shell.output_buffer.lock()
                         .map_err(|_| "Buffer lock poisoned")?;
@@ -1018,16 +1026,6 @@ impl BlockingShard for ExecuteShard {
                 }
 
                 let output_str = String::from_utf8_lossy(&output_buffer);
-
-                // Track whether the command echo-back has been received.
-                // The shell echoes the command text followed by a newline before
-                // producing actual output. Don't start counting silence until
-                // we've seen this echo, to avoid false requires_interaction on
-                // commands that are slow to produce their first real output.
-                if !seen_command_echo && output_str.contains('\n') {
-                    seen_command_echo = true;
-                    shlog_trace!("Command echo-back detected");
-                }
 
                 shlog_trace!(
                     "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
@@ -1060,9 +1058,9 @@ impl BlockingShard for ExecuteShard {
                 );
 
                 // Fallback interactive detection after silence threshold expires.
-                // Only trigger if we've seen the command echo-back — before that,
-                // the command hasn't had a chance to produce output yet.
-                if no_data_count >= silence_threshold && !output_buffer.is_empty() && seen_command_echo {
+                // Only trigger if the command has started producing output —
+                // before that, the command hasn't had a chance to run yet.
+                if no_data_count >= silence_threshold && seen_command_echo {
                     let output_str = String::from_utf8_lossy(&output_buffer);
 
                     if is_prompt_or_marker(&output_str, marker) {

--- a/shards/modules/ssh/src/lib.rs
+++ b/shards/modules/ssh/src/lib.rs
@@ -152,9 +152,11 @@ fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
 
         // Check sentinel marker first (most reliable)
         if let Some(m) = marker {
-            if trimmed.contains(m) {
-                return true;
-            }
+            // When sentinel marker is set, ONLY trust the sentinel.
+            // Generic prompt patterns ($ # > %) cause false positives with
+            // heredoc continuation prompts and command output that happens
+            // to end with these characters.
+            return trimmed.contains(m);
         }
 
         // Exclude interactive program prompts like >>> (Python), >> (continuation)
@@ -162,7 +164,7 @@ fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
             return false;
         }
 
-        // Check for common SHELL prompt patterns
+        // Check for common SHELL prompt patterns (fallback when no sentinel)
         trimmed.ends_with("$ ")
             || trimmed.ends_with("$")
             || trimmed.ends_with("# ")
@@ -983,8 +985,17 @@ impl BlockingShard for ExecuteShard {
         let mut no_data_count = 0;
         let mut prompt_detected = false;
         let mut was_truncated = false;
+        let mut seen_command_echo = false;
 
-        shlog_trace!("Starting to read command output from shared buffer");
+        // Scale silence threshold with timeout: at least 1/3 of max_iterations,
+        // but no less than the default 3 seconds. This prevents false
+        // requires_interaction on slow commands (network I/O, compilation, etc.)
+        let silence_threshold = std::cmp::max(
+            INTERACTIVE_DETECTION_ITERATIONS,
+            max_iterations / 3,
+        );
+
+        shlog_trace!("Starting to read command output from shared buffer (silence_threshold={})", silence_threshold);
         std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
 
         for iteration in 0..max_iterations {
@@ -1007,6 +1018,16 @@ impl BlockingShard for ExecuteShard {
                 }
 
                 let output_str = String::from_utf8_lossy(&output_buffer);
+
+                // Track whether the command echo-back has been received.
+                // The shell echoes the command text followed by a newline before
+                // producing actual output. Don't start counting silence until
+                // we've seen this echo, to avoid false requires_interaction on
+                // commands that are slow to produce their first real output.
+                if !seen_command_echo && output_str.contains('\n') {
+                    seen_command_echo = true;
+                    shlog_trace!("Command echo-back detected");
+                }
 
                 shlog_trace!(
                     "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
@@ -1031,13 +1052,17 @@ impl BlockingShard for ExecuteShard {
             } else {
                 no_data_count += 1;
                 shlog_trace!(
-                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}",
+                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}, seen_echo: {}",
                     iteration,
                     no_data_count,
-                    output_buffer.is_empty()
+                    output_buffer.is_empty(),
+                    seen_command_echo
                 );
 
-                if no_data_count >= INTERACTIVE_DETECTION_ITERATIONS && !output_buffer.is_empty() && iteration >= INTERACTIVE_DETECTION_ITERATIONS / 2 {
+                // Fallback interactive detection after silence threshold expires.
+                // Only trigger if we've seen the command echo-back — before that,
+                // the command hasn't had a chance to produce output yet.
+                if no_data_count >= silence_threshold && !output_buffer.is_empty() && seen_command_echo {
                     let output_str = String::from_utf8_lossy(&output_buffer);
 
                     if is_prompt_or_marker(&output_str, marker) {
@@ -1051,7 +1076,8 @@ impl BlockingShard for ExecuteShard {
                         break;
                     }
 
-                    shlog_trace!("Command appears to be interactive (no new data for 3s, no prompt detected)");
+                    shlog_trace!("Command appears to be interactive (no new data for {}ms, no prompt detected)",
+                        silence_threshold as u64 * ITERATION_SLEEP_MS);
                     break;
                 }
             }

--- a/shards/tests/localshell.shs
+++ b/shards/tests/localshell.shs
@@ -203,6 +203,32 @@ LocalShell.Read(Session: shell-session StripAnsi: false Timeout: 1000) >= raw-an
 raw-ansi | ExpectString | String.Contains("UNDERLINE") | Assert.Is(true)
 "StripAnsi works" | Log
 
+; Test: slow command that is silent then produces output should complete (not false requires_interaction)
+"Testing slow command completion (sleep then output)" | Log
+"sleep 2 && echo 'delayed_result_ok'" | LocalShell.Execute(Session: shell-session Timeout: 15) >= slow-result
+slow-result.status | Assert.Is("completed")
+slow-result.output | ExpectString | String.Contains("delayed_result_ok") | Assert.Is(true)
+"Slow command completed without false requires_interaction" | Log
+
+; Test: command output ending with prompt-like characters should not cause premature completion
+; With sentinel marker active, only the sentinel should trigger completion — not generic patterns
+"Testing output ending with prompt-like characters" | Log
+"echo 'price is 100$'" | LocalShell.Execute(Session: shell-session) >= dollar-result
+dollar-result.status | Assert.Is("completed")
+dollar-result.output | ExpectString | String.Contains("price is 100$") | Assert.Is(true)
+"echo 'choice A > choice B'" | LocalShell.Execute(Session: shell-session) >= gt-result
+gt-result.status | Assert.Is("completed")
+gt-result.output | ExpectString | String.Contains("choice A > choice B") | Assert.Is(true)
+"Prompt-like output handled correctly" | Log
+
+; Test: heredoc should complete without false interaction detection
+"Testing heredoc command" | Log
+"cat <<'HEREDOC_END'\nheredoc_line_1\nheredoc_line_2\nHEREDOC_END" | LocalShell.Execute(Session: shell-session Timeout: 10) >= heredoc-result
+heredoc-result.status | Assert.Is("completed")
+heredoc-result.output | ExpectString | String.Contains("heredoc_line_1") | Assert.Is(true)
+heredoc-result.output | ExpectString | String.Contains("heredoc_line_2") | Assert.Is(true)
+"Heredoc completed correctly" | Log
+
 ; Test session alive check
 "Testing session alive check" | Log
 shell-session | LocalShell.IsAlive | Assert.Is(true)


### PR DESCRIPTION
## Summary

- **Only trust sentinel marker when set**: When `__SHARDS_PROMPT_*` is active, `is_prompt_or_marker` now ignores generic prompt patterns (`$ # > %`), eliminating false positives from heredoc continuation prompts and command output ending with those characters.
- **Scale silence threshold with timeout**: Instead of a fixed 3-second silence threshold, it now scales to at least 1/3 of the configured command timeout (minimum 3s), giving slow commands (network I/O, compilation) more time before being declared interactive.
- **Track command echo-back**: The silence counter only starts after the PTY/shell has echoed back the command text, preventing false `requires_interaction` when commands are slow to produce their first real output.

All three fixes applied identically to both `LocalShell` and `SSH` shell modules.

## Test plan

- [ ] Verify `cargo check` passes for `shards-localshell` and `shards-ssh` (confirmed locally)
- [ ] Test that slow network commands (e.g. `gh api` calls) no longer falsely trigger `requires_interaction`
- [ ] Test heredoc input (`cat <<'EOF' ... EOF`) completes correctly without false interaction detection
- [ ] Test that genuinely interactive commands (`read -p`, `passwd`) still correctly detect `requires_interaction`
- [ ] Test that the scaled silence threshold respects custom `Timeout` values
- [ ] Run `just tests` to verify no regressions in existing shell tests

https://claude.ai/code/session_01S4GVeihVrYdkxHHKp4hod5