### PR TITLE
Bump llama.cpp to b8639 (Gemma 4 support)

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -481,7 +481,7 @@ if(LLM_ENABLED AND NOT EMSCRIPTEN AND NOT WATCHOS)
   CPMAddPackage(
     NAME llama.cpp
     GITHUB_REPOSITORY ggml-org/llama.cpp
-    GIT_TAG b8575
+    GIT_TAG b8639
   )
 
   # whisper.cpp configuration


### PR DESCRIPTION
## Summary
- Bump llama.cpp from b8575 to b8639 (April 2, 2026)
- Adds Gemma 4 model support (vision + MoE, [ggml-org/llama.cpp#21309](https://github.com/ggml-org/llama.cpp/pull/21309))
- Also includes: WebGPU vectorized flash attention, KV cache quantization fixes, Granite 4.0 chat template

## Test plan
- [x] `just build` succeeds
- [x] `just tests` passes
- [x] `ml-test-gemma3-base.shs` - text generation works
- [x] `ml-test-gemma3.shs` - chat template works
- [ ] CI passes