### PR TITLE
Enable artifact overwrite in Windows build workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -210,6 +210,7 @@ jobs:
           path: ${{ steps.setup.outputs.artifact-path }}
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -217,6 +218,7 @@ jobs:
           path: shards/gfx/tests/data/default/rejected
           if-no-files-found: ignore
           retention-days: 1
+          overwrite: true
 
   #
   # Test shards for Windows


### PR DESCRIPTION
## Description

This PR adds the `overwrite: true` option to the artifact upload steps in the Windows build workflow. This ensures that if artifacts with the same name are uploaded multiple times (e.g., in retry scenarios), they will be overwritten rather than causing conflicts.

## Changes

- Added `overwrite: true` to the main artifact upload step (build artifacts)
- Added `overwrite: true` to the rejected test data artifact upload step

## Motivation

The `overwrite` option prevents potential failures when artifacts need to be re-uploaded with the same name, improving workflow reliability in retry scenarios.

## Test Plan

No testing needed - this is a configuration change to the CI workflow that will be validated by the GitHub Actions runner.

https://claude.ai/code/session_012mrG51KRVrGpoVyseuo7qp