### PR TITLE
refactor(shell): extract shared shell-session crate for localshell + ssh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8450,6 +8450,7 @@ name = "shards-shell-common"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
+ "regex",
  "shards",
  "strip-ansi-escapes",
  "vt100",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8350,8 +8350,7 @@ dependencies = [
  "lazy_static",
  "portable-pty",
  "shards",
- "strip-ansi-escapes",
- "vt100",
+ "shards-shell-common",
 ]
 
 [[package]]
@@ -8447,6 +8446,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shards-shell-common"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "shards",
+ "strip-ansi-escapes",
+ "vt100",
+]
+
+[[package]]
 name = "shards-spreadsheet"
 version = "0.1.0"
 dependencies = [
@@ -8463,10 +8472,9 @@ dependencies = [
  "compile-time-crc32",
  "lazy_static",
  "shards",
+ "shards-shell-common",
  "shellexpand",
  "ssh2",
- "strip-ansi-escapes",
- "vt100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "shards/modules/candle",
     "shards/modules/pdf",
     "shards/modules/random",
+    "shards/modules/shell-common",
     "shards/modules/spreadsheet",
     "shards/modules/ssh",
     "shards/modules/svg",

--- a/shards/modules/localshell/Cargo.toml
+++ b/shards/modules/localshell/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["rlib", "staticlib"]
 [dependencies]
 lazy_static = "1.5.0"
 shards = { path = "../../rust" }
+shards-shell-common = { path = "../shell-common" }
 compile-time-crc32 = "0.1.2"
-strip-ansi-escapes = "0.2"
 portable-pty = "0.8"
-vt100 = "0.15"

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -839,6 +839,87 @@ impl Shard for ResizeShard {
 }
 
 // ============================================================================
+// LocalShell.WaitFor Shard — wait until output matches a regex
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info(
+  "LocalShell.WaitFor",
+  "Wait until the session output matches a regular expression, returning the matched text (errors on timeout)"
+)]
+pub struct WaitForShard {
+  #[shard_required]
+  required: ExposedTypes,
+
+  #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+  session: ParamVar,
+
+  #[shard_param("Pattern", "Regular expression to wait for in the output", [common_type::string, common_type::string_var])]
+  pattern: ParamVar,
+
+  #[shard_param("Timeout", "Timeout in milliseconds, 0 = wait indefinitely (default: 30000)", [common_type::int, common_type::int_var])]
+  timeout_ms: ParamVar,
+
+  #[shard_param("StripAnsi", "Strip ANSI escape sequences before matching (default: true)", [common_type::bool, common_type::bool_var])]
+  strip_ansi: ParamVar,
+
+  output: ClonedVar,
+}
+
+impl Default for WaitForShard {
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      pattern: ParamVar::default(),
+      timeout_ms: ParamVar::new(30000i64.into()),
+      strip_ansi: ParamVar::new(true.into()),
+      output: ClonedVar::default(),
+    }
+  }
+}
+
+#[shards::shard_impl]
+impl Shard for WaitForShard {
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
+
+  fn output_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
+
+  fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
+    let session_var = *self.session.get();
+    let pattern: &str = self.pattern.get().as_ref().try_into()?;
+    let timeout_ms: i64 = self.timeout_ms.get().as_ref().try_into()?;
+    let strip: bool = self.strip_ansi.get().as_ref().try_into()?;
+
+    let s = get_session(&session_var)?;
+    let matched = sc::wait_for(s, context, pattern, timeout_ms, strip)?;
+
+    self.output = Var::ephemeral_string(&matched).into();
+    Ok(Some(self.output.0))
+  }
+}
+
+// ============================================================================
 // Module Registration
 // ============================================================================
 
@@ -859,6 +940,7 @@ pub extern "C" fn shardsRegister_localshell_rust(core: *mut shards::shardsc::SHC
   register_shard::<ReadShard>();
   register_shard::<WriteShard>();
   register_shard::<ResizeShard>();
+  register_shard::<WaitForShard>();
 
   shlog_trace!("LocalShell module registered");
 }

--- a/shards/modules/localshell/src/lib.rs
+++ b/shards/modules/localshell/src/lib.rs
@@ -1,6 +1,10 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2025 Fragcolor Pte. Ltd. */
 
+//! LocalShell module: persistent, interactive local shell sessions backed by a
+//! PTY. All the session/buffer/prompt machinery lives in `shards-shell-common`;
+//! this crate only provides the PTY transport and the `LocalShell.*` shards.
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -17,7 +21,6 @@ use shards::core::BlockingShard;
 use shards::fourCharacterCode;
 use shards::shard::Shard;
 use shards::types::common_type;
-use shards::types::AutoTableVar;
 use shards::types::ClonedVar;
 use shards::types::Context;
 use shards::types::ExposedTypes;
@@ -26,351 +29,129 @@ use shards::types::ParamVar;
 use shards::types::Type;
 use shards::types::Types;
 use shards::types::Var;
-use shards::types::FRAG_CC;
-use shards::types::STRING_TYPES;
-use shards::types::NONE_TYPES;
 use shards::types::BOOL_TYPES;
+use shards::types::FRAG_CC;
+use shards::types::NONE_TYPES;
+use shards::types::STRING_TYPES;
+
+use shards_shell_common as sc;
 
 use portable_pty::{CommandBuilder, PtySize};
 use std::io::{Read, Write};
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
 
-// Configuration constants
-const INITIAL_PROMPT_WAIT_MS: u64 = 500;
-const INITIAL_PROMPT_MAX_RETRIES: usize = 20;
-const COMMAND_OUTPUT_WAIT_MS: u64 = 200;
-const ITERATION_SLEEP_MS: u64 = 100;
-const INTERACTIVE_DETECTION_ITERATIONS: usize = 30; // 30 * 100ms = 3 seconds
-const SENDINPUT_INITIAL_WAIT_MS: u64 = 500;
-const SENDINPUT_NO_DATA_THRESHOLD: usize = 20; // 20 iterations = 2 seconds
-const MAX_BUFFER_BYTES: usize = 65536; // 64KB default
-const BUFFER_TRUNCATE_KEEP_RATIO: usize = 93; // Keep 93% on truncation
+// ============================================================================
+// PTY transport
+// ============================================================================
 
-// LocalShell session object wrapper
+struct PtyTransport {
+  pair: Arc<Mutex<Option<portable_pty::PtyPair>>>,
+  reader: Arc<Mutex<Box<dyn Read + Send>>>,
+  writer: Arc<Mutex<Box<dyn Write + Send>>>,
+  child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
+}
+
+impl sc::ShellTransport for PtyTransport {
+  fn read_into(&self, buf: &mut [u8]) -> sc::ReadOutcome {
+    match self.reader.lock() {
+      Ok(mut reader) => match reader.read(buf) {
+        Ok(n) if n > 0 => sc::ReadOutcome::Data(n),
+        // EOF or any read error: the process has gone away.
+        Ok(_) => sc::ReadOutcome::Ended,
+        Err(_) => sc::ReadOutcome::Ended,
+      },
+      Err(_) => sc::ReadOutcome::Ended,
+    }
+  }
+
+  fn write_all(&self, data: &[u8]) -> Result<(), sc::TransportError> {
+    let mut writer = self
+      .writer
+      .lock()
+      .map_err(|_| sc::TransportError::Other("Writer lock poisoned"))?;
+    writer
+      .write_all(data)
+      .map_err(|_| sc::TransportError::Other("Failed to write to shell (IO error)"))?;
+    writer
+      .flush()
+      .map_err(|_| sc::TransportError::Other("Failed to flush writer (IO error)"))?;
+    Ok(())
+  }
+
+  fn resize(&self, rows: u16, cols: u16) -> Result<(), &'static str> {
+    let pair_guard = self.pair.lock().map_err(|_| "PTY pair lock poisoned")?;
+    if let Some(ref pair) = *pair_guard {
+      pair
+        .master
+        .resize(PtySize {
+          rows,
+          cols,
+          pixel_width: 0,
+          pixel_height: 0,
+        })
+        .map_err(|_| "Failed to resize PTY")?;
+      Ok(())
+    } else {
+      Err("PTY pair has been dropped")
+    }
+  }
+
+  fn close(&self) {
+    // Kill the shell child process first.
+    if let Ok(mut child_opt) = self.child.lock() {
+      if let Some(mut child) = child_opt.take() {
+        shlog_trace!("Killing shell child process");
+        let _ = child.kill();
+        let _ = child.wait();
+      }
+    }
+
+    // CRITICAL: drop the PTY pair to close file descriptors. This causes the
+    // blocking read() in the reader thread to return with EOF.
+    if let Ok(mut pair_opt) = self.pair.lock() {
+      if let Some(pair) = pair_opt.take() {
+        shlog_trace!("Dropping PTY pair to close file descriptors");
+        drop(pair);
+        shlog_trace!("PTY pair dropped");
+      }
+    }
+  }
+}
+
+// ============================================================================
+// Session object wrapper (local newtype satisfies the orphan rule for the
+// ref-counted object type impl).
+// ============================================================================
+
 mod local_shell {
-    use super::*;
+  use super::*;
 
-    #[derive(Debug, Clone, PartialEq)]
-    pub enum SessionState {
-        Running,
-        ProcessDied,
-        Corrupted(String),
-    }
+  pub struct LocalShellSession(pub sc::ShellSession);
 
-    pub struct LocalShellSession {
-        pub pair: Arc<Mutex<Option<portable_pty::PtyPair>>>,
-        #[allow(dead_code)] // Kept alive for Drop ordering; reader arc is moved into thread
-        pub reader: Arc<Mutex<Box<dyn Read + Send>>>,
-        pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
-        pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
-        pub is_alive: Arc<AtomicBool>,
-        pub state: Arc<Mutex<SessionState>>,
-        pub output_buffer: Arc<Mutex<Vec<u8>>>,
-        pub total_bytes_written: Arc<AtomicUsize>,
-        /// Read cursor for LocalShell.Read — tracks how many bytes have been consumed
-        /// by raw reads. Lives on the session so multiple Read shard instances share state.
-        pub read_position: Arc<AtomicUsize>,
-        pub reader_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
-        pub child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
-        pub prompt_marker: Option<String>,
-        pub term_rows: Arc<AtomicU16>,
-        pub term_cols: Arc<AtomicU16>,
-    }
-
-    #[derive(Clone)]
-    pub struct InteractiveState {
-        #[allow(dead_code)] // Stored for debugging/future use
-        pub original_cmd: String,
-    }
-
-    impl Drop for LocalShellSession {
-        fn drop(&mut self) {
-            shlog_trace!("Dropping LocalShellSession, cleaning up");
-
-            // Step 1: Mark as not alive (prevents new operations)
-            self.is_alive.store(false, Ordering::Release);
-
-            // Step 2: Kill the shell child process
-            if let Ok(mut child_opt) = self.child.lock() {
-                if let Some(mut child) = child_opt.take() {
-                    shlog_trace!("Killing shell child process");
-                    let _ = child.kill();
-                    let _ = child.wait();
-                }
-            }
-
-            // Step 3: CRITICAL - Drop the PTY pair to close file descriptors
-            // This causes the blocking read() in the reader thread to return with EOF
-            if let Ok(mut pair_opt) = self.pair.lock() {
-                if let Some(pair) = pair_opt.take() {
-                    shlog_trace!("Dropping PTY pair to close file descriptors");
-                    drop(pair);
-                    shlog_trace!("PTY pair dropped");
-                }
-            }
-
-            // Step 4: Wait for reader thread with timeout
-            if let Ok(mut thread_opt) = self.reader_thread.lock() {
-                if let Some(thread) = thread_opt.take() {
-                    shlog_trace!("Waiting for reader thread to finish");
-
-                    let mut finished = false;
-                    for _i in 0..20 {
-                        if thread.is_finished() {
-                            finished = true;
-                            break;
-                        }
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-
-                    if finished {
-                        let _ = thread.join();
-                        shlog_trace!("Reader thread joined successfully");
-                    } else {
-                        shlog_error!("Reader thread did not finish within timeout, leaving it detached (thread leak)");
-                    }
-                }
-            }
-
-            shlog_trace!("LocalShellSession cleanup complete");
-        }
-    }
-
-    ref_counted_object_type_impl!(LocalShellSession);
+  ref_counted_object_type_impl!(LocalShellSession);
 }
 
 use local_shell::*;
 
+const LOCAL_SHELL_MESSAGES: sc::SessionMessages = sc::SessionMessages {
+  ended: "Local shell process has exited",
+  corrupted: "Local shell session corrupted due to internal error",
+  poisoned: "Local shell session corrupted (state lock poisoned)",
+  unexpected: "Local shell is not alive (unexpected state)",
+};
+
 lazy_static! {
-    static ref LOCAL_SHELL_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"lshl"));
-    static ref LOCAL_SHELL_TYPE_VEC: Vec<Type> = vec![*LOCAL_SHELL_TYPE];
-    static ref LOCAL_SHELL_VAR_TYPE: Type = Type::context_variable(&LOCAL_SHELL_TYPE_VEC);
-    static ref EXECUTE_OUTPUT_TYPES: Vec<Type> = vec![common_type::string_table];
+  static ref LOCAL_SHELL_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"lshl"));
+  static ref LOCAL_SHELL_TYPE_VEC: Vec<Type> = vec![*LOCAL_SHELL_TYPE];
+  static ref LOCAL_SHELL_VAR_TYPE: Type = Type::context_variable(&LOCAL_SHELL_TYPE_VEC);
 }
 
-// Helper: detect shell prompts
-fn is_prompt(text: &str) -> bool {
-    is_prompt_or_marker(text, None)
-}
-
-// Helper: detect shell prompts with optional sentinel marker
-fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
-    let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
-    let cleaned = String::from_utf8_lossy(&stripped_bytes);
-
-    let lines: Vec<&str> = cleaned.lines().collect();
-    if let Some(last) = lines.last() {
-        let trimmed = last.trim();
-
-        // Check sentinel marker first (most reliable)
-        if let Some(m) = marker {
-            // When sentinel marker is set, ONLY trust the sentinel.
-            // Generic prompt patterns ($ # > %) cause false positives with
-            // heredoc continuation prompts and command output that happens
-            // to end with these characters.
-            return trimmed.contains(m);
-        }
-
-        // Exclude interactive program prompts like >>> (Python), >> (continuation)
-        if trimmed.ends_with(">>>") || trimmed.ends_with(">>") {
-            return false;
-        }
-
-        // Check for common SHELL prompt patterns (fallback when no sentinel)
-        trimmed.ends_with("$ ")
-            || trimmed.ends_with("$")
-            || trimmed.ends_with("# ")
-            || trimmed.ends_with("#")
-            || trimmed.ends_with("> ")
-            || trimmed.ends_with(">")
-            || trimmed.ends_with("% ")
-            || trimmed.ends_with("%")
-    } else {
-        false
-    }
-}
-
-// Helper: detect common interactive prompts (password, confirmation, etc.)
-fn is_interactive_prompt(text: &str) -> bool {
-    let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
-    let cleaned = String::from_utf8_lossy(&stripped_bytes);
-
-    let lines: Vec<&str> = cleaned.lines().collect();
-    if lines.is_empty() {
-        return false;
-    }
-
-    let check_lines = if lines.len() > 3 { &lines[lines.len()-3..] } else { &lines[..] };
-
-    for line in check_lines {
-        let lower = line.to_lowercase();
-
-        if lower.contains("password:")
-            || lower.contains("passphrase:")
-            || lower.contains("continue?")
-            || lower.contains("(y/n)")
-            || lower.contains("[y/n]")
-            || lower.contains("press enter")
-            || lower.contains("press any key")
-            || lower.contains("are you sure")
-            || lower.ends_with("? ")
-            || lower.ends_with(": ")
-        {
-            return true;
-        }
-    }
-
-    false
-}
-
-// Helper: mark session as corrupted
-fn mark_session_corrupted(local_shell: &LocalShellSession, error_context: &str) {
-    shlog_error!("Critical error in LocalShell ({}), marking session as corrupted", error_context);
-    local_shell.is_alive.store(false, Ordering::Release);
-    if let Ok(mut state) = local_shell.state.lock() {
-        *state = SessionState::Corrupted(error_context.to_string());
-    }
-}
-
-// Helper: clean output (remove ANSI codes, control chars, and trailing prompts)
-fn clean_output_with_marker(output: &str, marker: Option<&str>) -> String {
-    let stripped_bytes = strip_ansi_escapes::strip(output);
-    let text = String::from_utf8_lossy(&stripped_bytes);
-
-    let no_control: String = text.chars()
-        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
-        .collect();
-
-    let mut lines: Vec<&str> = no_control.lines().collect();
-
-    // Remove trailing prompt if present
-    if !lines.is_empty() {
-        let last_line = lines.last().unwrap();
-        if is_prompt_or_marker(last_line, marker) {
-            lines.pop();
-        }
-    }
-
-    let result = lines.join("\n");
-    result.trim().to_string()
-}
-
-// Helper: truncate output buffer to keep tail
-fn truncate_to_tail(buffer: &mut Vec<u8>, max_bytes: usize) -> bool {
-    if buffer.len() <= max_bytes {
-        return false;
-    }
-
-    let keep_bytes = (max_bytes * BUFFER_TRUNCATE_KEEP_RATIO) / 100;
-    let truncate_msg = b"[... output truncated ...]\n";
-
-    let skip = buffer.len() - keep_bytes + truncate_msg.len();
-    let tail: Vec<u8> = buffer.drain(skip..).collect();
-    buffer.clear();
-    buffer.extend_from_slice(truncate_msg);
-    buffer.extend_from_slice(&tail);
-
-    true
-}
-
-// Helper: check if session is alive, return descriptive error if not
-fn check_session_alive(local_shell: &LocalShellSession) -> Result<(), &'static str> {
-    if !local_shell.is_alive.load(Ordering::Acquire) {
-        if let Ok(state) = local_shell.state.lock() {
-            return Err(match *state {
-                SessionState::ProcessDied => "Local shell process has exited",
-                SessionState::Corrupted(ref reason) => {
-                    shlog_error!("Session corrupted: {}", reason);
-                    "Local shell session corrupted due to internal error"
-                },
-                SessionState::Running => "Local shell is not alive (unexpected state)",
-            });
-        } else {
-            return Err("Local shell session corrupted (state lock poisoned)");
-        }
-    }
-    Ok(())
-}
-
-// Helper: extract LocalShellSession from Var
-fn get_session(session_var: &Var) -> Result<&LocalShellSession, &'static str> {
-    let local_shell = unsafe {
-        Var::from_ref_counted_object::<LocalShellSession>(session_var, &*LOCAL_SHELL_TYPE)?
-    };
-    Ok(unsafe { &*(local_shell as *const LocalShellSession) })
-}
-
-// Start the reader thread for a session's shared buffer
-fn start_reader_thread(
-    reader_arc: Arc<Mutex<Box<dyn Read + Send>>>,
-    buffer: Arc<Mutex<Vec<u8>>>,
-    total_bytes: Arc<AtomicUsize>,
-    alive: Arc<AtomicBool>,
-    state: Arc<Mutex<SessionState>>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::spawn(move || {
-        shlog_trace!("Reader thread started");
-        let mut buf = [0u8; 4096];
-
-        loop {
-            if !alive.load(Ordering::Acquire) {
-                shlog_trace!("Reader thread exiting");
-                break;
-            }
-
-            match reader_arc.lock() {
-                Ok(mut reader) => {
-                    match reader.read(&mut buf) {
-                        Ok(n) if n > 0 => {
-                            match buffer.lock() {
-                                Ok(mut b) => {
-                                    b.extend_from_slice(&buf[..n]);
-
-                                    if b.len() > MAX_BUFFER_BYTES {
-                                        if truncate_to_tail(&mut b, MAX_BUFFER_BYTES) {
-                                            shlog_trace!("Reader thread: buffer truncated to {} bytes", b.len());
-                                        }
-                                    }
-
-                                    // Increment monotonic counter AFTER write
-                                    total_bytes.fetch_add(n, Ordering::Release);
-
-                                    shlog_trace!("Reader thread: read {} bytes, buffer now {} bytes", n, b.len());
-                                }
-                                Err(e) => {
-                                    shlog_trace!("Reader thread: buffer lock poisoned: {}", e);
-                                    break;
-                                }
-                            }
-                        }
-                        Ok(_) => {
-                            alive.store(false, Ordering::Release);
-                            if let Ok(mut s) = state.lock() {
-                                *s = SessionState::ProcessDied;
-                            }
-                            shlog_trace!("Reader thread: EOF detected, process died");
-                            break;
-                        }
-                        Err(e) => {
-                            alive.store(false, Ordering::Release);
-                            if let Ok(mut s) = state.lock() {
-                                *s = SessionState::ProcessDied;
-                            }
-                            shlog_trace!("Reader thread: read error: {}", e);
-                            break;
-                        }
-                    }
-                }
-                Err(e) => {
-                    shlog_trace!("Reader thread: reader lock poisoned: {}", e);
-                    break;
-                }
-            }
-        }
-        shlog_trace!("Reader thread finished");
-    })
+// Helper: extract the shared session from a Var.
+fn get_session(session_var: &Var) -> Result<&sc::ShellSession, &'static str> {
+  let wrapper =
+    unsafe { Var::from_ref_counted_object::<LocalShellSession>(session_var, &*LOCAL_SHELL_TYPE)? };
+  Ok(unsafe { &(*wrapper).0 })
 }
 
 // ============================================================================
@@ -380,263 +161,219 @@ fn start_reader_thread(
 #[derive(shards::shard)]
 #[shard_info("LocalShell.Create", "Create a persistent local shell session")]
 pub struct CreateShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Shell", "Shell to use (default: /bin/bash on Unix, cmd.exe on Windows)", [common_type::string, common_type::string_var, common_type::none])]
-    shell: ParamVar,
+  #[shard_param("Shell", "Shell to use (default: /bin/bash on Unix, cmd.exe on Windows)", [common_type::string, common_type::string_var, common_type::none])]
+  shell: ParamVar,
 
-    #[shard_param("WorkingDirectory", "Initial working directory (default: current directory)", [common_type::string, common_type::string_var, common_type::none])]
-    working_dir: ParamVar,
+  #[shard_param("WorkingDirectory", "Initial working directory (default: current directory)", [common_type::string, common_type::string_var, common_type::none])]
+  working_dir: ParamVar,
 
-    #[shard_param("ShellArgs", "Arguments to pass to shell (default: ['--login', '-i'] for bash on Unix)", [common_type::strings, common_type::strings_var, common_type::none])]
-    shell_args: ParamVar,
+  #[shard_param("ShellArgs", "Arguments to pass to shell (default: ['--login', '-i'] for bash on Unix)", [common_type::strings, common_type::strings_var, common_type::none])]
+  shell_args: ParamVar,
 
-    #[shard_param("Rows", "PTY rows (default: 24)", [common_type::int, common_type::int_var, common_type::none])]
-    rows: ParamVar,
+  #[shard_param("Rows", "PTY rows (default: 24)", [common_type::int, common_type::int_var, common_type::none])]
+  rows: ParamVar,
 
-    #[shard_param("Cols", "PTY columns (default: 80)", [common_type::int, common_type::int_var, common_type::none])]
-    cols: ParamVar,
+  #[shard_param("Cols", "PTY columns (default: 80)", [common_type::int, common_type::int_var, common_type::none])]
+  cols: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for CreateShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            shell: ParamVar::new(Var::default()),
-            working_dir: ParamVar::new(Var::default()),
-            shell_args: ParamVar::new(Var::default()),
-            rows: ParamVar::new(24i64.into()),
-            cols: ParamVar::new(80i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      shell: ParamVar::new(Var::default()),
+      working_dir: ParamVar::new(Var::default()),
+      shell_args: ParamVar::new(Var::default()),
+      rows: ParamVar::new(24i64.into()),
+      cols: ParamVar::new(80i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for CreateShard {
-    fn input_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &LOCAL_SHELL_TYPE_VEC
-    }
+  fn output_types(&mut self) -> &Types {
+    &LOCAL_SHELL_TYPE_VEC
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        Ok(Some(run_blocking(self, context, input)))
-    }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    Ok(Some(run_blocking(self, context, input)))
+  }
 }
 
 impl BlockingShard for CreateShard {
-    fn activate_blocking(&mut self, _context: &Context, _input: &Var) -> Result<Var, &'static str> {
-        let shell_var = self.shell.get();
-        let working_dir_var = self.working_dir.get();
+  fn activate_blocking(&mut self, _context: &Context, _input: &Var) -> Result<Var, &'static str> {
+    let shell_var = self.shell.get();
+    let working_dir_var = self.working_dir.get();
 
-        // Get PTY size params
-        let rows_val = self.rows.get();
-        let cols_val = self.cols.get();
-        let rows: u16 = if rows_val.is_none() { 24 } else {
-            let v: i64 = rows_val.as_ref().try_into().unwrap_or(24);
-            v.max(1).min(u16::MAX as i64) as u16
-        };
-        let cols: u16 = if cols_val.is_none() { 80 } else {
-            let v: i64 = cols_val.as_ref().try_into().unwrap_or(80);
-            v.max(1).min(u16::MAX as i64) as u16
-        };
+    // Get PTY size params
+    let rows_val = self.rows.get();
+    let cols_val = self.cols.get();
+    let rows: u16 = if rows_val.is_none() {
+      24
+    } else {
+      let v: i64 = rows_val.as_ref().try_into().unwrap_or(24);
+      v.max(1).min(u16::MAX as i64) as u16
+    };
+    let cols: u16 = if cols_val.is_none() {
+      80
+    } else {
+      let v: i64 = cols_val.as_ref().try_into().unwrap_or(80);
+      v.max(1).min(u16::MAX as i64) as u16
+    };
 
-        let pty_system = portable_pty::native_pty_system();
+    let pty_system = portable_pty::native_pty_system();
 
-        // Determine shell command
-        let shell_cmd = if !shell_var.is_none() {
-            let shell_path: &str = shell_var.as_ref().try_into()?;
-            shell_path.to_string()
-        } else {
-            #[cfg(unix)]
-            let default_shell = "/bin/bash";
-            #[cfg(windows)]
-            let default_shell = "cmd.exe";
+    // Determine shell command
+    let shell_cmd = if !shell_var.is_none() {
+      let shell_path: &str = shell_var.as_ref().try_into()?;
+      shell_path.to_string()
+    } else {
+      #[cfg(unix)]
+      let default_shell = "/bin/bash";
+      #[cfg(windows)]
+      let default_shell = "cmd.exe";
 
-            default_shell.to_string()
-        };
+      default_shell.to_string()
+    };
 
-        shlog_trace!("Creating local shell with: {} ({}x{})", shell_cmd, cols, rows);
+    shlog_trace!(
+      "Creating local shell with: {} ({}x{})",
+      shell_cmd,
+      cols,
+      rows
+    );
 
-        let pair = pty_system
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|_| "Failed to open PTY")?;
+    let pair = pty_system
+      .openpty(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+      })
+      .map_err(|_| "Failed to open PTY")?;
 
-        let mut cmd = CommandBuilder::new(&shell_cmd);
+    let mut cmd = CommandBuilder::new(&shell_cmd);
 
-        if !working_dir_var.is_none() {
-            let wd: &str = working_dir_var.as_ref().try_into()?;
-            cmd.cwd(wd);
-        }
-
-        let shell_args_var = self.shell_args.get();
-        if !shell_args_var.is_none() {
-            let args_seq: shards::types::SeqVar = shell_args_var.as_ref().try_into()
-                .map_err(|_| "ShellArgs must be a sequence of strings")?;
-            for arg_var in args_seq.iter() {
-                let arg_str = match arg_var.as_ref() {
-                    Var { valueType: shards::shardsc::SHType_String, .. } => {
-                        let s: &str = arg_var.as_ref().try_into()
-                            .map_err(|_| "ShellArgs elements must be strings")?;
-                        s
-                    }
-                    _ => return Err("ShellArgs elements must be strings"),
-                };
-                cmd.arg(arg_str);
-            }
-        } else {
-            #[cfg(unix)]
-            if shell_cmd.contains("bash") {
-                cmd.arg("--login");
-                cmd.arg("-i");
-            }
-        }
-
-        let child = pair
-            .slave
-            .spawn_command(cmd)
-            .map_err(|_| "Failed to spawn shell")?;
-
-        let reader = pair.master.try_clone_reader()
-            .map_err(|_| "Failed to clone reader")?;
-        let writer = pair.master.take_writer()
-            .map_err(|_| "Failed to take writer")?;
-
-        let reader_arc = Arc::new(Mutex::new(reader));
-        let writer_arc = Arc::new(Mutex::new(writer));
-
-        // Create shared state FIRST
-        let output_buffer = Arc::new(Mutex::new(Vec::new()));
-        let total_bytes_written = Arc::new(AtomicUsize::new(0));
-        let is_alive = Arc::new(AtomicBool::new(true));
-        let state = Arc::new(Mutex::new(SessionState::Running));
-
-        // Start reader thread BEFORE waiting for initial prompt (Bug 1 fix)
-        let reader_thread = start_reader_thread(
-            Arc::clone(&reader_arc),
-            Arc::clone(&output_buffer),
-            Arc::clone(&total_bytes_written),
-            Arc::clone(&is_alive),
-            Arc::clone(&state),
-        );
-
-        // Wait for initial prompt by polling the shared buffer (no throwaway threads)
-        std::thread::sleep(Duration::from_millis(INITIAL_PROMPT_WAIT_MS));
-
-        for _ in 0..INITIAL_PROMPT_MAX_RETRIES {
-            {
-                let buf = output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
-                if !buf.is_empty() {
-                    let output_str = String::from_utf8_lossy(&buf);
-                    if is_prompt(&output_str) {
-                        shlog_trace!("Initial prompt detected");
-                        break;
-                    }
-                }
-            }
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        shlog_trace!("Shell ready");
-
-        // Try to set PS1 sentinel marker for reliable prompt detection
-        let marker = format!("__SHARDS_PROMPT_{:x}__", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() & 0xFFFFFFFF);
-
-        // Send PS1 setup command
-        let prompt_marker = {
-            let ps1_cmd = format!("export PS1='{}'\n", marker);
-            let mut set_marker = false;
-            if let Ok(mut w) = writer_arc.lock() {
-                if w.write_all(ps1_cmd.as_bytes()).is_ok() && w.flush().is_ok() {
-                    set_marker = true;
-                }
-            }
-
-            if set_marker {
-                // Wait for the marker to appear
-                std::thread::sleep(Duration::from_millis(300));
-
-                // Check if marker appeared in buffer
-                let marker_found = if let Ok(buf) = output_buffer.lock() {
-                    let s = String::from_utf8_lossy(&buf);
-                    s.contains(&marker)
-                } else {
-                    false
-                };
-
-                if marker_found {
-                    shlog_trace!("Sentinel prompt marker set: {}", marker);
-                    // Clear buffer after marker setup - we don't want setup output in command results
-                    if let Ok(mut buf) = output_buffer.lock() {
-                        buf.clear();
-                    }
-                    total_bytes_written.store(0, Ordering::Release);
-                    Some(marker)
-                } else {
-                    shlog_trace!("Sentinel prompt marker not detected, falling back to pattern matching");
-                    // Clear buffer anyway
-                    if let Ok(mut buf) = output_buffer.lock() {
-                        buf.clear();
-                    }
-                    total_bytes_written.store(0, Ordering::Release);
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        let local_shell = LocalShellSession {
-            pair: Arc::new(Mutex::new(Some(pair))),
-            reader: reader_arc,
-            writer: writer_arc,
-            pending_interactive: Arc::new(Mutex::new(None)),
-            is_alive,
-            state,
-            output_buffer,
-            total_bytes_written,
-            read_position: Arc::new(AtomicUsize::new(0)),
-            reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
-            child: Arc::new(Mutex::new(Some(child))),
-            prompt_marker,
-            term_rows: Arc::new(AtomicU16::new(rows)),
-            term_cols: Arc::new(AtomicU16::new(cols)),
-        };
-
-        let shell_var = Var::new_ref_counted(local_shell, &*LOCAL_SHELL_TYPE);
-        self.output = shell_var.into();
-        Ok(self.output.0)
+    if !working_dir_var.is_none() {
+      let wd: &str = working_dir_var.as_ref().try_into()?;
+      cmd.cwd(wd);
     }
+
+    let shell_args_var = self.shell_args.get();
+    if !shell_args_var.is_none() {
+      let args_seq: shards::types::SeqVar = shell_args_var
+        .as_ref()
+        .try_into()
+        .map_err(|_| "ShellArgs must be a sequence of strings")?;
+      for arg_var in args_seq.iter() {
+        let arg_str = match arg_var.as_ref() {
+          Var {
+            valueType: shards::shardsc::SHType_String,
+            ..
+          } => {
+            let s: &str = arg_var
+              .as_ref()
+              .try_into()
+              .map_err(|_| "ShellArgs elements must be strings")?;
+            s
+          }
+          _ => return Err("ShellArgs elements must be strings"),
+        };
+        cmd.arg(arg_str);
+      }
+    } else {
+      #[cfg(unix)]
+      if shell_cmd.contains("bash") {
+        cmd.arg("--login");
+        cmd.arg("-i");
+      }
+    }
+
+    let child = pair
+      .slave
+      .spawn_command(cmd)
+      .map_err(|_| "Failed to spawn shell")?;
+
+    let reader = pair
+      .master
+      .try_clone_reader()
+      .map_err(|_| "Failed to clone reader")?;
+    let writer = pair
+      .master
+      .take_writer()
+      .map_err(|_| "Failed to take writer")?;
+
+    // Build the transport and shared session state.
+    let transport: Arc<dyn sc::ShellTransport> = Arc::new(PtyTransport {
+      pair: Arc::new(Mutex::new(Some(pair))),
+      reader: Arc::new(Mutex::new(reader)),
+      writer: Arc::new(Mutex::new(writer)),
+      child: Arc::new(Mutex::new(Some(child))),
+    });
+
+    let output_buffer = Arc::new(Mutex::new(Vec::new()));
+    let total_bytes_written = Arc::new(AtomicUsize::new(0));
+    let is_alive = Arc::new(AtomicBool::new(true));
+    let state = Arc::new(Mutex::new(sc::SessionState::Running));
+
+    // Start reader thread BEFORE waiting for the initial prompt.
+    let reader_thread = sc::start_reader_thread(
+      Arc::clone(&transport),
+      Arc::clone(&output_buffer),
+      Arc::clone(&total_bytes_written),
+      Arc::clone(&is_alive),
+      Arc::clone(&state),
+    );
+
+    sc::wait_for_initial_prompt(&output_buffer)?;
+    let prompt_marker = sc::setup_prompt_marker(&transport, &output_buffer, &total_bytes_written);
+
+    let session = sc::ShellSession {
+      transport,
+      pending_interactive: Arc::new(Mutex::new(None)),
+      is_alive,
+      state,
+      output_buffer,
+      total_bytes_written,
+      read_position: Arc::new(AtomicUsize::new(0)),
+      reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
+      prompt_marker,
+      term_rows: Arc::new(AtomicU16::new(rows)),
+      term_cols: Arc::new(AtomicU16::new(cols)),
+      messages: LOCAL_SHELL_MESSAGES,
+    };
+
+    let shell_var = Var::new_ref_counted(LocalShellSession(session), &*LOCAL_SHELL_TYPE);
+    self.output = shell_var.into();
+    Ok(self.output.0)
+  }
 }
 
 // ============================================================================
@@ -645,371 +382,91 @@ impl BlockingShard for CreateShard {
 
 #[derive(shards::shard)]
 #[shard_info(
-    "LocalShell.Execute",
-    "Execute a command in the persistent local shell session"
+  "LocalShell.Execute",
+  "Execute a command in the persistent local shell session"
 )]
 pub struct ExecuteShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
-    timeout_secs: ParamVar,
+  #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
+  timeout_secs: ParamVar,
 
-    #[shard_param("CleanOutput", "Clean ANSI codes and prompts from output (default: true)", [common_type::bool, common_type::bool_var])]
-    clean_output: ParamVar,
+  #[shard_param("CleanOutput", "Clean ANSI codes and prompts from output (default: true)", [common_type::bool, common_type::bool_var])]
+  clean_output: ParamVar,
 
-    #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
-    max_output_bytes: ParamVar,
+  #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
+  max_output_bytes: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ExecuteShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            timeout_secs: ParamVar::new(30i64.into()),
-            clean_output: ParamVar::new(true.into()),
-            max_output_bytes: ParamVar::new(65536i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      timeout_secs: ParamVar::new(30i64.into()),
+      clean_output: ParamVar::new(true.into()),
+      max_output_bytes: ParamVar::new(65536i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ExecuteShard {
-    fn input_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &EXECUTE_OUTPUT_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &sc::EXECUTE_OUTPUT_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        Ok(Some(run_blocking(self, context, input)))
-    }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    Ok(Some(run_blocking(self, context, input)))
+  }
 }
 
 impl BlockingShard for ExecuteShard {
-    fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
-        let cmd: &str = input.try_into()?;
-        let session_var = *self.session.get();
-        let should_clean: bool = self.clean_output.get().as_ref().try_into()?;
-        let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
-        let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
+  fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
+    let cmd: &str = input.try_into()?;
+    let session_var = *self.session.get();
+    let should_clean: bool = self.clean_output.get().as_ref().try_into()?;
+    let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
+    let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
 
-        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
-        let timeout_secs = if timeout_secs <= 0 { 30 } else { timeout_secs };
-        let max_iterations = (timeout_secs as usize) * 10;
-
-        let local_shell = get_session(&session_var)?;
-        check_session_alive(local_shell)?;
-
-        let marker = local_shell.prompt_marker.as_deref();
-
-        // Check if there's a pending interactive command
-        {
-            let mut pending = match local_shell.pending_interactive.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(local_shell, "interactive lock poisoned in Execute");
-                    return Err("Interactive state lock poisoned");
-                }
-            };
-            if pending.is_some() {
-                shlog_trace!("New command received while interactive command was pending, sending Ctrl+C");
-                {
-                    let mut writer = match local_shell.writer.lock() {
-                        Ok(guard) => guard,
-                        Err(_) => {
-                            mark_session_corrupted(local_shell, "writer lock poisoned in Execute");
-                            return Err("Writer lock poisoned");
-                        }
-                    };
-                    let _ = writer.write_all(&[3]);
-                    let _ = writer.flush();
-                }
-                std::thread::sleep(Duration::from_millis(300));
-                *pending = None;
-            }
-        }
-
-        // Clear shared buffer and reset monotonic counter before sending command
-        {
-            let mut shared_buffer = match local_shell.output_buffer.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(local_shell, "buffer lock poisoned before command");
-                    return Err("Buffer lock poisoned");
-                }
-            };
-            shared_buffer.clear();
-            local_shell.total_bytes_written.store(0, Ordering::Release);
-            local_shell.read_position.store(0, Ordering::Release);
-            shlog_trace!("Cleared shared buffer and reset counters before command");
-        }
-
-        // Send command
-        let cmd_with_newline = format!("{}\n", cmd);
-        {
-            let mut writer = match local_shell.writer.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(local_shell, "writer lock poisoned sending command");
-                    return Err("Writer lock poisoned");
-                }
-            };
-            writer.write_all(cmd_with_newline.as_bytes())
-                .map_err(|_| "Failed to write command to shell (IO error)")?;
-            writer.flush()
-                .map_err(|_| "Failed to flush command writer (IO error)")?;
-        }
-
-        // Read output using monotonic byte counter (Bug 2 fix)
-        let mut output_buffer = Vec::new();
-        let mut last_total_bytes = 0usize;
-        let mut no_data_count = 0;
-        let mut prompt_detected = false;
-        let mut was_truncated = false;
-        let mut seen_command_echo = false;
-
-        // Scale silence threshold with timeout: at least 1/3 of max_iterations,
-        // but no less than the default 3 seconds. This prevents false
-        // requires_interaction on slow commands (network I/O, compilation, etc.)
-        let silence_threshold = std::cmp::max(
-            INTERACTIVE_DETECTION_ITERATIONS,
-            max_iterations / 3,
-        );
-
-        shlog_trace!("Starting to read command output from shared buffer (silence_threshold={})", silence_threshold);
-        std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
-
-        for iteration in 0..max_iterations {
-            // Use monotonic counter to detect new data (immune to truncation)
-            let current_total = local_shell.total_bytes_written.load(Ordering::Acquire);
-            let has_new_data = current_total > last_total_bytes;
-
-            if has_new_data {
-                // Mark that the command has started producing output.
-                // Done before truncation so that small MaxOutputBytes or
-                // fast/large output can't cause us to miss the signal.
-                if !seen_command_echo {
-                    seen_command_echo = true;
-                    shlog_trace!("Command has started producing output");
-                }
-
-                // New data arrived — snapshot the buffer contents
-                let snapshot = {
-                    let shared_buffer = local_shell.output_buffer.lock()
-                        .map_err(|_| "Buffer lock poisoned")?;
-                    shared_buffer.clone()
-                };
-
-                output_buffer = snapshot;
-                last_total_bytes = current_total;
-
-                // Truncate local copy if needed
-                if truncate_to_tail(&mut output_buffer, max_output_bytes) {
-                    was_truncated = true;
-                    shlog_trace!("Output buffer truncated to tail ({} bytes)", max_output_bytes);
-                }
-
-                let output_str = String::from_utf8_lossy(&output_buffer);
-
-                shlog_trace!(
-                    "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
-                    iteration,
-                    current_total,
-                    output_buffer.len(),
-                    output_str.lines().last()
-                );
-
-                // Check for prompt
-                if is_prompt_or_marker(&output_str, marker) {
-                    prompt_detected = true;
-                    shlog_trace!("Prompt detected in output, command completed");
-                    break;
-                }
-
-                // Check for interactive prompt IMMEDIATELY when we have data
-                if is_interactive_prompt(&output_str) {
-                    shlog_trace!("Interactive prompt pattern detected early: {:?}", output_str.lines().last());
-                    break;
-                }
-
-                no_data_count = 0;
-            } else {
-                no_data_count += 1;
-                shlog_trace!(
-                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}, seen_echo: {}",
-                    iteration,
-                    no_data_count,
-                    output_buffer.is_empty(),
-                    seen_command_echo
-                );
-
-                // Fallback interactive detection after silence threshold expires.
-                // Only trigger if the command has started producing output —
-                // before that, the command hasn't had a chance to run yet.
-                if no_data_count >= silence_threshold && seen_command_echo {
-                    let output_str = String::from_utf8_lossy(&output_buffer);
-
-                    if is_prompt_or_marker(&output_str, marker) {
-                        prompt_detected = true;
-                        shlog_trace!("Prompt detected on final check");
-                        break;
-                    }
-
-                    if is_interactive_prompt(&output_str) {
-                        shlog_trace!("Interactive prompt pattern detected: {:?}", output_str.lines().last());
-                        break;
-                    }
-
-                    shlog_trace!("Command appears to be interactive (no new data for {}ms, no prompt detected)",
-                        silence_threshold as u64 * ITERATION_SLEEP_MS);
-                    break;
-                }
-            }
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        // Build result table
-        let mut result_table = AutoTableVar::new();
-        let output_str = String::from_utf8_lossy(&output_buffer).to_string();
-
-        if prompt_detected {
-            // Try to capture exit code
-            let exit_code = capture_exit_code(local_shell, marker);
-
-            let final_output = if should_clean {
-                clean_output_with_marker(&output_str, marker)
-            } else {
-                output_str
-            };
-
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("completed"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
-            if let Some(code) = exit_code {
-                result_table.0.insert_fast_static("exit_code", &Var::from(code));
-            }
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        } else {
-            // Command is interactive (waiting for input)
-            {
-                let mut pending = local_shell.pending_interactive.lock()
-                    .map_err(|_| "Interactive state lock poisoned")?;
-                *pending = Some(InteractiveState {
-                    original_cmd: cmd.to_string(),
-                });
-            }
-
-            let partial_output = if should_clean {
-                clean_output_with_marker(&output_str, marker)
-            } else {
-                output_str
-            };
-
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("requires_interaction"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&partial_output));
-            result_table.0.insert_fast_static(
-                "message",
-                &Var::ephemeral_string("Command is waiting for input. Use LocalShell.SendInput to interact.")
-            );
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        }
-
-        // Sync read position so subsequent LocalShell.Read doesn't pick up stale data
-        // from command execution or exit code capture
-        let final_total = local_shell.total_bytes_written.load(Ordering::Acquire);
-        local_shell.read_position.store(final_total, Ordering::Release);
-
-        self.output = result_table.to_cloned();
-        Ok(self.output.0)
-    }
-}
-
-// Helper: capture exit code by sending `echo $?` after command completes
-fn capture_exit_code(local_shell: &LocalShellSession, marker: Option<&str>) -> Option<i64> {
-    // Clear buffer, send echo $?, wait for prompt, parse result
-    {
-        let mut buf = match local_shell.output_buffer.lock() {
-            Ok(b) => b,
-            Err(_) => return None,
-        };
-        buf.clear();
-        local_shell.total_bytes_written.store(0, Ordering::Release);
-        local_shell.read_position.store(0, Ordering::Release);
-    }
-
-    {
-        let mut writer = match local_shell.writer.lock() {
-            Ok(w) => w,
-            Err(_) => return None,
-        };
-        if writer.write_all(b"echo $?\n").is_err() || writer.flush().is_err() {
-            return None;
-        }
-    }
-
-    // Wait for response
-    std::thread::sleep(Duration::from_millis(200));
-
-    for _ in 0..10 {
-        let snapshot = {
-            let buf = local_shell.output_buffer.lock().ok()?;
-            buf.clone()
-        };
-
-        let output = String::from_utf8_lossy(&snapshot);
-        if is_prompt_or_marker(&output, marker) {
-            // Parse exit code from output
-            let stripped = strip_ansi_escapes::strip(output.as_bytes());
-            let cleaned = String::from_utf8_lossy(&stripped);
-            for line in cleaned.lines() {
-                let trimmed = line.trim();
-                // Skip the echo command itself and the prompt
-                if trimmed == "echo $?" || trimmed.is_empty() {
-                    continue;
-                }
-                if is_prompt_or_marker(trimmed, marker) {
-                    continue;
-                }
-                if let Ok(code) = trimmed.parse::<i64>() {
-                    return Some(code);
-                }
-            }
-            return None;
-        }
-
-        std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-    }
-
-    None
+    let s = get_session(&session_var)?;
+    self.output = sc::execute(
+      s,
+      cmd,
+      timeout_secs,
+      should_clean,
+      max_output_bytes,
+      "Command is waiting for input. Use LocalShell.SendInput to interact.",
+    )?;
+    Ok(self.output.0)
+  }
 }
 
 // ============================================================================
@@ -1018,228 +475,85 @@ fn capture_exit_code(local_shell: &LocalShellSession, marker: Option<&str>) -> O
 
 #[derive(shards::shard)]
 #[shard_info(
-    "LocalShell.SendInput",
-    "Send input to an interactive local shell command"
+  "LocalShell.SendInput",
+  "Send input to an interactive local shell command"
 )]
 pub struct SendInputShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
-    timeout_secs: ParamVar,
+  #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
+  timeout_secs: ParamVar,
 
-    #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
-    max_output_bytes: ParamVar,
+  #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
+  max_output_bytes: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for SendInputShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            timeout_secs: ParamVar::new(10i64.into()),
-            max_output_bytes: ParamVar::new(65536i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      timeout_secs: ParamVar::new(10i64.into()),
+      max_output_bytes: ParamVar::new(65536i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for SendInputShard {
-    fn input_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &EXECUTE_OUTPUT_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &sc::EXECUTE_OUTPUT_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        Ok(Some(run_blocking(self, context, input)))
-    }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    Ok(Some(run_blocking(self, context, input)))
+  }
 }
 
 impl BlockingShard for SendInputShard {
-    fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
-        let input_str: &str = input.try_into()?;
-        let session_var = *self.session.get();
-        let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
-        let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
+  fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
+    let input_str: &str = input.try_into()?;
+    let session_var = *self.session.get();
+    let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
+    let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
 
-        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
-        let timeout_secs = if timeout_secs <= 0 { 10 } else { timeout_secs };
-        let max_iterations = (timeout_secs as usize) * 10;
-
-        let local_shell = get_session(&session_var)?;
-        check_session_alive(local_shell)?;
-
-        let marker = local_shell.prompt_marker.as_deref();
-
-        // Check if there's a pending interactive command
-        {
-            let pending = match local_shell.pending_interactive.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(local_shell, "interactive lock poisoned in SendInput");
-                    return Err("Interactive state lock poisoned");
-                }
-            };
-            if pending.is_none() {
-                return Err("No interactive command is pending");
-            }
-        }
-
-        // Record monotonic position before sending input
-        let start_total_bytes = local_shell.total_bytes_written.load(Ordering::Acquire);
-
-        // Send input (if not empty)
-        if !input_str.is_empty() {
-            let input_with_newline = format!("{}\n", input_str);
-            shlog_trace!("SendInput: Writing {} bytes: {:?}", input_with_newline.len(), input_with_newline);
-            let mut writer = match local_shell.writer.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(local_shell, "writer lock poisoned in SendInput");
-                    return Err("Writer lock poisoned");
-                }
-            };
-            writer.write_all(input_with_newline.as_bytes())
-                .map_err(|_| "Failed to write input to interactive command (IO error)")?;
-            writer.flush()
-                .map_err(|_| "Failed to flush input writer (IO error)")?;
-            shlog_trace!("SendInput: Write and flush succeeded");
-        }
-
-        // Wait for output
-        std::thread::sleep(Duration::from_millis(SENDINPUT_INITIAL_WAIT_MS));
-        shlog_trace!("SendInput: Starting to read output after input (start_total_bytes={})", start_total_bytes);
-
-        let mut output_buffer = Vec::new();
-        let mut last_total_bytes = start_total_bytes;
-        let mut was_truncated = false;
-        let mut no_data_count = 0;
-        let mut prompt_detected = false;
-
-        for iteration in 0..max_iterations {
-            let current_total = local_shell.total_bytes_written.load(Ordering::Acquire);
-            let has_new_data = current_total > last_total_bytes;
-
-            if has_new_data {
-                // Snapshot the entire buffer
-                let snapshot = {
-                    let shared_buffer = local_shell.output_buffer.lock()
-                        .map_err(|_| "Buffer lock poisoned")?;
-                    shared_buffer.clone()
-                };
-
-                output_buffer = snapshot;
-                last_total_bytes = current_total;
-
-                if truncate_to_tail(&mut output_buffer, max_output_bytes) {
-                    was_truncated = true;
-                }
-
-                let output_str = String::from_utf8_lossy(&output_buffer);
-                shlog_trace!(
-                    "SendInput: Read data (iteration {}), total_bytes: {}, buffer size: {}",
-                    iteration, current_total, output_buffer.len()
-                );
-
-                no_data_count = 0;
-
-                if is_prompt_or_marker(&output_str, marker) {
-                    shlog_trace!("SendInput: Prompt detected in new output, exiting early");
-                    prompt_detected = true;
-                    break;
-                }
-            } else {
-                no_data_count += 1;
-                shlog_trace!("SendInput: No new data (iteration {}), no_data_count: {}",
-                    iteration, no_data_count);
-
-                if no_data_count >= SENDINPUT_NO_DATA_THRESHOLD {
-                    // Re-check buffer for prompt
-                    let output_str = String::from_utf8_lossy(&output_buffer);
-                    if is_prompt_or_marker(&output_str, marker) {
-                        shlog_trace!("SendInput: Prompt detected after silence, exiting");
-                        prompt_detected = true;
-                        break;
-                    }
-                }
-            }
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        // Final prompt check
-        if !prompt_detected {
-            let output_str = String::from_utf8_lossy(&output_buffer);
-            prompt_detected = is_prompt_or_marker(&output_str, marker);
-        }
-
-        // Clean output
-        let output_str = String::from_utf8_lossy(&output_buffer).to_string();
-        let stripped_bytes = strip_ansi_escapes::strip(&output_str);
-        let cleaned = String::from_utf8_lossy(&stripped_bytes);
-        let mut lines: Vec<&str> = cleaned.lines().collect();
-        if prompt_detected && !lines.is_empty() {
-            lines.pop(); // Remove prompt line
-        }
-        let final_output = lines.join("\n");
-
-        let mut result_table = AutoTableVar::new();
-
-        if prompt_detected {
-            {
-                let mut pending = local_shell.pending_interactive.lock()
-                    .map_err(|_| "Interactive state lock poisoned")?;
-                *pending = None;
-            }
-            shlog_trace!("Interactive session completed");
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("completed"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        } else {
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("pending_output"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
-            result_table.0.insert_fast_static(
-                "message",
-                &Var::ephemeral_string("Command still running. Use LocalShell.SendInput to continue.")
-            );
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        }
-
-        // Sync read position so subsequent LocalShell.Read doesn't pick up stale data
-        let final_total = local_shell.total_bytes_written.load(Ordering::Acquire);
-        local_shell.read_position.store(final_total, Ordering::Release);
-
-        self.output = result_table.to_cloned();
-        Ok(self.output.0)
-    }
+    let s = get_session(&session_var)?;
+    self.output = sc::send_input(
+      s,
+      input_str,
+      timeout_secs,
+      max_output_bytes,
+      "Command still running. Use LocalShell.SendInput to continue.",
+    )?;
+    Ok(self.output.0)
+  }
 }
 
 // ============================================================================
@@ -1247,83 +561,55 @@ impl BlockingShard for SendInputShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "LocalShell.IsAlive",
-    "Check if local shell session is still alive"
-)]
+#[shard_info("LocalShell.IsAlive", "Check if local shell session is still alive")]
 pub struct IsAliveShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for IsAliveShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for IsAliveShard {
-    fn input_types(&mut self) -> &Types {
-        &LOCAL_SHELL_TYPE_VEC
-    }
+  fn input_types(&mut self) -> &Types {
+    &LOCAL_SHELL_TYPE_VEC
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &BOOL_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &BOOL_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(common_type::bool)
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(common_type::bool)
+  }
 
-    fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        let local_shell = get_session(input)?;
-        let is_alive = local_shell.is_alive.load(Ordering::Acquire);
-        self.output = is_alive.into();
-        Ok(Some(self.output.0))
-    }
-}
-
-/// Render raw PTY output through a virtual VT100 terminal to get properly-spaced text.
-/// Ink/TUI frameworks use cursor positioning sequences (CSI H, CSI C, etc.) for layout
-/// instead of literal spaces — simple ANSI stripping concatenates words without gaps.
-/// This processes bytes through a virtual screen and extracts the resulting text grid.
-fn render_through_virtual_terminal(raw_bytes: &[u8], rows: u16, cols: u16) -> String {
-    let mut parser = vt100::Parser::new(rows, cols, 0);
-    parser.process(raw_bytes);
-
-    let screen = parser.screen();
-    let mut output = String::new();
-
-    for row in 0..rows {
-        let row_text = screen.contents_between(row, 0, row, cols);
-        let trimmed = row_text.trim_end();
-        if !trimmed.is_empty() || !output.is_empty() {
-            if !output.is_empty() {
-                output.push('\n');
-            }
-            output.push_str(trimmed);
-        }
-    }
-
-    output.trim().to_string()
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let s = get_session(input)?;
+    let is_alive = s.is_alive.load(Ordering::Acquire);
+    self.output = is_alive.into();
+    Ok(Some(self.output.0))
+  }
 }
 
 // ============================================================================
@@ -1332,202 +618,79 @@ fn render_through_virtual_terminal(raw_bytes: &[u8], rows: u16, cols: u16) -> St
 
 #[derive(shards::shard)]
 #[shard_info(
-    "LocalShell.Read",
-    "Read raw output from local shell session (non-blocking)"
+  "LocalShell.Read",
+  "Read raw output from local shell session (non-blocking)"
 )]
 pub struct ReadShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("MaxBytes", "Maximum bytes to read (default: 65536)", [common_type::int, common_type::int_var])]
-    max_bytes: ParamVar,
+  #[shard_param("MaxBytes", "Maximum bytes to read (default: 65536)", [common_type::int, common_type::int_var])]
+  max_bytes: ParamVar,
 
-    #[shard_param("StripAnsi", "Strip ANSI escape sequences (default: false)", [common_type::bool, common_type::bool_var])]
-    strip_ansi: ParamVar,
+  #[shard_param("StripAnsi", "Strip ANSI escape sequences (default: false)", [common_type::bool, common_type::bool_var])]
+  strip_ansi: ParamVar,
 
-    #[shard_param("Timeout", "Timeout in milliseconds, 0 = immediate (default: 0)", [common_type::int, common_type::int_var])]
-    timeout_ms: ParamVar,
+  #[shard_param("Timeout", "Timeout in milliseconds, 0 = immediate (default: 0)", [common_type::int, common_type::int_var])]
+  timeout_ms: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ReadShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            max_bytes: ParamVar::new(65536i64.into()),
-            strip_ansi: ParamVar::new(false.into()),
-            timeout_ms: ParamVar::new(0i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      max_bytes: ParamVar::new(65536i64.into()),
+      strip_ansi: ParamVar::new(false.into()),
+      timeout_ms: ParamVar::new(0i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ReadShard {
-    fn input_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
-        let session_var = *self.session.get();
-        let max_bytes: i64 = self.max_bytes.get().as_ref().try_into()?;
-        let max_bytes = if max_bytes <= 0 { 65536usize } else { max_bytes as usize };
-        let strip: bool = self.strip_ansi.get().as_ref().try_into()?;
-        let timeout_ms: i64 = self.timeout_ms.get().as_ref().try_into()?;
-        let timeout_ms = if timeout_ms < 0 { 0u64 } else { timeout_ms as u64 };
+  fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
+    let session_var = *self.session.get();
+    let max_bytes: i64 = self.max_bytes.get().as_ref().try_into()?;
+    let strip: bool = self.strip_ansi.get().as_ref().try_into()?;
+    let timeout_ms: i64 = self.timeout_ms.get().as_ref().try_into()?;
 
-        let local_shell = get_session(&session_var)?;
-        check_session_alive(local_shell)?;
+    let s = get_session(&session_var)?;
+    let output_str = sc::read_raw(s, context, max_bytes, strip, timeout_ms)?;
 
-        // Read cursor lives on the session so multiple Read shard instances share it
-        let read_pos = &local_shell.read_position;
-
-        let deadline = if timeout_ms > 0 {
-            Some(std::time::Instant::now() + Duration::from_millis(timeout_ms))
-        } else {
-            None
-        };
-
-        let mut result_data = Vec::new();
-
-        // Accumulate data until timeout expires or data settles.
-        // Settle time scales with timeout: 20% of requested timeout, clamped [100ms, 2000ms].
-        // TUI apps (Ink/React) render in bursts with gaps — a longer settle avoids
-        // returning between render bursts with only partial output.
-        let settle_ms = if timeout_ms > 0 {
-            (timeout_ms / 5).max(100).min(2000)
-        } else {
-            100
-        };
-        let mut last_data_time: Option<std::time::Instant> = None;
-        let mut prev_total = read_pos.load(Ordering::Acquire);
-
-        loop {
-            let current_total = local_shell.total_bytes_written.load(Ordering::Acquire);
-
-            if current_total > prev_total {
-                // New data arrived since last poll — reset settle timer
-                last_data_time = Some(std::time::Instant::now());
-                prev_total = current_total;
-            }
-
-            if let Some(dl) = deadline {
-                // Hard timeout
-                if std::time::Instant::now() >= dl {
-                    break;
-                }
-                // Early exit: data arrived then went quiet for SETTLE_MS
-                if let Some(ldt) = last_data_time {
-                    if std::time::Instant::now().duration_since(ldt) >= Duration::from_millis(settle_ms) {
-                        break;
-                    }
-                }
-                // Yield to scheduler instead of blocking the thread
-                shards::core::suspend(context, 0.01);
-            } else {
-                // No timeout = immediate mode, return whatever is available now
-                break;
-            }
-        }
-
-        // Final snapshot of accumulated data
-        let final_total = local_shell.total_bytes_written.load(Ordering::Acquire);
-        let final_consumed = read_pos.load(Ordering::Acquire);
-        if final_total > final_consumed {
-            let snapshot = {
-                let buf = local_shell.output_buffer.lock()
-                    .map_err(|_| "Buffer lock poisoned")?;
-                buf.clone()
-            };
-
-            let new_byte_count = final_total - final_consumed;
-            let available = snapshot.len().min(new_byte_count).min(max_bytes);
-            result_data = snapshot[snapshot.len().saturating_sub(available)..].to_vec();
-            read_pos.store(final_total, Ordering::Release);
-        }
-
-        let output_str = if strip {
-            let term_rows = local_shell.term_rows.load(Ordering::Acquire);
-            let term_cols = local_shell.term_cols.load(Ordering::Acquire);
-            render_through_virtual_terminal(&result_data, term_rows, term_cols)
-        } else {
-            String::from_utf8_lossy(&result_data).to_string()
-        };
-
-        self.output = Var::ephemeral_string(&output_str).into();
-        Ok(Some(self.output.0))
-    }
-}
-
-// Interpret escape sequences in input strings for PTY writing.
-// Handles \r, \n, \t, \\, \xNN. Also converts bare LF (0x0A) to CR (0x0D)
-// because PTY Enter = CR, and TUI apps in raw mode expect CR not LF.
-fn interpret_escape_sequences(input: &str) -> Vec<u8> {
-    let mut result = Vec::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            match chars.peek() {
-                Some('n') => { chars.next(); result.push(0x0A); }
-                Some('r') => { chars.next(); result.push(0x0D); }
-                Some('t') => { chars.next(); result.push(0x09); }
-                Some('\\') => { chars.next(); result.push(b'\\'); }
-                Some('x') => {
-                    chars.next(); // consume 'x'
-                    let mut hex = String::new();
-                    for _ in 0..2 {
-                        if let Some(&c) = chars.peek() {
-                            if c.is_ascii_hexdigit() {
-                                hex.push(c);
-                                chars.next();
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                        result.push(byte);
-                    }
-                }
-                _ => { result.push(b'\\'); }
-            }
-        } else if ch == '\n' {
-            // Bare LF → CR: terminal Enter sends CR to PTY master
-            result.push(0x0D);
-        } else {
-            let mut buf = [0u8; 4];
-            let encoded = ch.encode_utf8(&mut buf);
-            result.extend_from_slice(encoded.as_bytes());
-        }
-    }
-
-    result
+    self.output = Var::ephemeral_string(&output_str).into();
+    Ok(Some(self.output.0))
+  }
 }
 
 // ============================================================================
@@ -1535,86 +698,69 @@ fn interpret_escape_sequences(input: &str) -> Vec<u8> {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "LocalShell.Write",
-    "Write raw bytes to local shell session"
-)]
+#[shard_info("LocalShell.Write", "Write raw bytes to local shell session")]
 pub struct WriteShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("AppendNewline", "Append newline after input (default: false)", [common_type::bool, common_type::bool_var])]
-    append_newline: ParamVar,
+  #[shard_param("AppendNewline", "Append newline after input (default: false)", [common_type::bool, common_type::bool_var])]
+  append_newline: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for WriteShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            append_newline: ParamVar::new(false.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      append_newline: ParamVar::new(false.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for WriteShard {
-    fn input_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        let input_str: &str = input.try_into()?;
-        let session_var = *self.session.get();
-        let append_nl: bool = self.append_newline.get().as_ref().try_into()?;
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let input_str: &str = input.try_into()?;
+    let session_var = *self.session.get();
+    let append_nl: bool = self.append_newline.get().as_ref().try_into()?;
 
-        let local_shell = get_session(&session_var)?;
-        check_session_alive(local_shell)?;
+    let s = get_session(&session_var)?;
+    sc::write_raw(s, input_str, append_nl)?;
 
-        {
-            let bytes = interpret_escape_sequences(input_str);
-            let mut writer = local_shell.writer.lock()
-                .map_err(|_| "Writer lock poisoned")?;
-            writer.write_all(&bytes)
-                .map_err(|_| "Failed to write to shell (IO error)")?;
-            if append_nl {
-                writer.write_all(b"\r")
-                    .map_err(|_| "Failed to write newline to shell (IO error)")?;
-            }
-            writer.flush()
-                .map_err(|_| "Failed to flush writer (IO error)")?;
-        }
-
-        // Passthrough input
-        self.output = input.into();
-        Ok(Some(self.output.0))
-    }
+    // Passthrough input
+    self.output = input.into();
+    Ok(Some(self.output.0))
+  }
 }
 
 // ============================================================================
@@ -1623,93 +769,73 @@ impl Shard for WriteShard {
 
 #[derive(shards::shard)]
 #[shard_info(
-    "LocalShell.Resize",
-    "Resize the PTY terminal of a local shell session"
+  "LocalShell.Resize",
+  "Resize the PTY terminal of a local shell session"
 )]
 pub struct ResizeShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "Local shell session object", [*LOCAL_SHELL_TYPE, *LOCAL_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("Rows", "Number of rows", [common_type::int, common_type::int_var])]
-    rows: ParamVar,
+  #[shard_param("Rows", "Number of rows", [common_type::int, common_type::int_var])]
+  rows: ParamVar,
 
-    #[shard_param("Cols", "Number of columns", [common_type::int, common_type::int_var])]
-    cols: ParamVar,
+  #[shard_param("Cols", "Number of columns", [common_type::int, common_type::int_var])]
+  cols: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ResizeShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            rows: ParamVar::new(24i64.into()),
-            cols: ParamVar::new(80i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      rows: ParamVar::new(24i64.into()),
+      cols: ParamVar::new(80i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ResizeShard {
-    fn input_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
-        let session_var = *self.session.get();
-        let rows_val: i64 = self.rows.get().as_ref().try_into()?;
-        let cols_val: i64 = self.cols.get().as_ref().try_into()?;
+  fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
+    let session_var = *self.session.get();
+    let rows_val: i64 = self.rows.get().as_ref().try_into()?;
+    let cols_val: i64 = self.cols.get().as_ref().try_into()?;
 
-        let rows = rows_val.max(1).min(u16::MAX as i64) as u16;
-        let cols = cols_val.max(1).min(u16::MAX as i64) as u16;
+    let s = get_session(&session_var)?;
+    sc::resize(s, rows_val, cols_val)?;
 
-        let local_shell = get_session(&session_var)?;
-        check_session_alive(local_shell)?;
-
-        let pair_guard = local_shell.pair.lock()
-            .map_err(|_| "PTY pair lock poisoned")?;
-
-        if let Some(ref pair) = *pair_guard {
-            pair.master.resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            }).map_err(|_| "Failed to resize PTY")?;
-            local_shell.term_rows.store(rows, Ordering::Release);
-            local_shell.term_cols.store(cols, Ordering::Release);
-            shlog_trace!("PTY resized to {}x{}", cols, rows);
-        } else {
-            return Err("PTY pair has been dropped");
-        }
-
-        Ok(None)
-    }
+    Ok(None)
+  }
 }
 
 // ============================================================================
@@ -1718,21 +844,21 @@ impl Shard for ResizeShard {
 
 #[no_mangle]
 pub extern "C" fn shardsRegister_localshell_rust(core: *mut shards::shardsc::SHCore) {
-    unsafe {
-        shards::core::Core = core;
-    }
+  unsafe {
+    shards::core::Core = core;
+  }
 
-    let mut info = shards::SHObjectInfo::default();
-    info.name = cstr!("LocalShell.Session").as_ptr() as shards::SHString;
-    shards::core::register_object_type_internal(FRAG_CC, fourCharacterCode(*b"lshl"), info);
+  let mut info = shards::SHObjectInfo::default();
+  info.name = cstr!("LocalShell.Session").as_ptr() as shards::SHString;
+  shards::core::register_object_type_internal(FRAG_CC, fourCharacterCode(*b"lshl"), info);
 
-    register_shard::<CreateShard>();
-    register_shard::<ExecuteShard>();
-    register_shard::<SendInputShard>();
-    register_shard::<IsAliveShard>();
-    register_shard::<ReadShard>();
-    register_shard::<WriteShard>();
-    register_shard::<ResizeShard>();
+  register_shard::<CreateShard>();
+  register_shard::<ExecuteShard>();
+  register_shard::<SendInputShard>();
+  register_shard::<IsAliveShard>();
+  register_shard::<ReadShard>();
+  register_shard::<WriteShard>();
+  register_shard::<ResizeShard>();
 
-    shlog_trace!("LocalShell module registered");
+  shlog_trace!("LocalShell module registered");
 }

--- a/shards/modules/shell-common/Cargo.toml
+++ b/shards/modules/shell-common/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["rlib"]
 [dependencies]
 lazy_static = "1.5.0"
 shards = { path = "../../rust" }
+regex = "1"
 strip-ansi-escapes = "0.2"
 vt100 = "0.15"

--- a/shards/modules/shell-common/Cargo.toml
+++ b/shards/modules/shell-common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "shards-shell-common"
+description = "Shared interactive shell-session machinery for Shards shell modules (localshell, ssh)"
+license = "BSD-3-Clause"
+version = "0.1.0"
+authors = ["Fragcolor Pte. Ltd."]
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+lazy_static = "1.5.0"
+shards = { path = "../../rust" }
+strip-ansi-escapes = "0.2"
+vt100 = "0.15"

--- a/shards/modules/shell-common/src/lib.rs
+++ b/shards/modules/shell-common/src/lib.rs
@@ -1205,3 +1205,88 @@ pub fn resize(s: &ShellSession, rows: i64, cols: i64) -> Result<(), &'static str
   shlog_trace!("PTY resized to {}x{}", cols, rows);
   Ok(())
 }
+
+/// Watch the session's output stream until `pattern` (a regular expression)
+/// matches, returning the matched text. Cooperatively suspends the wire (via
+/// `context`) between polls so the reader thread keeps filling the buffer and
+/// the wire stays responsive.
+///
+/// Matching is performed against output accumulated from the shared read cursor
+/// forward; on a match the cursor is advanced past everything observed so far,
+/// so a subsequent `Read`/`WaitFor` continues after the matched region. When
+/// `strip` is set, ANSI escape sequences are removed before matching (and from
+/// the returned text). `timeout_ms` of 0 means wait indefinitely (until the
+/// session ends). Returns an error on timeout or if the session ends first.
+pub fn wait_for(
+  s: &ShellSession,
+  context: &Context,
+  pattern: &str,
+  timeout_ms: i64,
+  strip: bool,
+) -> Result<String, &'static str> {
+  check_session_alive(s)?;
+
+  let re = regex::Regex::new(pattern).map_err(|_| "Invalid regex pattern")?;
+
+  let timeout_ms = if timeout_ms < 0 {
+    0u64
+  } else {
+    timeout_ms as u64
+  };
+  let deadline = if timeout_ms > 0 {
+    Some(std::time::Instant::now() + Duration::from_millis(timeout_ms))
+  } else {
+    None
+  };
+
+  // Shared read cursor, so this composes with Read/Execute on the same session.
+  let read_pos = &s.read_position;
+
+  loop {
+    let current_total = s.total_bytes_written.load(Ordering::Acquire);
+    let consumed = read_pos.load(Ordering::Acquire);
+
+    if current_total > consumed {
+      let snapshot = {
+        let buf = s.output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
+        buf.clone()
+      };
+
+      // The monotonic counter can outrun the (truncated) buffer; clamp to what
+      // is actually retained.
+      let new_count = current_total - consumed;
+      let available = snapshot.len().min(new_count);
+      let new_slice = &snapshot[snapshot.len() - available..];
+
+      let text = if strip {
+        let stripped = strip_ansi_escapes::strip(new_slice);
+        String::from_utf8_lossy(&stripped).to_string()
+      } else {
+        String::from_utf8_lossy(new_slice).to_string()
+      };
+
+      if let Some(m) = re.find(&text) {
+        let matched = m.as_str().to_string();
+        // Consume everything observed so far.
+        read_pos.store(current_total, Ordering::Release);
+        shlog_trace!("WaitFor: pattern matched: {:?}", matched);
+        return Ok(matched);
+      }
+    }
+
+    // Stop if the session ended (process exited / connection lost). Done after
+    // the match attempt so the final output is still considered.
+    if !s.is_alive.load(Ordering::Acquire) {
+      return Err(s.messages.ended);
+    }
+
+    if let Some(dl) = deadline {
+      if std::time::Instant::now() >= dl {
+        return Err("Timed out waiting for pattern");
+      }
+    }
+
+    // Yield to the scheduler instead of blocking the thread.
+    shards::core::suspend(context, 0.05);
+  }
+}

--- a/shards/modules/shell-common/src/lib.rs
+++ b/shards/modules/shell-common/src/lib.rs
@@ -1,0 +1,1207 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2025 Fragcolor Pte. Ltd. */
+
+//! Shared machinery for Shards interactive shell-session modules.
+//!
+//! Both `shards-localshell` (PTY-backed local shells) and `shards-ssh` (remote
+//! shells over SSH) implement the exact same "persistent interactive shell
+//! session" model: a background reader thread fills a shared byte buffer, a
+//! monotonic byte counter tracks progress (immune to buffer truncation), and a
+//! sentinel `PS1` marker drives reliable prompt detection.
+//!
+//! This crate owns everything except the transport. A module provides an
+//! implementation of [`ShellTransport`] (how to read/write/resize/close its
+//! underlying channel) plus its `Create`/`Connect` shard, and delegates the
+//! `Execute` / `SendInput` / `Read` / `Write` / `Resize` logic to the free
+//! functions here.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate shards;
+
+#[macro_use]
+extern crate lazy_static;
+
+use shards::types::common_type;
+use shards::types::AutoTableVar;
+use shards::types::ClonedVar;
+use shards::types::Context;
+use shards::types::Type;
+use shards::types::Var;
+
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+// ============================================================================
+// Configuration constants (shared by every shell transport)
+// ============================================================================
+pub const INITIAL_PROMPT_WAIT_MS: u64 = 500;
+pub const INITIAL_PROMPT_MAX_RETRIES: usize = 20;
+pub const COMMAND_OUTPUT_WAIT_MS: u64 = 200;
+pub const ITERATION_SLEEP_MS: u64 = 100;
+pub const INTERACTIVE_DETECTION_ITERATIONS: usize = 30; // 30 * 100ms = 3 seconds
+pub const SENDINPUT_INITIAL_WAIT_MS: u64 = 500;
+pub const SENDINPUT_NO_DATA_THRESHOLD: usize = 20; // 20 iterations = 2 seconds
+pub const MAX_BUFFER_BYTES: usize = 65536; // 64KB default
+pub const BUFFER_TRUNCATE_KEEP_RATIO: usize = 93; // Keep 93% on truncation
+pub const READER_POLL_MS: u64 = 50; // How often a polling reader thread retries
+
+lazy_static! {
+    /// Output type shared by `Execute` / `SendInput`: a string-keyed table.
+    pub static ref EXECUTE_OUTPUT_TYPES: Vec<Type> = vec![common_type::string_table];
+}
+
+// ============================================================================
+// Transport abstraction
+// ============================================================================
+
+/// Result of a single non-/blocking read attempt by the reader thread.
+pub enum ReadOutcome {
+  /// `n` bytes were read into the provided buffer.
+  Data(usize),
+  /// The transport ended (EOF / connection closed / fatal error). The reader
+  /// thread will mark the session as ended and exit.
+  Ended,
+  /// No data was available right now (or a transient, recoverable error). The
+  /// reader thread will sleep for `poll_interval_ms()` and try again.
+  Retry,
+}
+
+/// Error returned from a write attempt.
+pub enum TransportError {
+  /// The underlying connection/process went away. The session will be marked
+  /// ended.
+  ConnectionLost,
+  /// Any other failure; the static string is surfaced to the caller as-is.
+  Other(&'static str),
+}
+
+/// The per-module transport. All methods use `&self` + interior mutability so
+/// the transport can be shared (via `Arc`) between the reader thread and the
+/// activating shard.
+pub trait ShellTransport: Send + Sync {
+  /// Read whatever is currently available into `buf`. Called only from the
+  /// reader thread.
+  fn read_into(&self, buf: &mut [u8]) -> ReadOutcome;
+
+  /// Write all bytes, blocking until they are flushed.
+  fn write_all(&self, data: &[u8]) -> Result<(), TransportError>;
+
+  /// Resize the remote/local PTY.
+  fn resize(&self, rows: u16, cols: u16) -> Result<(), &'static str>;
+
+  /// Tear down the transport (kill child / close channel / disconnect). Called
+  /// once from [`ShellSession`]'s `Drop`, before the reader thread is joined.
+  fn close(&self);
+
+  /// Poll interval used when [`read_into`](Self::read_into) returns
+  /// [`ReadOutcome::Retry`].
+  fn poll_interval_ms(&self) -> u64 {
+    READER_POLL_MS
+  }
+}
+
+// ============================================================================
+// Session state + messages
+// ============================================================================
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionState {
+  Running,
+  /// The process exited / the connection was lost.
+  Ended,
+  /// An internal invariant was violated (e.g. a poisoned lock).
+  Corrupted(String),
+}
+
+#[derive(Clone)]
+pub struct InteractiveState {
+  #[allow(dead_code)] // Stored for debugging/future use
+  pub original_cmd: String,
+}
+
+/// User-facing error strings, customised per module so a dead session reports
+/// "Local shell process has exited" vs "SSH connection lost".
+#[derive(Clone, Copy)]
+pub struct SessionMessages {
+  pub ended: &'static str,
+  pub corrupted: &'static str,
+  pub poisoned: &'static str,
+  pub unexpected: &'static str,
+}
+
+/// The transport-agnostic interactive shell session. Modules wrap this in a
+/// local newtype to satisfy the orphan rule when implementing the ref-counted
+/// object type.
+pub struct ShellSession {
+  pub transport: Arc<dyn ShellTransport>,
+  pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
+  pub is_alive: Arc<AtomicBool>,
+  pub state: Arc<Mutex<SessionState>>,
+  pub output_buffer: Arc<Mutex<Vec<u8>>>,
+  pub total_bytes_written: Arc<AtomicUsize>,
+  /// Read cursor for `Read` — how many bytes have been consumed by raw reads.
+  /// Lives on the session so multiple `Read` shard instances share state.
+  pub read_position: Arc<AtomicUsize>,
+  pub reader_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+  pub prompt_marker: Option<String>,
+  pub term_rows: Arc<AtomicU16>,
+  pub term_cols: Arc<AtomicU16>,
+  pub messages: SessionMessages,
+}
+
+impl Drop for ShellSession {
+  fn drop(&mut self) {
+    shlog_trace!("Dropping ShellSession, cleaning up");
+
+    // Step 1: Mark as not alive (prevents new operations / stops the loop).
+    self.is_alive.store(false, Ordering::Release);
+
+    // Step 2: Transport-specific teardown. For a PTY this kills the child and
+    // drops the pair, which causes the blocking read in the reader thread to
+    // return EOF. For SSH it closes the channel and disconnects the session.
+    self.transport.close();
+
+    // Step 3: Wait for the reader thread with a timeout.
+    if let Ok(mut thread_opt) = self.reader_thread.lock() {
+      if let Some(thread) = thread_opt.take() {
+        shlog_trace!("Waiting for reader thread to finish");
+
+        let mut finished = false;
+        for _i in 0..20 {
+          if thread.is_finished() {
+            finished = true;
+            break;
+          }
+          std::thread::sleep(Duration::from_millis(100));
+        }
+
+        if finished {
+          let _ = thread.join();
+          shlog_trace!("Reader thread joined successfully");
+        } else {
+          shlog_error!(
+            "Reader thread did not finish within timeout, leaving it detached (thread leak)"
+          );
+        }
+      }
+    }
+
+    shlog_trace!("ShellSession cleanup complete");
+  }
+}
+
+// ============================================================================
+// Reader thread
+// ============================================================================
+
+/// Spawn the background reader thread for a session's shared buffer. Started
+/// before the initial prompt is awaited so no throwaway threads are needed.
+pub fn start_reader_thread(
+  transport: Arc<dyn ShellTransport>,
+  buffer: Arc<Mutex<Vec<u8>>>,
+  total_bytes: Arc<AtomicUsize>,
+  alive: Arc<AtomicBool>,
+  state: Arc<Mutex<SessionState>>,
+) -> std::thread::JoinHandle<()> {
+  let poll_ms = transport.poll_interval_ms();
+  std::thread::spawn(move || {
+    shlog_trace!("Reader thread started");
+    let mut buf = [0u8; 4096];
+
+    loop {
+      if !alive.load(Ordering::Acquire) {
+        shlog_trace!("Reader thread exiting (not alive)");
+        break;
+      }
+
+      match transport.read_into(&mut buf) {
+        ReadOutcome::Data(n) if n > 0 => match buffer.lock() {
+          Ok(mut b) => {
+            b.extend_from_slice(&buf[..n]);
+
+            if b.len() > MAX_BUFFER_BYTES {
+              if truncate_to_tail(&mut b, MAX_BUFFER_BYTES) {
+                shlog_trace!("Reader thread: buffer truncated to {} bytes", b.len());
+              }
+            }
+
+            // Increment the monotonic counter AFTER the write so that
+            // a reader observing the counter always sees the bytes.
+            total_bytes.fetch_add(n, Ordering::Release);
+            shlog_trace!(
+              "Reader thread: read {} bytes, buffer now {} bytes",
+              n,
+              b.len()
+            );
+          }
+          Err(e) => {
+            shlog_trace!("Reader thread: buffer lock poisoned: {}", e);
+            break;
+          }
+        },
+        ReadOutcome::Data(_) => {
+          // Zero-length read: treat as ended (defensive; transports
+          // normally return Ended for this).
+          alive.store(false, Ordering::Release);
+          if let Ok(mut s) = state.lock() {
+            *s = SessionState::Ended;
+          }
+          shlog_trace!("Reader thread: zero-length read, ending");
+          break;
+        }
+        ReadOutcome::Ended => {
+          alive.store(false, Ordering::Release);
+          if let Ok(mut s) = state.lock() {
+            *s = SessionState::Ended;
+          }
+          shlog_trace!("Reader thread: transport ended");
+          break;
+        }
+        ReadOutcome::Retry => {
+          std::thread::sleep(Duration::from_millis(poll_ms));
+        }
+      }
+    }
+    shlog_trace!("Reader thread finished");
+  })
+}
+
+// ============================================================================
+// Text helpers (pure)
+// ============================================================================
+
+/// Detect shell prompts (no sentinel marker).
+pub fn is_prompt(text: &str) -> bool {
+  is_prompt_or_marker(text, None)
+}
+
+/// Detect shell prompts, preferring an explicit sentinel marker when present.
+pub fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
+  let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
+  let cleaned = String::from_utf8_lossy(&stripped_bytes);
+
+  let lines: Vec<&str> = cleaned.lines().collect();
+  if let Some(last) = lines.last() {
+    let trimmed = last.trim();
+
+    // Check sentinel marker first (most reliable).
+    if let Some(m) = marker {
+      // When sentinel marker is set, ONLY trust the sentinel. Generic
+      // prompt patterns ($ # > %) cause false positives with heredoc
+      // continuation prompts and command output that happens to end with
+      // these characters.
+      return trimmed.contains(m);
+    }
+
+    // Exclude interactive program prompts like >>> (Python), >> (continuation).
+    if trimmed.ends_with(">>>") || trimmed.ends_with(">>") {
+      return false;
+    }
+
+    // Check for common shell prompt patterns (fallback when no sentinel).
+    trimmed.ends_with("$ ")
+      || trimmed.ends_with("$")
+      || trimmed.ends_with("# ")
+      || trimmed.ends_with("#")
+      || trimmed.ends_with("> ")
+      || trimmed.ends_with(">")
+      || trimmed.ends_with("% ")
+      || trimmed.ends_with("%")
+  } else {
+    false
+  }
+}
+
+/// Detect common interactive prompts (password, confirmation, etc.).
+pub fn is_interactive_prompt(text: &str) -> bool {
+  let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
+  let cleaned = String::from_utf8_lossy(&stripped_bytes);
+
+  let lines: Vec<&str> = cleaned.lines().collect();
+  if lines.is_empty() {
+    return false;
+  }
+
+  let check_lines = if lines.len() > 3 {
+    &lines[lines.len() - 3..]
+  } else {
+    &lines[..]
+  };
+
+  for line in check_lines {
+    let lower = line.to_lowercase();
+
+    if lower.contains("password:")
+      || lower.contains("passphrase:")
+      || lower.contains("continue?")
+      || lower.contains("(y/n)")
+      || lower.contains("[y/n]")
+      || lower.contains("press enter")
+      || lower.contains("press any key")
+      || lower.contains("are you sure")
+      || lower.ends_with("? ")
+      || lower.ends_with(": ")
+    {
+      return true;
+    }
+  }
+
+  false
+}
+
+/// Clean output: remove ANSI codes, control chars, and a trailing prompt line.
+pub fn clean_output_with_marker(output: &str, marker: Option<&str>) -> String {
+  let stripped_bytes = strip_ansi_escapes::strip(output);
+  let text = String::from_utf8_lossy(&stripped_bytes);
+
+  let no_control: String = text
+    .chars()
+    .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+    .collect();
+
+  let mut lines: Vec<&str> = no_control.lines().collect();
+
+  // Remove trailing prompt if present.
+  if !lines.is_empty() {
+    let last_line = lines.last().unwrap();
+    if is_prompt_or_marker(last_line, marker) {
+      lines.pop();
+    }
+  }
+
+  let result = lines.join("\n");
+  result.trim().to_string()
+}
+
+/// Truncate an output buffer to keep the tail, prepending a truncation notice.
+pub fn truncate_to_tail(buffer: &mut Vec<u8>, max_bytes: usize) -> bool {
+  if buffer.len() <= max_bytes {
+    return false;
+  }
+
+  let keep_bytes = (max_bytes * BUFFER_TRUNCATE_KEEP_RATIO) / 100;
+  let truncate_msg = b"[... output truncated ...]\n";
+
+  let skip = buffer.len() - keep_bytes + truncate_msg.len();
+  let tail: Vec<u8> = buffer.drain(skip..).collect();
+  buffer.clear();
+  buffer.extend_from_slice(truncate_msg);
+  buffer.extend_from_slice(&tail);
+
+  true
+}
+
+/// Render raw PTY output through a virtual VT100 terminal to get properly-spaced
+/// text. Ink/TUI frameworks use cursor positioning sequences (CSI H, CSI C, etc.)
+/// for layout instead of literal spaces — simple ANSI stripping concatenates
+/// words without gaps. This processes bytes through a virtual screen and extracts
+/// the resulting text grid.
+pub fn render_through_virtual_terminal(raw_bytes: &[u8], rows: u16, cols: u16) -> String {
+  let mut parser = vt100::Parser::new(rows, cols, 0);
+  parser.process(raw_bytes);
+
+  let screen = parser.screen();
+  let mut output = String::new();
+
+  for row in 0..rows {
+    let row_text = screen.contents_between(row, 0, row, cols);
+    let trimmed = row_text.trim_end();
+    if !trimmed.is_empty() || !output.is_empty() {
+      if !output.is_empty() {
+        output.push('\n');
+      }
+      output.push_str(trimmed);
+    }
+  }
+
+  output.trim().to_string()
+}
+
+/// Interpret escape sequences in input strings for PTY writing. Handles `\r`,
+/// `\n`, `\t`, `\\`, `\xNN`. Also converts bare LF (0x0A) to CR (0x0D) because
+/// PTY Enter = CR, and TUI apps in raw mode expect CR not LF.
+pub fn interpret_escape_sequences(input: &str) -> Vec<u8> {
+  let mut result = Vec::with_capacity(input.len());
+  let mut chars = input.chars().peekable();
+
+  while let Some(ch) = chars.next() {
+    if ch == '\\' {
+      match chars.peek() {
+        Some('n') => {
+          chars.next();
+          result.push(0x0A);
+        }
+        Some('r') => {
+          chars.next();
+          result.push(0x0D);
+        }
+        Some('t') => {
+          chars.next();
+          result.push(0x09);
+        }
+        Some('\\') => {
+          chars.next();
+          result.push(b'\\');
+        }
+        Some('x') => {
+          chars.next(); // consume 'x'
+          let mut hex = String::new();
+          for _ in 0..2 {
+            if let Some(&c) = chars.peek() {
+              if c.is_ascii_hexdigit() {
+                hex.push(c);
+                chars.next();
+              } else {
+                break;
+              }
+            }
+          }
+          if let Ok(byte) = u8::from_str_radix(&hex, 16) {
+            result.push(byte);
+          }
+        }
+        _ => {
+          result.push(b'\\');
+        }
+      }
+    } else if ch == '\n' {
+      // Bare LF → CR: terminal Enter sends CR to PTY master.
+      result.push(0x0D);
+    } else {
+      let mut buf = [0u8; 4];
+      let encoded = ch.encode_utf8(&mut buf);
+      result.extend_from_slice(encoded.as_bytes());
+    }
+  }
+
+  result
+}
+
+// ============================================================================
+// Session helpers
+// ============================================================================
+
+/// Mark a session corrupted after an unrecoverable internal error.
+pub fn mark_session_corrupted(s: &ShellSession, error_context: &str) {
+  shlog_error!(
+    "Critical error in shell session ({}), marking as corrupted",
+    error_context
+  );
+  s.is_alive.store(false, Ordering::Release);
+  if let Ok(mut state) = s.state.lock() {
+    *state = SessionState::Corrupted(error_context.to_string());
+  }
+}
+
+/// Return a descriptive error if the session is no longer alive.
+pub fn check_session_alive(s: &ShellSession) -> Result<(), &'static str> {
+  if !s.is_alive.load(Ordering::Acquire) {
+    if let Ok(state) = s.state.lock() {
+      return Err(match *state {
+        SessionState::Ended => s.messages.ended,
+        SessionState::Corrupted(ref reason) => {
+          shlog_error!("Session corrupted: {}", reason);
+          s.messages.corrupted
+        }
+        SessionState::Running => s.messages.unexpected,
+      });
+    } else {
+      return Err(s.messages.poisoned);
+    }
+  }
+  Ok(())
+}
+
+/// Write to the transport, marking the session ended if the connection drops.
+pub fn session_write(s: &ShellSession, data: &[u8]) -> Result<(), &'static str> {
+  match s.transport.write_all(data) {
+    Ok(()) => Ok(()),
+    Err(TransportError::ConnectionLost) => {
+      s.is_alive.store(false, Ordering::Release);
+      if let Ok(mut st) = s.state.lock() {
+        *st = SessionState::Ended;
+      }
+      shlog_trace!("Connection lost during write");
+      Err(s.messages.ended)
+    }
+    Err(TransportError::Other(e)) => Err(e),
+  }
+}
+
+fn now_marker() -> String {
+  format!(
+    "__SHARDS_PROMPT_{:x}__",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_nanos()
+      & 0xFFFFFFFF
+  )
+}
+
+// ============================================================================
+// Bootstrap helpers (used by each module's Create/Connect shard)
+// ============================================================================
+
+/// Poll the shared buffer until a prompt appears (or retries are exhausted).
+pub fn wait_for_initial_prompt(buffer: &Arc<Mutex<Vec<u8>>>) -> Result<(), &'static str> {
+  std::thread::sleep(Duration::from_millis(INITIAL_PROMPT_WAIT_MS));
+
+  for _ in 0..INITIAL_PROMPT_MAX_RETRIES {
+    {
+      let buf = buffer.lock().map_err(|_| "Buffer lock poisoned")?;
+      if !buf.is_empty() {
+        let output_str = String::from_utf8_lossy(&buf);
+        if is_prompt(&output_str) {
+          shlog_trace!("Initial prompt detected");
+          break;
+        }
+      }
+    }
+    std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
+  }
+
+  shlog_trace!("Shell ready");
+  Ok(())
+}
+
+/// Try to install a `PS1` sentinel marker for reliable prompt detection. On
+/// success the shared buffer is cleared and the byte counter reset so setup
+/// output never leaks into command results. Returns the marker if confirmed.
+pub fn setup_prompt_marker(
+  transport: &Arc<dyn ShellTransport>,
+  buffer: &Arc<Mutex<Vec<u8>>>,
+  total_bytes: &Arc<AtomicUsize>,
+) -> Option<String> {
+  let marker = now_marker();
+  let ps1_cmd = format!("export PS1='{}'\n", marker);
+
+  if transport.write_all(ps1_cmd.as_bytes()).is_err() {
+    return None;
+  }
+
+  // Wait for the marker to appear.
+  std::thread::sleep(Duration::from_millis(300));
+
+  let marker_found = if let Ok(buf) = buffer.lock() {
+    String::from_utf8_lossy(&buf).contains(&marker)
+  } else {
+    false
+  };
+
+  // Clear buffer + reset counter regardless — we don't want setup output in
+  // command results.
+  if let Ok(mut buf) = buffer.lock() {
+    buf.clear();
+  }
+  total_bytes.store(0, Ordering::Release);
+
+  if marker_found {
+    shlog_trace!("Sentinel prompt marker set: {}", marker);
+    Some(marker)
+  } else {
+    shlog_trace!("Sentinel prompt marker not detected, falling back to pattern matching");
+    None
+  }
+}
+
+// ============================================================================
+// Exit code capture
+// ============================================================================
+
+/// Capture the previous command's exit code by sending `echo $?`.
+fn capture_exit_code(s: &ShellSession, marker: Option<&str>) -> Option<i64> {
+  {
+    let mut buf = s.output_buffer.lock().ok()?;
+    buf.clear();
+    s.total_bytes_written.store(0, Ordering::Release);
+    s.read_position.store(0, Ordering::Release);
+  }
+
+  if session_write(s, b"echo $?\n").is_err() {
+    return None;
+  }
+
+  // Wait for response.
+  std::thread::sleep(Duration::from_millis(200));
+
+  for _ in 0..10 {
+    let snapshot = {
+      let buf = s.output_buffer.lock().ok()?;
+      buf.clone()
+    };
+
+    let output = String::from_utf8_lossy(&snapshot);
+    if is_prompt_or_marker(&output, marker) {
+      let stripped = strip_ansi_escapes::strip(output.as_bytes());
+      let cleaned = String::from_utf8_lossy(&stripped);
+      for line in cleaned.lines() {
+        let trimmed = line.trim();
+        // Skip the echo command itself and the prompt.
+        if trimmed == "echo $?" || trimmed.is_empty() {
+          continue;
+        }
+        if is_prompt_or_marker(trimmed, marker) {
+          continue;
+        }
+        if let Ok(code) = trimmed.parse::<i64>() {
+          return Some(code);
+        }
+      }
+      return None;
+    }
+
+    std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
+  }
+
+  None
+}
+
+// ============================================================================
+// Generic shard operations
+// ============================================================================
+
+/// Execute a command in the session and collect its output.
+///
+/// `interact_hint` is the module-specific message returned when the command
+/// appears to be waiting for input (e.g. "...Use SSH.SendInput to interact.").
+pub fn execute(
+  s: &ShellSession,
+  cmd: &str,
+  timeout_secs: i64,
+  should_clean: bool,
+  max_output_bytes: i64,
+  interact_hint: &'static str,
+) -> Result<ClonedVar, &'static str> {
+  check_session_alive(s)?;
+
+  let max_output_bytes = if max_output_bytes <= 0 {
+    usize::MAX
+  } else {
+    max_output_bytes as usize
+  };
+  let timeout_secs = if timeout_secs <= 0 { 30 } else { timeout_secs };
+  let max_iterations = (timeout_secs as usize) * 10;
+
+  let marker = s.prompt_marker.as_deref();
+
+  // If a previous interactive command is still pending, interrupt it.
+  {
+    let mut pending = match s.pending_interactive.lock() {
+      Ok(guard) => guard,
+      Err(_) => {
+        mark_session_corrupted(s, "interactive lock poisoned in Execute");
+        return Err("Interactive state lock poisoned");
+      }
+    };
+    if pending.is_some() {
+      shlog_trace!("New command received while interactive command was pending, sending Ctrl+C");
+      let _ = session_write(s, &[3]);
+      std::thread::sleep(Duration::from_millis(300));
+      *pending = None;
+    }
+  }
+
+  // Clear shared buffer and reset monotonic counter before sending command.
+  {
+    let mut shared_buffer = match s.output_buffer.lock() {
+      Ok(guard) => guard,
+      Err(_) => {
+        mark_session_corrupted(s, "buffer lock poisoned before command");
+        return Err("Buffer lock poisoned");
+      }
+    };
+    shared_buffer.clear();
+    s.total_bytes_written.store(0, Ordering::Release);
+    s.read_position.store(0, Ordering::Release);
+    shlog_trace!("Cleared shared buffer and reset counters before command");
+  }
+
+  // Send command.
+  let cmd_with_newline = format!("{}\n", cmd);
+  session_write(s, cmd_with_newline.as_bytes())?;
+
+  // Read output using the monotonic byte counter (immune to truncation).
+  let mut output_buffer = Vec::new();
+  let mut last_total_bytes = 0usize;
+  let mut no_data_count = 0;
+  let mut prompt_detected = false;
+  let mut was_truncated = false;
+  let mut seen_command_echo = false;
+
+  // Scale silence threshold with timeout: at least 1/3 of max_iterations, but
+  // no less than the default 3 seconds. This prevents false
+  // requires_interaction on slow commands (network I/O, compilation, etc.)
+  let silence_threshold = std::cmp::max(INTERACTIVE_DETECTION_ITERATIONS, max_iterations / 3);
+
+  shlog_trace!(
+    "Starting to read command output from shared buffer (silence_threshold={})",
+    silence_threshold
+  );
+  std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
+
+  for iteration in 0..max_iterations {
+    let current_total = s.total_bytes_written.load(Ordering::Acquire);
+    let has_new_data = current_total > last_total_bytes;
+
+    if has_new_data {
+      // Mark that the command has started producing output. Done before
+      // truncation so that a small MaxOutputBytes or fast/large output
+      // can't cause us to miss the signal.
+      if !seen_command_echo {
+        seen_command_echo = true;
+        shlog_trace!("Command has started producing output");
+      }
+
+      let snapshot = {
+        let shared_buffer = s.output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
+        shared_buffer.clone()
+      };
+
+      output_buffer = snapshot;
+      last_total_bytes = current_total;
+
+      if truncate_to_tail(&mut output_buffer, max_output_bytes) {
+        was_truncated = true;
+        shlog_trace!(
+          "Output buffer truncated to tail ({} bytes)",
+          max_output_bytes
+        );
+      }
+
+      let output_str = String::from_utf8_lossy(&output_buffer);
+
+      shlog_trace!(
+        "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
+        iteration,
+        current_total,
+        output_buffer.len(),
+        output_str.lines().last()
+      );
+
+      if is_prompt_or_marker(&output_str, marker) {
+        prompt_detected = true;
+        shlog_trace!("Prompt detected in output, command completed");
+        break;
+      }
+
+      if is_interactive_prompt(&output_str) {
+        shlog_trace!(
+          "Interactive prompt pattern detected early: {:?}",
+          output_str.lines().last()
+        );
+        break;
+      }
+
+      no_data_count = 0;
+    } else {
+      no_data_count += 1;
+      shlog_trace!(
+        "No data (iteration {}), no_data_count: {}, buffer_empty: {}, seen_echo: {}",
+        iteration,
+        no_data_count,
+        output_buffer.is_empty(),
+        seen_command_echo
+      );
+
+      // Fallback interactive detection after the silence threshold expires.
+      // Only trigger if the command has started producing output — before
+      // that, the command hasn't had a chance to run yet.
+      if no_data_count >= silence_threshold && seen_command_echo {
+        let output_str = String::from_utf8_lossy(&output_buffer);
+
+        if is_prompt_or_marker(&output_str, marker) {
+          prompt_detected = true;
+          shlog_trace!("Prompt detected on final check");
+          break;
+        }
+
+        if is_interactive_prompt(&output_str) {
+          shlog_trace!(
+            "Interactive prompt pattern detected: {:?}",
+            output_str.lines().last()
+          );
+          break;
+        }
+
+        shlog_trace!(
+          "Command appears to be interactive (no new data for {}ms, no prompt detected)",
+          silence_threshold as u64 * ITERATION_SLEEP_MS
+        );
+        break;
+      }
+    }
+    std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
+  }
+
+  // Build result table.
+  let mut result_table = AutoTableVar::new();
+  let output_str = String::from_utf8_lossy(&output_buffer).to_string();
+
+  if prompt_detected {
+    let exit_code = capture_exit_code(s, marker);
+
+    let final_output = if should_clean {
+      clean_output_with_marker(&output_str, marker)
+    } else {
+      output_str
+    };
+
+    result_table
+      .0
+      .insert_fast_static("status", &Var::ephemeral_string("completed"));
+    result_table
+      .0
+      .insert_fast_static("output", &Var::ephemeral_string(&final_output));
+    if let Some(code) = exit_code {
+      result_table
+        .0
+        .insert_fast_static("exit_code", &Var::from(code));
+    }
+    if was_truncated {
+      result_table.0.insert_fast_static("truncated", &true.into());
+    }
+  } else {
+    // Command is interactive (waiting for input).
+    {
+      let mut pending = s
+        .pending_interactive
+        .lock()
+        .map_err(|_| "Interactive state lock poisoned")?;
+      *pending = Some(InteractiveState {
+        original_cmd: cmd.to_string(),
+      });
+    }
+
+    let partial_output = if should_clean {
+      clean_output_with_marker(&output_str, marker)
+    } else {
+      output_str
+    };
+
+    result_table
+      .0
+      .insert_fast_static("status", &Var::ephemeral_string("requires_interaction"));
+    result_table
+      .0
+      .insert_fast_static("output", &Var::ephemeral_string(&partial_output));
+    result_table
+      .0
+      .insert_fast_static("message", &Var::ephemeral_string(interact_hint));
+    if was_truncated {
+      result_table.0.insert_fast_static("truncated", &true.into());
+    }
+  }
+
+  // Sync read position so a subsequent Read doesn't pick up stale data from
+  // command execution or exit code capture.
+  let final_total = s.total_bytes_written.load(Ordering::Acquire);
+  s.read_position.store(final_total, Ordering::Release);
+
+  Ok(result_table.to_cloned())
+}
+
+/// Send input to a pending interactive command.
+///
+/// `continue_hint` is the module-specific message returned when the command is
+/// still running (e.g. "...Use SSH.SendInput to continue.").
+pub fn send_input(
+  s: &ShellSession,
+  input_str: &str,
+  timeout_secs: i64,
+  max_output_bytes: i64,
+  continue_hint: &'static str,
+) -> Result<ClonedVar, &'static str> {
+  check_session_alive(s)?;
+
+  let max_output_bytes = if max_output_bytes <= 0 {
+    usize::MAX
+  } else {
+    max_output_bytes as usize
+  };
+  let timeout_secs = if timeout_secs <= 0 { 10 } else { timeout_secs };
+  let max_iterations = (timeout_secs as usize) * 10;
+
+  let marker = s.prompt_marker.as_deref();
+
+  // There must be a pending interactive command.
+  {
+    let pending = match s.pending_interactive.lock() {
+      Ok(guard) => guard,
+      Err(_) => {
+        mark_session_corrupted(s, "interactive lock poisoned in SendInput");
+        return Err("Interactive state lock poisoned");
+      }
+    };
+    if pending.is_none() {
+      return Err("No interactive command is pending");
+    }
+  }
+
+  // Record monotonic position before sending input.
+  let start_total_bytes = s.total_bytes_written.load(Ordering::Acquire);
+
+  // Send input (if not empty).
+  if !input_str.is_empty() {
+    let input_with_newline = format!("{}\n", input_str);
+    shlog_trace!(
+      "SendInput: Writing {} bytes: {:?}",
+      input_with_newline.len(),
+      input_with_newline
+    );
+    session_write(s, input_with_newline.as_bytes())?;
+    shlog_trace!("SendInput: Write succeeded");
+  }
+
+  // Wait for output.
+  std::thread::sleep(Duration::from_millis(SENDINPUT_INITIAL_WAIT_MS));
+  shlog_trace!(
+    "SendInput: Starting to read output after input (start_total_bytes={})",
+    start_total_bytes
+  );
+
+  let mut output_buffer = Vec::new();
+  let mut last_total_bytes = start_total_bytes;
+  let mut was_truncated = false;
+  let mut no_data_count = 0;
+  let mut prompt_detected = false;
+
+  for iteration in 0..max_iterations {
+    let current_total = s.total_bytes_written.load(Ordering::Acquire);
+    let has_new_data = current_total > last_total_bytes;
+
+    if has_new_data {
+      let snapshot = {
+        let shared_buffer = s.output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
+        shared_buffer.clone()
+      };
+
+      output_buffer = snapshot;
+      last_total_bytes = current_total;
+
+      if truncate_to_tail(&mut output_buffer, max_output_bytes) {
+        was_truncated = true;
+      }
+
+      let output_str = String::from_utf8_lossy(&output_buffer);
+      shlog_trace!(
+        "SendInput: Read data (iteration {}), total_bytes: {}, buffer size: {}",
+        iteration,
+        current_total,
+        output_buffer.len()
+      );
+
+      no_data_count = 0;
+
+      if is_prompt_or_marker(&output_str, marker) {
+        shlog_trace!("SendInput: Prompt detected in new output, exiting early");
+        prompt_detected = true;
+        break;
+      }
+    } else {
+      no_data_count += 1;
+      shlog_trace!(
+        "SendInput: No new data (iteration {}), no_data_count: {}",
+        iteration,
+        no_data_count
+      );
+
+      if no_data_count >= SENDINPUT_NO_DATA_THRESHOLD {
+        let output_str = String::from_utf8_lossy(&output_buffer);
+        if is_prompt_or_marker(&output_str, marker) {
+          shlog_trace!("SendInput: Prompt detected after silence, exiting");
+          prompt_detected = true;
+          break;
+        }
+      }
+    }
+    std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
+  }
+
+  // Final prompt check.
+  if !prompt_detected {
+    let output_str = String::from_utf8_lossy(&output_buffer);
+    prompt_detected = is_prompt_or_marker(&output_str, marker);
+  }
+
+  // Clean output.
+  let output_str = String::from_utf8_lossy(&output_buffer).to_string();
+  let stripped_bytes = strip_ansi_escapes::strip(&output_str);
+  let cleaned = String::from_utf8_lossy(&stripped_bytes);
+  let mut lines: Vec<&str> = cleaned.lines().collect();
+  if prompt_detected && !lines.is_empty() {
+    lines.pop(); // Remove prompt line.
+  }
+  let final_output = lines.join("\n");
+
+  let mut result_table = AutoTableVar::new();
+
+  if prompt_detected {
+    {
+      let mut pending = s
+        .pending_interactive
+        .lock()
+        .map_err(|_| "Interactive state lock poisoned")?;
+      *pending = None;
+    }
+    shlog_trace!("Interactive session completed");
+    result_table
+      .0
+      .insert_fast_static("status", &Var::ephemeral_string("completed"));
+    result_table
+      .0
+      .insert_fast_static("output", &Var::ephemeral_string(&final_output));
+    if was_truncated {
+      result_table.0.insert_fast_static("truncated", &true.into());
+    }
+  } else {
+    result_table
+      .0
+      .insert_fast_static("status", &Var::ephemeral_string("pending_output"));
+    result_table
+      .0
+      .insert_fast_static("output", &Var::ephemeral_string(&final_output));
+    result_table
+      .0
+      .insert_fast_static("message", &Var::ephemeral_string(continue_hint));
+    if was_truncated {
+      result_table.0.insert_fast_static("truncated", &true.into());
+    }
+  }
+
+  // Sync read position.
+  let final_total = s.total_bytes_written.load(Ordering::Acquire);
+  s.read_position.store(final_total, Ordering::Release);
+
+  Ok(result_table.to_cloned())
+}
+
+/// Raw, non-blocking read of accumulated output. Cooperatively suspends the wire
+/// (via `context`) while waiting for data to settle when a timeout is given.
+pub fn read_raw(
+  s: &ShellSession,
+  context: &Context,
+  max_bytes: i64,
+  strip: bool,
+  timeout_ms: i64,
+) -> Result<String, &'static str> {
+  check_session_alive(s)?;
+
+  let max_bytes = if max_bytes <= 0 {
+    65536usize
+  } else {
+    max_bytes as usize
+  };
+  let timeout_ms = if timeout_ms < 0 {
+    0u64
+  } else {
+    timeout_ms as u64
+  };
+
+  // Read cursor lives on the session so multiple Read shard instances share it.
+  let read_pos = &s.read_position;
+
+  let deadline = if timeout_ms > 0 {
+    Some(std::time::Instant::now() + Duration::from_millis(timeout_ms))
+  } else {
+    None
+  };
+
+  let mut result_data = Vec::new();
+
+  // Accumulate data until timeout expires or data settles. Settle time scales
+  // with timeout: 20% of requested timeout, clamped [100ms, 2000ms]. TUI apps
+  // (Ink/React) render in bursts with gaps — a longer settle avoids returning
+  // between render bursts with only partial output.
+  let settle_ms = if timeout_ms > 0 {
+    (timeout_ms / 5).max(100).min(2000)
+  } else {
+    100
+  };
+  let mut last_data_time: Option<std::time::Instant> = None;
+  let mut prev_total = read_pos.load(Ordering::Acquire);
+
+  loop {
+    let current_total = s.total_bytes_written.load(Ordering::Acquire);
+
+    if current_total > prev_total {
+      // New data arrived since last poll — reset settle timer.
+      last_data_time = Some(std::time::Instant::now());
+      prev_total = current_total;
+    }
+
+    if let Some(dl) = deadline {
+      // Hard timeout.
+      if std::time::Instant::now() >= dl {
+        break;
+      }
+      // Early exit: data arrived then went quiet for settle_ms.
+      if let Some(ldt) = last_data_time {
+        if std::time::Instant::now().duration_since(ldt) >= Duration::from_millis(settle_ms) {
+          break;
+        }
+      }
+      // Yield to the scheduler instead of blocking the thread.
+      shards::core::suspend(context, 0.01);
+    } else {
+      // No timeout = immediate mode, return whatever is available now.
+      break;
+    }
+  }
+
+  // Final snapshot of accumulated data.
+  let final_total = s.total_bytes_written.load(Ordering::Acquire);
+  let final_consumed = read_pos.load(Ordering::Acquire);
+  if final_total > final_consumed {
+    let snapshot = {
+      let buf = s.output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
+      buf.clone()
+    };
+
+    let new_byte_count = final_total - final_consumed;
+    let available = snapshot.len().min(new_byte_count).min(max_bytes);
+    result_data = snapshot[snapshot.len().saturating_sub(available)..].to_vec();
+    read_pos.store(final_total, Ordering::Release);
+  }
+
+  let output_str = if strip {
+    let term_rows = s.term_rows.load(Ordering::Acquire);
+    let term_cols = s.term_cols.load(Ordering::Acquire);
+    render_through_virtual_terminal(&result_data, term_rows, term_cols)
+  } else {
+    String::from_utf8_lossy(&result_data).to_string()
+  };
+
+  Ok(output_str)
+}
+
+/// Raw byte write to the session, interpreting escape sequences.
+pub fn write_raw(s: &ShellSession, input_str: &str, append_nl: bool) -> Result<(), &'static str> {
+  check_session_alive(s)?;
+
+  let bytes = interpret_escape_sequences(input_str);
+  session_write(s, &bytes)?;
+  if append_nl {
+    session_write(s, b"\r")?;
+  }
+  Ok(())
+}
+
+/// Resize the session's PTY and remember the new dimensions.
+pub fn resize(s: &ShellSession, rows: i64, cols: i64) -> Result<(), &'static str> {
+  check_session_alive(s)?;
+
+  let rows = rows.max(1).min(u16::MAX as i64) as u16;
+  let cols = cols.max(1).min(u16::MAX as i64) as u16;
+
+  s.transport.resize(rows, cols)?;
+  s.term_rows.store(rows, Ordering::Release);
+  s.term_cols.store(cols, Ordering::Release);
+  shlog_trace!("PTY resized to {}x{}", cols, rows);
+  Ok(())
+}

--- a/shards/modules/shell-common/src/lib.rs
+++ b/shards/modules/shell-common/src/lib.rs
@@ -384,10 +384,21 @@ pub fn truncate_to_tail(buffer: &mut Vec<u8>, max_bytes: usize) -> bool {
     return false;
   }
 
-  let keep_bytes = (max_bytes * BUFFER_TRUNCATE_KEEP_RATIO) / 100;
   let truncate_msg = b"[... output truncated ...]\n";
+  let keep_bytes = (max_bytes * BUFFER_TRUNCATE_KEEP_RATIO) / 100;
 
-  let skip = buffer.len() - keep_bytes + truncate_msg.len();
+  // When max_bytes is too small to fit the truncation notice plus any tail,
+  // just keep the last keep_bytes raw (without the notice). Otherwise the
+  // skip computation below underflows and `drain` panics on an out-of-range
+  // index — reachable from user code via a small MaxOutputBytes (1..=29).
+  if keep_bytes <= truncate_msg.len() {
+    let skip = buffer.len() - keep_bytes;
+    buffer.drain(..skip);
+    return true;
+  }
+
+  let tail_len = keep_bytes - truncate_msg.len();
+  let skip = buffer.len() - tail_len;
   let tail: Vec<u8> = buffer.drain(skip..).collect();
   buffer.clear();
   buffer.extend_from_slice(truncate_msg);
@@ -595,11 +606,14 @@ pub fn setup_prompt_marker(
   };
 
   // Clear buffer + reset counter regardless — we don't want setup output in
-  // command results.
+  // command results. Reset the counter while still holding the buffer lock so
+  // the reader thread can't append bytes (and bump the counter) in the gap
+  // between the clear and the reset, which would leave the counter out of sync
+  // with the buffer (matches the ordering in execute / capture_exit_code).
   if let Ok(mut buf) = buffer.lock() {
     buf.clear();
+    total_bytes.store(0, Ordering::Release);
   }
-  total_bytes.store(0, Ordering::Release);
 
   if marker_found {
     shlog_trace!("Sentinel prompt marker set: {}", marker);
@@ -750,9 +764,9 @@ pub fn execute(
     let has_new_data = current_total > last_total_bytes;
 
     if has_new_data {
-      // Mark that the command has started producing output. Done before
-      // truncation so that a small MaxOutputBytes or fast/large output
-      // can't cause us to miss the signal.
+      // Mark that the command has started producing output as soon as any
+      // bytes arrive, so a small MaxOutputBytes or fast/large output can't
+      // cause us to miss the signal.
       if !seen_command_echo {
         seen_command_echo = true;
         shlog_trace!("Command has started producing output");
@@ -766,14 +780,10 @@ pub fn execute(
       output_buffer = snapshot;
       last_total_bytes = current_total;
 
-      if truncate_to_tail(&mut output_buffer, max_output_bytes) {
-        was_truncated = true;
-        shlog_trace!(
-          "Output buffer truncated to tail ({} bytes)",
-          max_output_bytes
-        );
-      }
-
+      // Detect prompts/interaction on the FULL buffer; the output retention
+      // cap is applied once after the loop. Truncating here would let a cap
+      // smaller than the prompt marker cut the marker off the tail and break
+      // completion detection.
       let output_str = String::from_utf8_lossy(&output_buffer);
 
       shlog_trace!(
@@ -837,6 +847,11 @@ pub fn execute(
       }
     }
     std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
+  }
+
+  // Apply the output retention cap now that detection ran on the full buffer.
+  if truncate_to_tail(&mut output_buffer, max_output_bytes) {
+    was_truncated = true;
   }
 
   // Build result table.
@@ -984,10 +999,8 @@ pub fn send_input(
       output_buffer = snapshot;
       last_total_bytes = current_total;
 
-      if truncate_to_tail(&mut output_buffer, max_output_bytes) {
-        was_truncated = true;
-      }
-
+      // Detect on the FULL buffer; the retention cap is applied once after the
+      // loop so a tiny MaxOutputBytes can't truncate the prompt marker away.
       let output_str = String::from_utf8_lossy(&output_buffer);
       shlog_trace!(
         "SendInput: Read data (iteration {}), total_bytes: {}, buffer size: {}",
@@ -1027,6 +1040,11 @@ pub fn send_input(
   if !prompt_detected {
     let output_str = String::from_utf8_lossy(&output_buffer);
     prompt_detected = is_prompt_or_marker(&output_str, marker);
+  }
+
+  // Apply the output retention cap now that detection ran on the full buffer.
+  if truncate_to_tail(&mut output_buffer, max_output_bytes) {
+    was_truncated = true;
   }
 
   // Clean output.

--- a/shards/modules/ssh/Cargo.toml
+++ b/shards/modules/ssh/Cargo.toml
@@ -12,8 +12,7 @@ crate-type = ["rlib", "staticlib"]
 [dependencies]
 lazy_static = "1.5.0"
 shards = { path = "../../rust" }
+shards-shell-common = { path = "../shell-common" }
 compile-time-crc32 = "0.1.2"
 ssh2 = "0.9"
-strip-ansi-escapes = "0.2"
 shellexpand = "3.1"
-vt100 = "0.15"

--- a/shards/modules/ssh/src/lib.rs
+++ b/shards/modules/ssh/src/lib.rs
@@ -892,6 +892,87 @@ impl Shard for ResizeShard {
 }
 
 // ============================================================================
+// SSH.WaitFor Shard — wait until output matches a regex
+// ============================================================================
+
+#[derive(shards::shard)]
+#[shard_info(
+  "SSH.WaitFor",
+  "Wait until the session output matches a regular expression, returning the matched text (errors on timeout)"
+)]
+pub struct WaitForShard {
+  #[shard_required]
+  required: ExposedTypes,
+
+  #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
+  session: ParamVar,
+
+  #[shard_param("Pattern", "Regular expression to wait for in the output", [common_type::string, common_type::string_var])]
+  pattern: ParamVar,
+
+  #[shard_param("Timeout", "Timeout in milliseconds, 0 = wait indefinitely (default: 30000)", [common_type::int, common_type::int_var])]
+  timeout_ms: ParamVar,
+
+  #[shard_param("StripAnsi", "Strip ANSI escape sequences before matching (default: true)", [common_type::bool, common_type::bool_var])]
+  strip_ansi: ParamVar,
+
+  output: ClonedVar,
+}
+
+impl Default for WaitForShard {
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      pattern: ParamVar::default(),
+      timeout_ms: ParamVar::new(30000i64.into()),
+      strip_ansi: ParamVar::new(true.into()),
+      output: ClonedVar::default(),
+    }
+  }
+}
+
+#[shards::shard_impl]
+impl Shard for WaitForShard {
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
+
+  fn output_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
+
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
+
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
+
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
+
+  fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
+    let session_var = *self.session.get();
+    let pattern: &str = self.pattern.get().as_ref().try_into()?;
+    let timeout_ms: i64 = self.timeout_ms.get().as_ref().try_into()?;
+    let strip: bool = self.strip_ansi.get().as_ref().try_into()?;
+
+    let s = get_session(&session_var)?;
+    let matched = sc::wait_for(s, context, pattern, timeout_ms, strip)?;
+
+    self.output = Var::ephemeral_string(&matched).into();
+    Ok(Some(self.output.0))
+  }
+}
+
+// ============================================================================
 // Module Registration
 // ============================================================================
 
@@ -914,6 +995,7 @@ pub extern "C" fn shardsRegister_ssh_rust(core: *mut shards::shardsc::SHCore) {
   register_shard::<ReadShard>();
   register_shard::<WriteShard>();
   register_shard::<ResizeShard>();
+  register_shard::<WaitForShard>();
 
   shlog_trace!("SSH module registered");
 }

--- a/shards/modules/ssh/src/lib.rs
+++ b/shards/modules/ssh/src/lib.rs
@@ -98,27 +98,31 @@ impl sc::ShellTransport for SshTransport {
       .lock()
       .map_err(|_| sc::TransportError::Other("Channel lock poisoned"))?;
 
-    // Set blocking for writes to ensure they complete.
-    if let Ok(sess) = self.session.lock() {
-      sess.set_blocking(true);
+    // Hold the session lock across the write + flush. Setting blocking mode and
+    // releasing the session lock *before* writing leaves a window where the
+    // reader thread (which flips the session to non-blocking before every read)
+    // can make our write run non-blocking and fail with a spurious WouldBlock.
+    // Holding session here is deadlock-safe: write_all is the only path that
+    // ever holds both locks, and read_into never holds the session lock while
+    // waiting on the channel, so no lock cycle can form. A poisoned session
+    // lock is recovered (set_blocking can't panic) to keep writes best-effort.
+    let sess = self.session.lock().unwrap_or_else(|e| e.into_inner());
+    sess.set_blocking(true);
+
+    let write_result = channel.write_all(data);
+    if write_result.is_ok() {
+      let _ = channel.flush();
     }
 
-    if let Err(e) = channel.write_all(data) {
-      // Restore non-blocking before reporting.
-      if let Ok(sess) = self.session.lock() {
-        sess.set_blocking(false);
-      }
+    // Restore non-blocking before releasing the session lock.
+    sess.set_blocking(false);
+    drop(sess);
+
+    if let Err(e) = write_result {
       if is_connection_error(&e) {
         return Err(sc::TransportError::ConnectionLost);
       }
       return Err(sc::TransportError::Other("Failed to write to SSH channel"));
-    }
-
-    let _ = channel.flush();
-
-    // Restore non-blocking.
-    if let Ok(sess) = self.session.lock() {
-      sess.set_blocking(false);
     }
 
     Ok(())

--- a/shards/modules/ssh/src/lib.rs
+++ b/shards/modules/ssh/src/lib.rs
@@ -1,6 +1,10 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2025 Fragcolor Pte. Ltd. */
 
+//! SSH module: persistent, interactive remote shell sessions over SSH. All the
+//! session/buffer/prompt machinery lives in `shards-shell-common`; this crate
+//! only provides the SSH transport and the `SSH.*` shards.
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -17,7 +21,6 @@ use shards::core::BlockingShard;
 use shards::fourCharacterCode;
 use shards::shard::Shard;
 use shards::types::common_type;
-use shards::types::AutoTableVar;
 use shards::types::ClonedVar;
 use shards::types::Context;
 use shards::types::ExposedTypes;
@@ -26,529 +29,170 @@ use shards::types::ParamVar;
 use shards::types::Type;
 use shards::types::Types;
 use shards::types::Var;
-use shards::types::FRAG_CC;
-use shards::types::STRING_TYPES;
-use shards::types::NONE_TYPES;
 use shards::types::BOOL_TYPES;
+use shards::types::FRAG_CC;
+use shards::types::NONE_TYPES;
+use shards::types::STRING_TYPES;
+
+use shards_shell_common as sc;
+
 use ssh2::Session;
 use std::io::prelude::*;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-// Configuration constants
-const INITIAL_PROMPT_WAIT_MS: u64 = 500;
-const INITIAL_PROMPT_MAX_RETRIES: usize = 20;
-const COMMAND_OUTPUT_WAIT_MS: u64 = 200;
-const ITERATION_SLEEP_MS: u64 = 100;
-const INTERACTIVE_DETECTION_ITERATIONS: usize = 30; // 30 * 100ms = 3 seconds
-const SENDINPUT_INITIAL_WAIT_MS: u64 = 500;
-const SENDINPUT_NO_DATA_THRESHOLD: usize = 20; // 20 iterations = 2 seconds
-const MAX_BUFFER_BYTES: usize = 65536; // 64KB default
-const BUFFER_TRUNCATE_KEEP_RATIO: usize = 93; // Keep 93% on truncation
-const READER_POLL_MS: u64 = 50; // How often the reader thread polls the channel
-
-// SSH Shell object wrapper
-mod ssh_shell {
-    use super::*;
-
-    #[derive(Debug, Clone, PartialEq)]
-    pub enum SessionState {
-        Running,
-        Disconnected,
-        Corrupted(String),
-    }
-
-    pub struct SSHShell {
-        pub session: Arc<Mutex<Session>>,
-        pub channel: Arc<Mutex<ssh2::Channel>>,
-        pub pending_interactive: Arc<Mutex<Option<InteractiveState>>>,
-        pub is_connected: Arc<AtomicBool>,
-        pub state: Arc<Mutex<SessionState>>,
-        pub output_buffer: Arc<Mutex<Vec<u8>>>,
-        pub total_bytes_written: Arc<AtomicUsize>,
-        pub read_position: Arc<AtomicUsize>,
-        pub reader_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
-        pub prompt_marker: Option<String>,
-        pub term_rows: Arc<AtomicU16>,
-        pub term_cols: Arc<AtomicU16>,
-    }
-
-    #[derive(Clone)]
-    pub struct InteractiveState {
-        #[allow(dead_code)]
-        pub original_cmd: String,
-    }
-
-    impl Drop for SSHShell {
-        fn drop(&mut self) {
-            shlog_trace!("Dropping SSHShell, cleaning up connection");
-
-            // Step 1: Mark as disconnected (stops reader thread loop)
-            self.is_connected.store(false, Ordering::Release);
-
-            // Step 2: Close channel gracefully
-            if let Ok(mut channel) = self.channel.lock() {
-                let _ = channel.send_eof();
-                let _ = channel.wait_eof();
-                let _ = channel.close();
-                let _ = channel.wait_close();
-            }
-
-            // Step 3: Disconnect session
-            if let Ok(session) = self.session.lock() {
-                let _ = session.disconnect(None, "Session closed", None);
-            }
-
-            // Step 4: Wait for reader thread with timeout
-            if let Ok(mut thread_opt) = self.reader_thread.lock() {
-                if let Some(thread) = thread_opt.take() {
-                    shlog_trace!("Waiting for reader thread to finish");
-
-                    let mut finished = false;
-                    for _i in 0..20 {
-                        if thread.is_finished() {
-                            finished = true;
-                            break;
-                        }
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-
-                    if finished {
-                        let _ = thread.join();
-                        shlog_trace!("Reader thread joined successfully");
-                    } else {
-                        shlog_error!("Reader thread did not finish within timeout, leaving it detached (thread leak)");
-                    }
-                }
-            }
-
-            shlog_trace!("SSHShell cleanup complete");
-        }
-    }
-
-    ref_counted_object_type_impl!(SSHShell);
-}
-
-use ssh_shell::*;
-
-lazy_static! {
-    static ref SSH_SHELL_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"sshs"));
-    static ref SSH_SHELL_TYPE_VEC: Vec<Type> = vec![*SSH_SHELL_TYPE];
-    static ref SSH_SHELL_VAR_TYPE: Type = Type::context_variable(&SSH_SHELL_TYPE_VEC);
-    static ref EXECUTE_OUTPUT_TYPES: Vec<Type> = vec![common_type::string_table];
-}
-
-// Helper: detect shell prompts with optional sentinel marker
-fn is_prompt_or_marker(text: &str, marker: Option<&str>) -> bool {
-    let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
-    let cleaned = String::from_utf8_lossy(&stripped_bytes);
-
-    let lines: Vec<&str> = cleaned.lines().collect();
-    if let Some(last) = lines.last() {
-        let trimmed = last.trim();
-
-        // Check sentinel marker first (most reliable)
-        if let Some(m) = marker {
-            // When sentinel marker is set, ONLY trust the sentinel.
-            // Generic prompt patterns ($ # > %) cause false positives with
-            // heredoc continuation prompts and command output that happens
-            // to end with these characters.
-            return trimmed.contains(m);
-        }
-
-        // Exclude interactive program prompts like >>> (Python), >> (continuation)
-        if trimmed.ends_with(">>>") || trimmed.ends_with(">>") {
-            return false;
-        }
-
-        // Check for common SHELL prompt patterns (fallback when no sentinel)
-        trimmed.ends_with("$ ")
-            || trimmed.ends_with("$")
-            || trimmed.ends_with("# ")
-            || trimmed.ends_with("#")
-            || trimmed.ends_with("> ")
-            || trimmed.ends_with(">")
-            || trimmed.ends_with("% ")
-            || trimmed.ends_with("%")
-    } else {
-        false
-    }
-}
-
-fn is_prompt(text: &str) -> bool {
-    is_prompt_or_marker(text, None)
-}
-
-// Helper: detect common interactive prompts (password, confirmation, etc.)
-fn is_interactive_prompt(text: &str) -> bool {
-    let stripped_bytes = strip_ansi_escapes::strip(text.as_bytes());
-    let cleaned = String::from_utf8_lossy(&stripped_bytes);
-
-    let lines: Vec<&str> = cleaned.lines().collect();
-    if lines.is_empty() {
-        return false;
-    }
-
-    let check_lines = if lines.len() > 3 { &lines[lines.len()-3..] } else { &lines[..] };
-
-    for line in check_lines {
-        let lower = line.to_lowercase();
-
-        if lower.contains("password:")
-            || lower.contains("passphrase:")
-            || lower.contains("continue?")
-            || lower.contains("(y/n)")
-            || lower.contains("[y/n]")
-            || lower.contains("press enter")
-            || lower.contains("press any key")
-            || lower.contains("are you sure")
-            || lower.ends_with("? ")
-            || lower.ends_with(": ")
-        {
-            return true;
-        }
-    }
-
-    false
-}
-
-// Helper: mark session as corrupted
-fn mark_session_corrupted(ssh_shell: &SSHShell, error_context: &str) {
-    shlog_error!("Critical error in SSH session ({}), marking as corrupted", error_context);
-    ssh_shell.is_connected.store(false, Ordering::Release);
-    if let Ok(mut state) = ssh_shell.state.lock() {
-        *state = SessionState::Corrupted(error_context.to_string());
-    }
-}
-
-// Helper: clean output (remove ANSI codes, control chars, and trailing prompts)
-fn clean_output_with_marker(output: &str, marker: Option<&str>) -> String {
-    let stripped_bytes = strip_ansi_escapes::strip(output);
-    let text = String::from_utf8_lossy(&stripped_bytes);
-
-    let no_control: String = text.chars()
-        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
-        .collect();
-
-    let mut lines: Vec<&str> = no_control.lines().collect();
-
-    // Remove trailing prompt if present
-    if !lines.is_empty() {
-        let last_line = lines.last().unwrap();
-        if is_prompt_or_marker(last_line, marker) {
-            lines.pop();
-        }
-    }
-
-    let result = lines.join("\n");
-    result.trim().to_string()
-}
-
-// Helper: truncate output buffer to keep tail
-fn truncate_to_tail(buffer: &mut Vec<u8>, max_bytes: usize) -> bool {
-    if buffer.len() <= max_bytes {
-        return false;
-    }
-
-    let keep_bytes = (max_bytes * BUFFER_TRUNCATE_KEEP_RATIO) / 100;
-    let truncate_msg = b"[... output truncated ...]\n";
-
-    let skip = buffer.len() - keep_bytes + truncate_msg.len();
-    let tail: Vec<u8> = buffer.drain(skip..).collect();
-    buffer.clear();
-    buffer.extend_from_slice(truncate_msg);
-    buffer.extend_from_slice(&tail);
-
-    true
-}
-
-// Helper: check if an IO error indicates connection loss
+// Helper: check if an IO error indicates connection loss.
 fn is_connection_error(err: &std::io::Error) -> bool {
-    use std::io::ErrorKind;
-    matches!(
-        err.kind(),
-        ErrorKind::ConnectionReset
-            | ErrorKind::ConnectionAborted
-            | ErrorKind::BrokenPipe
-            | ErrorKind::UnexpectedEof
-    )
+  use std::io::ErrorKind;
+  matches!(
+    err.kind(),
+    ErrorKind::ConnectionReset
+      | ErrorKind::ConnectionAborted
+      | ErrorKind::BrokenPipe
+      | ErrorKind::UnexpectedEof
+  )
 }
 
-// Helper: check if session is alive, return descriptive error if not
-fn check_session_alive(ssh_shell: &SSHShell) -> Result<(), &'static str> {
-    if !ssh_shell.is_connected.load(Ordering::Acquire) {
-        if let Ok(state) = ssh_shell.state.lock() {
-            return Err(match *state {
-                SessionState::Disconnected => "SSH connection lost",
-                SessionState::Corrupted(ref reason) => {
-                    shlog_error!("Session corrupted: {}", reason);
-                    "SSH session corrupted due to internal error"
-                },
-                SessionState::Running => "SSH connection is not alive (unexpected state)",
-            });
-        } else {
-            return Err("SSH session corrupted (state lock poisoned)");
-        }
+// ============================================================================
+// SSH transport
+// ============================================================================
+
+struct SshTransport {
+  session: Arc<Mutex<Session>>,
+  channel: Arc<Mutex<ssh2::Channel>>,
+}
+
+impl sc::ShellTransport for SshTransport {
+  fn read_into(&self, buf: &mut [u8]) -> sc::ReadOutcome {
+    // Ensure non-blocking mode, then RELEASE the session lock before touching
+    // the channel. `write_all` holds the channel lock while acquiring the
+    // session lock, so the reader must never hold session while waiting on
+    // channel — otherwise the two could deadlock.
+    if let Ok(sess) = self.session.lock() {
+      sess.set_blocking(false);
     }
-    Ok(())
-}
 
-// Helper: extract SSHShell from Var
-fn get_session(session_var: &Var) -> Result<&SSHShell, &'static str> {
-    let ssh_shell = unsafe {
-        Var::from_ref_counted_object::<SSHShell>(session_var, &*SSH_SHELL_TYPE)?
-    };
-    Ok(unsafe { &*(ssh_shell as *const SSHShell) })
-}
-
-// Start the background reader thread for an SSH session.
-// The thread polls the channel in non-blocking mode and appends data to the shared buffer.
-fn start_reader_thread(
-    channel: Arc<Mutex<ssh2::Channel>>,
-    session: Arc<Mutex<Session>>,
-    buffer: Arc<Mutex<Vec<u8>>>,
-    total_bytes: Arc<AtomicUsize>,
-    alive: Arc<AtomicBool>,
-    state: Arc<Mutex<SessionState>>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::spawn(move || {
-        shlog_trace!("SSH reader thread started");
-        let mut buf = [0u8; 4096];
-
-        loop {
-            if !alive.load(Ordering::Acquire) {
-                shlog_trace!("SSH reader thread exiting (not alive)");
-                break;
-            }
-
-            // Ensure session is in non-blocking mode before each read
-            if let Ok(sess) = session.lock() {
-                sess.set_blocking(false);
-            }
-
-            let read_result = {
-                match channel.lock() {
-                    Ok(mut ch) => ch.read(&mut buf),
-                    Err(e) => {
-                        shlog_trace!("SSH reader thread: channel lock poisoned: {}", e);
-                        break;
-                    }
-                }
-            };
-
-            match read_result {
-                Ok(n) if n > 0 => {
-                    match buffer.lock() {
-                        Ok(mut b) => {
-                            b.extend_from_slice(&buf[..n]);
-
-                            if b.len() > MAX_BUFFER_BYTES {
-                                if truncate_to_tail(&mut b, MAX_BUFFER_BYTES) {
-                                    shlog_trace!("SSH reader thread: buffer truncated to {} bytes", b.len());
-                                }
-                            }
-
-                            total_bytes.fetch_add(n, Ordering::Release);
-                            shlog_trace!("SSH reader thread: read {} bytes, buffer now {} bytes", n, b.len());
-                        }
-                        Err(e) => {
-                            shlog_trace!("SSH reader thread: buffer lock poisoned: {}", e);
-                            break;
-                        }
-                    }
-                }
-                Ok(_) => {
-                    // EOF — connection closed
-                    alive.store(false, Ordering::Release);
-                    if let Ok(mut s) = state.lock() {
-                        *s = SessionState::Disconnected;
-                    }
-                    shlog_trace!("SSH reader thread: EOF detected, connection closed");
-                    break;
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    // No data available, sleep briefly and try again
-                    std::thread::sleep(Duration::from_millis(READER_POLL_MS));
-                    continue;
-                }
-                Err(e) if is_connection_error(&e) => {
-                    alive.store(false, Ordering::Release);
-                    if let Ok(mut s) = state.lock() {
-                        *s = SessionState::Disconnected;
-                    }
-                    shlog_trace!("SSH reader thread: connection error: {}", e);
-                    break;
-                }
-                Err(e) => {
-                    // Other errors — might be transient, log and sleep
-                    shlog_trace!("SSH reader thread: read error (non-fatal): {}", e);
-                    std::thread::sleep(Duration::from_millis(READER_POLL_MS));
-                }
-            }
-        }
-        shlog_trace!("SSH reader thread finished");
-    })
-}
-
-// Helper: write to channel, handling connection errors
-fn write_to_channel(ssh_shell: &SSHShell, data: &[u8]) -> Result<(), &'static str> {
-    let mut channel = match ssh_shell.channel.lock() {
-        Ok(guard) => guard,
-        Err(_) => {
-            mark_session_corrupted(ssh_shell, "channel lock poisoned during write");
-            return Err("Channel lock poisoned");
-        }
+    let read_result = match self.channel.lock() {
+      Ok(mut ch) => ch.read(buf),
+      Err(_) => return sc::ReadOutcome::Ended,
     };
 
-    // Set blocking for writes to ensure they complete
-    if let Ok(sess) = ssh_shell.session.lock() {
-        sess.set_blocking(true);
+    match read_result {
+      Ok(n) if n > 0 => sc::ReadOutcome::Data(n),
+      Ok(_) => sc::ReadOutcome::Ended,
+      Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => sc::ReadOutcome::Retry,
+      Err(e) if is_connection_error(&e) => sc::ReadOutcome::Ended,
+      Err(e) => {
+        shlog_trace!("SSH reader thread: read error (non-fatal): {}", e);
+        sc::ReadOutcome::Retry
+      }
+    }
+  }
+
+  fn write_all(&self, data: &[u8]) -> Result<(), sc::TransportError> {
+    let mut channel = self
+      .channel
+      .lock()
+      .map_err(|_| sc::TransportError::Other("Channel lock poisoned"))?;
+
+    // Set blocking for writes to ensure they complete.
+    if let Ok(sess) = self.session.lock() {
+      sess.set_blocking(true);
     }
 
     if let Err(e) = channel.write_all(data) {
-        // Restore non-blocking
-        if let Ok(sess) = ssh_shell.session.lock() {
-            sess.set_blocking(false);
-        }
-        if is_connection_error(&e) {
-            ssh_shell.is_connected.store(false, Ordering::Release);
-            if let Ok(mut s) = ssh_shell.state.lock() {
-                *s = SessionState::Disconnected;
-            }
-            shlog_trace!("Connection lost during write: {:?}", e);
-            return Err("SSH connection lost");
-        }
-        return Err("Failed to write to SSH channel");
+      // Restore non-blocking before reporting.
+      if let Ok(sess) = self.session.lock() {
+        sess.set_blocking(false);
+      }
+      if is_connection_error(&e) {
+        return Err(sc::TransportError::ConnectionLost);
+      }
+      return Err(sc::TransportError::Other("Failed to write to SSH channel"));
     }
 
     let _ = channel.flush();
 
-    // Restore non-blocking
-    if let Ok(sess) = ssh_shell.session.lock() {
-        sess.set_blocking(false);
+    // Restore non-blocking.
+    if let Ok(sess) = self.session.lock() {
+      sess.set_blocking(false);
     }
 
     Ok(())
-}
+  }
 
-// Helper: capture exit code by sending `echo $?` after command completes
-fn capture_exit_code(ssh_shell: &SSHShell, marker: Option<&str>) -> Option<i64> {
-    // Clear buffer, send echo $?, wait for prompt, parse result
+  fn resize(&self, rows: u16, cols: u16) -> Result<(), &'static str> {
+    // Set blocking for the resize request.
+    if let Ok(sess) = self.session.lock() {
+      sess.set_blocking(true);
+    }
+
     {
-        let mut buf = match ssh_shell.output_buffer.lock() {
-            Ok(b) => b,
-            Err(_) => return None,
-        };
-        buf.clear();
-        ssh_shell.total_bytes_written.store(0, Ordering::Release);
-        ssh_shell.read_position.store(0, Ordering::Release);
+      let mut channel = self.channel.lock().map_err(|_| "Channel lock poisoned")?;
+      channel
+        .request_pty_size(cols as u32, rows as u32, None, None)
+        .map_err(|_| "Failed to resize PTY")?;
     }
 
-    if write_to_channel(ssh_shell, b"echo $?\n").is_err() {
-        return None;
+    // Restore non-blocking.
+    if let Ok(sess) = self.session.lock() {
+      sess.set_blocking(false);
     }
 
-    // Wait for response
-    std::thread::sleep(Duration::from_millis(200));
+    Ok(())
+  }
 
-    for _ in 0..10 {
-        let snapshot = {
-            let buf = ssh_shell.output_buffer.lock().ok()?;
-            buf.clone()
-        };
-
-        let output = String::from_utf8_lossy(&snapshot);
-        if is_prompt_or_marker(&output, marker) {
-            let stripped = strip_ansi_escapes::strip(output.as_bytes());
-            let cleaned = String::from_utf8_lossy(&stripped);
-            for line in cleaned.lines() {
-                let trimmed = line.trim();
-                if trimmed == "echo $?" || trimmed.is_empty() {
-                    continue;
-                }
-                if is_prompt_or_marker(trimmed, marker) {
-                    continue;
-                }
-                if let Ok(code) = trimmed.parse::<i64>() {
-                    return Some(code);
-                }
-            }
-            return None;
-        }
-
-        std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
+  fn close(&self) {
+    // Close channel gracefully.
+    if let Ok(mut channel) = self.channel.lock() {
+      let _ = channel.send_eof();
+      let _ = channel.wait_eof();
+      let _ = channel.close();
+      let _ = channel.wait_close();
     }
 
-    None
+    // Disconnect session.
+    if let Ok(session) = self.session.lock() {
+      let _ = session.disconnect(None, "Session closed", None);
+    }
+  }
 }
 
-/// Render raw PTY output through a virtual VT100 terminal to get properly-spaced text.
-fn render_through_virtual_terminal(raw_bytes: &[u8], rows: u16, cols: u16) -> String {
-    let mut parser = vt100::Parser::new(rows, cols, 0);
-    parser.process(raw_bytes);
+// ============================================================================
+// Session object wrapper (local newtype satisfies the orphan rule for the
+// ref-counted object type impl).
+// ============================================================================
 
-    let screen = parser.screen();
-    let mut output = String::new();
+mod ssh_shell {
+  use super::*;
 
-    for row in 0..rows {
-        let row_text = screen.contents_between(row, 0, row, cols);
-        let trimmed = row_text.trim_end();
-        if !trimmed.is_empty() || !output.is_empty() {
-            if !output.is_empty() {
-                output.push('\n');
-            }
-            output.push_str(trimmed);
-        }
-    }
+  pub struct SSHShell(pub sc::ShellSession);
 
-    output.trim().to_string()
+  ref_counted_object_type_impl!(SSHShell);
 }
 
-// Interpret escape sequences in input strings for PTY writing.
-fn interpret_escape_sequences(input: &str) -> Vec<u8> {
-    let mut result = Vec::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
+use ssh_shell::*;
 
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            match chars.peek() {
-                Some('n') => { chars.next(); result.push(0x0A); }
-                Some('r') => { chars.next(); result.push(0x0D); }
-                Some('t') => { chars.next(); result.push(0x09); }
-                Some('\\') => { chars.next(); result.push(b'\\'); }
-                Some('x') => {
-                    chars.next();
-                    let mut hex = String::new();
-                    for _ in 0..2 {
-                        if let Some(&c) = chars.peek() {
-                            if c.is_ascii_hexdigit() {
-                                hex.push(c);
-                                chars.next();
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                        result.push(byte);
-                    }
-                }
-                _ => { result.push(b'\\'); }
-            }
-        } else if ch == '\n' {
-            // Bare LF → CR: terminal Enter sends CR to PTY master
-            result.push(0x0D);
-        } else {
-            let mut buf = [0u8; 4];
-            let encoded = ch.encode_utf8(&mut buf);
-            result.extend_from_slice(encoded.as_bytes());
-        }
-    }
+const SSH_MESSAGES: sc::SessionMessages = sc::SessionMessages {
+  ended: "SSH connection lost",
+  corrupted: "SSH session corrupted due to internal error",
+  poisoned: "SSH session corrupted (state lock poisoned)",
+  unexpected: "SSH connection is not alive (unexpected state)",
+};
 
-    result
+lazy_static! {
+  static ref SSH_SHELL_TYPE: Type = Type::object(FRAG_CC, fourCharacterCode(*b"sshs"));
+  static ref SSH_SHELL_TYPE_VEC: Vec<Type> = vec![*SSH_SHELL_TYPE];
+  static ref SSH_SHELL_VAR_TYPE: Type = Type::context_variable(&SSH_SHELL_TYPE_VEC);
+}
+
+// Helper: extract the shared session from a Var.
+fn get_session(session_var: &Var) -> Result<&sc::ShellSession, &'static str> {
+  let wrapper = unsafe { Var::from_ref_counted_object::<SSHShell>(session_var, &*SSH_SHELL_TYPE)? };
+  Ok(unsafe { &(*wrapper).0 })
 }
 
 // ============================================================================
@@ -556,302 +200,245 @@ fn interpret_escape_sequences(input: &str) -> Vec<u8> {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info("SSH.Connect", "Connect to an SSH server and create a persistent shell session")]
+#[shard_info(
+  "SSH.Connect",
+  "Connect to an SSH server and create a persistent shell session"
+)]
 pub struct ConnectShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Host", "SSH server hostname or IP address", [common_type::string, common_type::string_var])]
-    host: ParamVar,
+  #[shard_param("Host", "SSH server hostname or IP address", [common_type::string, common_type::string_var])]
+  host: ParamVar,
 
-    #[shard_param("Port", "SSH server port (default: 22)", [common_type::int, common_type::int_var])]
-    port: ParamVar,
+  #[shard_param("Port", "SSH server port (default: 22)", [common_type::int, common_type::int_var])]
+  port: ParamVar,
 
-    #[shard_param("User", "SSH username", [common_type::string, common_type::string_var])]
-    user: ParamVar,
+  #[shard_param("User", "SSH username", [common_type::string, common_type::string_var])]
+  user: ParamVar,
 
-    #[shard_param("KeyPath", "Path to SSH private key file", [common_type::string, common_type::string_var, common_type::none])]
-    key_path: ParamVar,
+  #[shard_param("KeyPath", "Path to SSH private key file", [common_type::string, common_type::string_var, common_type::none])]
+  key_path: ParamVar,
 
-    #[shard_param("Password", "SSH password (if not using key)", [common_type::string, common_type::string_var, common_type::none])]
-    password: ParamVar,
+  #[shard_param("Password", "SSH password (if not using key)", [common_type::string, common_type::string_var, common_type::none])]
+  password: ParamVar,
 
-    #[shard_param("Timeout", "Connection timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
-    timeout_secs: ParamVar,
+  #[shard_param("Timeout", "Connection timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
+  timeout_secs: ParamVar,
 
-    #[shard_param("Rows", "PTY rows (default: 24)", [common_type::int, common_type::int_var, common_type::none])]
-    rows: ParamVar,
+  #[shard_param("Rows", "PTY rows (default: 24)", [common_type::int, common_type::int_var, common_type::none])]
+  rows: ParamVar,
 
-    #[shard_param("Cols", "PTY columns (default: 80)", [common_type::int, common_type::int_var, common_type::none])]
-    cols: ParamVar,
+  #[shard_param("Cols", "PTY columns (default: 80)", [common_type::int, common_type::int_var, common_type::none])]
+  cols: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ConnectShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            host: ParamVar::new(Var::ephemeral_string("localhost")),
-            port: ParamVar::new(22i64.into()),
-            user: ParamVar::new(Var::ephemeral_string("user")),
-            key_path: ParamVar::new(Var::default()),
-            password: ParamVar::new(Var::default()),
-            timeout_secs: ParamVar::new(10i64.into()),
-            rows: ParamVar::new(24i64.into()),
-            cols: ParamVar::new(80i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      host: ParamVar::new(Var::ephemeral_string("localhost")),
+      port: ParamVar::new(22i64.into()),
+      user: ParamVar::new(Var::ephemeral_string("user")),
+      key_path: ParamVar::new(Var::default()),
+      password: ParamVar::new(Var::default()),
+      timeout_secs: ParamVar::new(10i64.into()),
+      rows: ParamVar::new(24i64.into()),
+      cols: ParamVar::new(80i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ConnectShard {
-    fn input_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &SSH_SHELL_TYPE_VEC
-    }
+  fn output_types(&mut self) -> &Types {
+    &SSH_SHELL_TYPE_VEC
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        Ok(Some(run_blocking(self, context, input)))
-    }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    Ok(Some(run_blocking(self, context, input)))
+  }
 }
 
 impl BlockingShard for ConnectShard {
-    fn activate_blocking(&mut self, _context: &Context, _input: &Var) -> Result<Var, &'static str> {
-        let host: &str = self.host.get().as_ref().try_into()?;
-        let port: i64 = self.port.get().as_ref().try_into()?;
-        let user: &str = self.user.get().as_ref().try_into()?;
-        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
+  fn activate_blocking(&mut self, _context: &Context, _input: &Var) -> Result<Var, &'static str> {
+    let host: &str = self.host.get().as_ref().try_into()?;
+    let port: i64 = self.port.get().as_ref().try_into()?;
+    let user: &str = self.user.get().as_ref().try_into()?;
+    let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
 
-        let key_path_var = self.key_path.get();
-        let password_var = self.password.get();
+    let key_path_var = self.key_path.get();
+    let password_var = self.password.get();
 
-        // Get PTY size params
-        let rows_val = self.rows.get();
-        let cols_val = self.cols.get();
-        let rows: u16 = if rows_val.is_none() { 24 } else {
-            let v: i64 = rows_val.as_ref().try_into().unwrap_or(24);
-            v.max(1).min(u16::MAX as i64) as u16
-        };
-        let cols: u16 = if cols_val.is_none() { 80 } else {
-            let v: i64 = cols_val.as_ref().try_into().unwrap_or(80);
-            v.max(1).min(u16::MAX as i64) as u16
-        };
+    // Get PTY size params
+    let rows_val = self.rows.get();
+    let cols_val = self.cols.get();
+    let rows: u16 = if rows_val.is_none() {
+      24
+    } else {
+      let v: i64 = rows_val.as_ref().try_into().unwrap_or(24);
+      v.max(1).min(u16::MAX as i64) as u16
+    };
+    let cols: u16 = if cols_val.is_none() {
+      80
+    } else {
+      let v: i64 = cols_val.as_ref().try_into().unwrap_or(80);
+      v.max(1).min(u16::MAX as i64) as u16
+    };
 
-        // Connect to SSH server
-        let addr = format!("{}:{}", host, port);
+    // Connect to SSH server
+    let addr = format!("{}:{}", host, port);
 
-        let socket_addrs: Vec<_> = addr
-            .to_socket_addrs()
-            .map_err(|_| "Failed to resolve hostname")?
-            .collect();
+    let socket_addrs: Vec<_> = addr
+      .to_socket_addrs()
+      .map_err(|_| "Failed to resolve hostname")?
+      .collect();
 
-        let socket_addr = socket_addrs
-            .first()
-            .ok_or("No address found for hostname")?;
+    let socket_addr = socket_addrs
+      .first()
+      .ok_or("No address found for hostname")?;
 
-        let tcp = TcpStream::connect_timeout(
-            socket_addr,
-            Duration::from_secs(timeout_secs as u64),
-        )
-        .map_err(|_| "Connection failed")?;
+    let tcp = TcpStream::connect_timeout(socket_addr, Duration::from_secs(timeout_secs as u64))
+      .map_err(|_| "Connection failed")?;
 
-        tcp.set_read_timeout(Some(Duration::from_secs(timeout_secs as u64)))
-            .map_err(|_| "Failed to set timeout")?;
+    tcp
+      .set_read_timeout(Some(Duration::from_secs(timeout_secs as u64)))
+      .map_err(|_| "Failed to set timeout")?;
 
-        let mut sess = Session::new().map_err(|_| "Failed to create SSH session")?;
-        sess.set_tcp_stream(tcp);
-        sess.handshake().map_err(|_| "SSH handshake failed")?;
+    let mut sess = Session::new().map_err(|_| "Failed to create SSH session")?;
+    sess.set_tcp_stream(tcp);
+    sess.handshake().map_err(|_| "SSH handshake failed")?;
 
-        // Authenticate
-        if !key_path_var.is_none() {
-            let key_path: &str = key_path_var.as_ref().try_into()?;
-            let key_path_expanded = shellexpand::tilde(key_path).to_string();
-            sess.userauth_pubkey_file(user, None, Path::new(&key_path_expanded), None)
-                .map_err(|_| "Public key authentication failed")?;
-        } else if !password_var.is_none() {
-            let password: &str = password_var.as_ref().try_into()?;
-            sess.userauth_password(user, password)
-                .map_err(|_| "Password authentication failed")?;
-        } else {
-            return Err("Either KeyPath or Password must be provided");
-        }
-
-        if !sess.authenticated() {
-            return Err("Authentication failed");
-        }
-
-        // Open channel and request PTY with size
-        let mut channel = sess.channel_session().map_err(|_| "Failed to open channel")?;
-        channel
-            .request_pty("xterm-256color", None, Some((cols as u32, rows as u32, 0, 0)))
-            .map_err(|_| "Failed to request PTY")?;
-        channel.shell().map_err(|_| "Failed to start shell")?;
-
-        // Set non-blocking mode for reads
-        sess.set_blocking(false);
-
-        // Create shared state
-        let channel_arc = Arc::new(Mutex::new(channel));
-        let session_arc = Arc::new(Mutex::new(sess));
-        let output_buffer = Arc::new(Mutex::new(Vec::new()));
-        let total_bytes_written = Arc::new(AtomicUsize::new(0));
-        let is_connected = Arc::new(AtomicBool::new(true));
-        let state = Arc::new(Mutex::new(SessionState::Running));
-
-        // Start reader thread BEFORE waiting for initial prompt
-        let reader_thread = start_reader_thread(
-            Arc::clone(&channel_arc),
-            Arc::clone(&session_arc),
-            Arc::clone(&output_buffer),
-            Arc::clone(&total_bytes_written),
-            Arc::clone(&is_connected),
-            Arc::clone(&state),
-        );
-
-        // Wait for initial prompt by polling the shared buffer
-        std::thread::sleep(Duration::from_millis(INITIAL_PROMPT_WAIT_MS));
-
-        for _ in 0..INITIAL_PROMPT_MAX_RETRIES {
-            {
-                let buf = output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
-                if !buf.is_empty() {
-                    let output_str = String::from_utf8_lossy(&buf);
-                    if is_prompt(&output_str) {
-                        shlog_trace!("Initial prompt detected");
-                        break;
-                    }
-                }
-            }
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        shlog_trace!("Shell ready, attempting to switch to bash for consistent behavior");
-
-        // Helper closure to write to channel (needs blocking mode for reliable writes)
-        let write_cmd = |channel_arc: &Arc<Mutex<ssh2::Channel>>, session_arc: &Arc<Mutex<Session>>, data: &[u8]| -> Result<(), &'static str> {
-            if let Ok(sess) = session_arc.lock() {
-                sess.set_blocking(true);
-            }
-            let result = {
-                let mut ch = channel_arc.lock().map_err(|_| "Channel lock poisoned")?;
-                ch.write_all(data).map_err(|_| "Write failed")?;
-                ch.flush().map_err(|_| "Flush failed")
-            };
-            if let Ok(sess) = session_arc.lock() {
-                sess.set_blocking(false);
-            }
-            result
-        };
-
-        // Try to switch to bash
-        let _ = write_cmd(&channel_arc, &session_arc, b"command -v bash >/dev/null 2>&1 && exec bash --login\n");
-
-        // Wait for bash to start and show prompt
-        std::thread::sleep(Duration::from_millis(500));
-
-        let mut bash_switched = false;
-        for _ in 0..10 {
-            let buf = output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
-            let output_str = String::from_utf8_lossy(&buf);
-            if is_prompt(&output_str) {
-                bash_switched = !output_str.contains("command not found") &&
-                               !output_str.contains("not found");
-                break;
-            }
-            drop(buf);
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        if bash_switched {
-            shlog_trace!("Switched to bash");
-        } else {
-            shlog_trace!("Bash not available or switch failed, continuing with current shell");
-        }
-
-        // Try to set PS1 sentinel marker for reliable prompt detection
-        let marker = format!("__SHARDS_PROMPT_{:x}__", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() & 0xFFFFFFFF);
-
-        let prompt_marker = {
-            let ps1_cmd = format!("export PS1='{}'\n", marker);
-            let set_ok = write_cmd(&channel_arc, &session_arc, ps1_cmd.as_bytes()).is_ok();
-
-            if set_ok {
-                // Wait for the marker to appear
-                std::thread::sleep(Duration::from_millis(300));
-
-                let marker_found = if let Ok(buf) = output_buffer.lock() {
-                    let s = String::from_utf8_lossy(&buf);
-                    s.contains(&marker)
-                } else {
-                    false
-                };
-
-                if marker_found {
-                    shlog_trace!("Sentinel prompt marker set: {}", marker);
-                    // Clear buffer after marker setup
-                    if let Ok(mut buf) = output_buffer.lock() {
-                        buf.clear();
-                    }
-                    total_bytes_written.store(0, Ordering::Release);
-                    Some(marker)
-                } else {
-                    shlog_trace!("Sentinel prompt marker not detected, falling back to pattern matching");
-                    if let Ok(mut buf) = output_buffer.lock() {
-                        buf.clear();
-                    }
-                    total_bytes_written.store(0, Ordering::Release);
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        shlog_trace!("SSH connection established");
-
-        let ssh_shell = SSHShell {
-            session: session_arc,
-            channel: channel_arc,
-            pending_interactive: Arc::new(Mutex::new(None)),
-            is_connected,
-            state,
-            output_buffer,
-            total_bytes_written,
-            read_position: Arc::new(AtomicUsize::new(0)),
-            reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
-            prompt_marker,
-            term_rows: Arc::new(AtomicU16::new(rows)),
-            term_cols: Arc::new(AtomicU16::new(cols)),
-        };
-
-        let shell_var = Var::new_ref_counted(ssh_shell, &*SSH_SHELL_TYPE);
-        self.output = shell_var.into();
-        Ok(self.output.0)
+    // Authenticate
+    if !key_path_var.is_none() {
+      let key_path: &str = key_path_var.as_ref().try_into()?;
+      let key_path_expanded = shellexpand::tilde(key_path).to_string();
+      sess
+        .userauth_pubkey_file(user, None, Path::new(&key_path_expanded), None)
+        .map_err(|_| "Public key authentication failed")?;
+    } else if !password_var.is_none() {
+      let password: &str = password_var.as_ref().try_into()?;
+      sess
+        .userauth_password(user, password)
+        .map_err(|_| "Password authentication failed")?;
+    } else {
+      return Err("Either KeyPath or Password must be provided");
     }
+
+    if !sess.authenticated() {
+      return Err("Authentication failed");
+    }
+
+    // Open channel and request PTY with size
+    let mut channel = sess
+      .channel_session()
+      .map_err(|_| "Failed to open channel")?;
+    channel
+      .request_pty(
+        "xterm-256color",
+        None,
+        Some((cols as u32, rows as u32, 0, 0)),
+      )
+      .map_err(|_| "Failed to request PTY")?;
+    channel.shell().map_err(|_| "Failed to start shell")?;
+
+    // Set non-blocking mode for reads
+    sess.set_blocking(false);
+
+    // Build the transport and shared session state.
+    let transport: Arc<dyn sc::ShellTransport> = Arc::new(SshTransport {
+      session: Arc::new(Mutex::new(sess)),
+      channel: Arc::new(Mutex::new(channel)),
+    });
+
+    let output_buffer = Arc::new(Mutex::new(Vec::new()));
+    let total_bytes_written = Arc::new(AtomicUsize::new(0));
+    let is_connected = Arc::new(AtomicBool::new(true));
+    let state = Arc::new(Mutex::new(sc::SessionState::Running));
+
+    // Start reader thread BEFORE waiting for the initial prompt.
+    let reader_thread = sc::start_reader_thread(
+      Arc::clone(&transport),
+      Arc::clone(&output_buffer),
+      Arc::clone(&total_bytes_written),
+      Arc::clone(&is_connected),
+      Arc::clone(&state),
+    );
+
+    sc::wait_for_initial_prompt(&output_buffer)?;
+
+    // Try to switch to bash for consistent behavior across servers.
+    shlog_trace!("Shell ready, attempting to switch to bash for consistent behavior");
+    let _ = transport.write_all(b"command -v bash >/dev/null 2>&1 && exec bash --login\n");
+
+    // Wait for bash to start and show a prompt.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let mut bash_switched = false;
+    for _ in 0..10 {
+      let buf = output_buffer.lock().map_err(|_| "Buffer lock poisoned")?;
+      let output_str = String::from_utf8_lossy(&buf);
+      if sc::is_prompt(&output_str) {
+        bash_switched =
+          !output_str.contains("command not found") && !output_str.contains("not found");
+        break;
+      }
+      drop(buf);
+      std::thread::sleep(Duration::from_millis(sc::ITERATION_SLEEP_MS));
+    }
+
+    if bash_switched {
+      shlog_trace!("Switched to bash");
+    } else {
+      shlog_trace!("Bash not available or switch failed, continuing with current shell");
+    }
+
+    let prompt_marker = sc::setup_prompt_marker(&transport, &output_buffer, &total_bytes_written);
+
+    shlog_trace!("SSH connection established");
+
+    let session = sc::ShellSession {
+      transport,
+      pending_interactive: Arc::new(Mutex::new(None)),
+      is_alive: is_connected,
+      state,
+      output_buffer,
+      total_bytes_written,
+      read_position: Arc::new(AtomicUsize::new(0)),
+      reader_thread: Arc::new(Mutex::new(Some(reader_thread))),
+      prompt_marker,
+      term_rows: Arc::new(AtomicU16::new(rows)),
+      term_cols: Arc::new(AtomicU16::new(cols)),
+      messages: SSH_MESSAGES,
+    };
+
+    let shell_var = Var::new_ref_counted(SSHShell(session), &*SSH_SHELL_TYPE);
+    self.output = shell_var.into();
+    Ok(self.output.0)
+  }
 }
 
 // ============================================================================
@@ -859,283 +446,89 @@ impl BlockingShard for ConnectShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "SSH.Execute",
-    "Execute a command in the persistent SSH shell session"
-)]
+#[shard_info("SSH.Execute", "Execute a command in the persistent SSH shell session")]
 pub struct ExecuteShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
-    timeout_secs: ParamVar,
+  #[shard_param("Timeout", "Command timeout in seconds (default: 30)", [common_type::int, common_type::int_var])]
+  timeout_secs: ParamVar,
 
-    #[shard_param("CleanOutput", "Clean ANSI codes and prompts from output (default: true)", [common_type::bool, common_type::bool_var])]
-    clean_output: ParamVar,
+  #[shard_param("CleanOutput", "Clean ANSI codes and prompts from output (default: true)", [common_type::bool, common_type::bool_var])]
+  clean_output: ParamVar,
 
-    #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
-    max_output_bytes: ParamVar,
+  #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
+  max_output_bytes: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ExecuteShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            timeout_secs: ParamVar::new(30i64.into()),
-            clean_output: ParamVar::new(true.into()),
-            max_output_bytes: ParamVar::new(65536i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      timeout_secs: ParamVar::new(30i64.into()),
+      clean_output: ParamVar::new(true.into()),
+      max_output_bytes: ParamVar::new(65536i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ExecuteShard {
-    fn input_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &EXECUTE_OUTPUT_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &sc::EXECUTE_OUTPUT_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        Ok(Some(run_blocking(self, context, input)))
-    }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    Ok(Some(run_blocking(self, context, input)))
+  }
 }
 
 impl BlockingShard for ExecuteShard {
-    fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
-        let cmd: &str = input.try_into()?;
-        let session_var = *self.session.get();
-        let should_clean: bool = self.clean_output.get().as_ref().try_into()?;
-        let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
-        let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
+  fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
+    let cmd: &str = input.try_into()?;
+    let session_var = *self.session.get();
+    let should_clean: bool = self.clean_output.get().as_ref().try_into()?;
+    let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
+    let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
 
-        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
-        let timeout_secs = if timeout_secs <= 0 { 30 } else { timeout_secs };
-        let max_iterations = (timeout_secs as usize) * 10;
-
-        let ssh_shell = get_session(&session_var)?;
-        check_session_alive(ssh_shell)?;
-
-        let marker = ssh_shell.prompt_marker.as_deref();
-
-        // Check if there's a pending interactive command
-        {
-            let mut pending = match ssh_shell.pending_interactive.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(ssh_shell, "interactive lock poisoned in Execute");
-                    return Err("Interactive state lock poisoned");
-                }
-            };
-            if pending.is_some() {
-                shlog_trace!("New command received while interactive command was pending, sending Ctrl+C");
-                write_to_channel(ssh_shell, &[3])?;
-                std::thread::sleep(Duration::from_millis(300));
-                *pending = None;
-            }
-        }
-
-        // Clear shared buffer and reset monotonic counter before sending command
-        {
-            let mut shared_buffer = match ssh_shell.output_buffer.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(ssh_shell, "buffer lock poisoned before command");
-                    return Err("Buffer lock poisoned");
-                }
-            };
-            shared_buffer.clear();
-            ssh_shell.total_bytes_written.store(0, Ordering::Release);
-            ssh_shell.read_position.store(0, Ordering::Release);
-            shlog_trace!("Cleared shared buffer and reset counters before command");
-        }
-
-        // Send command
-        let cmd_with_newline = format!("{}\n", cmd);
-        write_to_channel(ssh_shell, cmd_with_newline.as_bytes())?;
-
-        // Read output using monotonic byte counter
-        let mut output_buffer = Vec::new();
-        let mut last_total_bytes = 0usize;
-        let mut no_data_count = 0;
-        let mut prompt_detected = false;
-        let mut was_truncated = false;
-        let mut seen_command_echo = false;
-
-        // Scale silence threshold with timeout: at least 1/3 of max_iterations,
-        // but no less than the default 3 seconds. This prevents false
-        // requires_interaction on slow commands (network I/O, compilation, etc.)
-        let silence_threshold = std::cmp::max(
-            INTERACTIVE_DETECTION_ITERATIONS,
-            max_iterations / 3,
-        );
-
-        shlog_trace!("Starting to read command output from shared buffer (silence_threshold={})", silence_threshold);
-        std::thread::sleep(Duration::from_millis(COMMAND_OUTPUT_WAIT_MS));
-
-        for iteration in 0..max_iterations {
-            let current_total = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-            let has_new_data = current_total > last_total_bytes;
-
-            if has_new_data {
-                // Mark that the command has started producing output.
-                // Done before truncation so that small MaxOutputBytes or
-                // fast/large output can't cause us to miss the signal.
-                if !seen_command_echo {
-                    seen_command_echo = true;
-                    shlog_trace!("Command has started producing output");
-                }
-
-                let snapshot = {
-                    let shared_buffer = ssh_shell.output_buffer.lock()
-                        .map_err(|_| "Buffer lock poisoned")?;
-                    shared_buffer.clone()
-                };
-
-                output_buffer = snapshot;
-                last_total_bytes = current_total;
-
-                if truncate_to_tail(&mut output_buffer, max_output_bytes) {
-                    was_truncated = true;
-                    shlog_trace!("Output buffer truncated to tail ({} bytes)", max_output_bytes);
-                }
-
-                let output_str = String::from_utf8_lossy(&output_buffer);
-
-                shlog_trace!(
-                    "Read data (iteration {}), total_bytes: {}, buffer size: {}, last line: {:?}",
-                    iteration,
-                    current_total,
-                    output_buffer.len(),
-                    output_str.lines().last()
-                );
-
-                if is_prompt_or_marker(&output_str, marker) {
-                    prompt_detected = true;
-                    shlog_trace!("Prompt detected in output, command completed");
-                    break;
-                }
-
-                if is_interactive_prompt(&output_str) {
-                    shlog_trace!("Interactive prompt pattern detected early: {:?}", output_str.lines().last());
-                    break;
-                }
-
-                no_data_count = 0;
-            } else {
-                no_data_count += 1;
-                shlog_trace!(
-                    "No data (iteration {}), no_data_count: {}, buffer_empty: {}, seen_echo: {}",
-                    iteration,
-                    no_data_count,
-                    output_buffer.is_empty(),
-                    seen_command_echo
-                );
-
-                // Fallback interactive detection after silence threshold expires.
-                // Only trigger if the command has started producing output —
-                // before that, the command hasn't had a chance to run yet.
-                if no_data_count >= silence_threshold && seen_command_echo {
-                    let output_str = String::from_utf8_lossy(&output_buffer);
-
-                    if is_prompt_or_marker(&output_str, marker) {
-                        prompt_detected = true;
-                        shlog_trace!("Prompt detected on final check");
-                        break;
-                    }
-
-                    if is_interactive_prompt(&output_str) {
-                        shlog_trace!("Interactive prompt pattern detected: {:?}", output_str.lines().last());
-                        break;
-                    }
-
-                    shlog_trace!("Command appears to be interactive (no new data for {}ms, no prompt detected)",
-                        silence_threshold as u64 * ITERATION_SLEEP_MS);
-                    break;
-                }
-            }
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        // Build result table
-        let mut result_table = AutoTableVar::new();
-        let output_str = String::from_utf8_lossy(&output_buffer).to_string();
-
-        if prompt_detected {
-            let exit_code = capture_exit_code(ssh_shell, marker);
-
-            let final_output = if should_clean {
-                clean_output_with_marker(&output_str, marker)
-            } else {
-                output_str
-            };
-
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("completed"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
-            if let Some(code) = exit_code {
-                result_table.0.insert_fast_static("exit_code", &Var::from(code));
-            }
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        } else {
-            {
-                let mut pending = ssh_shell.pending_interactive.lock()
-                    .map_err(|_| "Interactive state lock poisoned")?;
-                *pending = Some(InteractiveState {
-                    original_cmd: cmd.to_string(),
-                });
-            }
-
-            let partial_output = if should_clean {
-                clean_output_with_marker(&output_str, marker)
-            } else {
-                output_str
-            };
-
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("requires_interaction"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&partial_output));
-            result_table.0.insert_fast_static(
-                "message",
-                &Var::ephemeral_string("Command is waiting for input. Use SSH.SendInput to interact.")
-            );
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        }
-
-        // Sync read position
-        let final_total = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-        ssh_shell.read_position.store(final_total, Ordering::Release);
-
-        self.output = result_table.to_cloned();
-        Ok(self.output.0)
-    }
+    let s = get_session(&session_var)?;
+    self.output = sc::execute(
+      s,
+      cmd,
+      timeout_secs,
+      should_clean,
+      max_output_bytes,
+      "Command is waiting for input. Use SSH.SendInput to interact.",
+    )?;
+    Ok(self.output.0)
+  }
 }
 
 // ============================================================================
@@ -1143,217 +536,83 @@ impl BlockingShard for ExecuteShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "SSH.SendInput",
-    "Send input to an interactive SSH command"
-)]
+#[shard_info("SSH.SendInput", "Send input to an interactive SSH command")]
 pub struct SendInputShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
-    timeout_secs: ParamVar,
+  #[shard_param("Timeout", "Timeout in seconds (default: 10)", [common_type::int, common_type::int_var])]
+  timeout_secs: ParamVar,
 
-    #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
-    max_output_bytes: ParamVar,
+  #[shard_param("MaxOutputBytes", "Maximum output bytes to retain (keeps tail, 0 = unlimited, default: 65536)", [common_type::int, common_type::int_var])]
+  max_output_bytes: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for SendInputShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            timeout_secs: ParamVar::new(10i64.into()),
-            max_output_bytes: ParamVar::new(65536i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      timeout_secs: ParamVar::new(10i64.into()),
+      max_output_bytes: ParamVar::new(65536i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for SendInputShard {
-    fn input_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &EXECUTE_OUTPUT_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &sc::EXECUTE_OUTPUT_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        Ok(Some(run_blocking(self, context, input)))
-    }
+  fn activate(&mut self, context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    Ok(Some(run_blocking(self, context, input)))
+  }
 }
 
 impl BlockingShard for SendInputShard {
-    fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
-        let input_str: &str = input.try_into()?;
-        let session_var = *self.session.get();
-        let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
-        let max_output_bytes = if max_output_bytes <= 0 { usize::MAX } else { max_output_bytes as usize };
+  fn activate_blocking(&mut self, _context: &Context, input: &Var) -> Result<Var, &'static str> {
+    let input_str: &str = input.try_into()?;
+    let session_var = *self.session.get();
+    let max_output_bytes: i64 = self.max_output_bytes.get().as_ref().try_into()?;
+    let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
 
-        let timeout_secs: i64 = self.timeout_secs.get().as_ref().try_into()?;
-        let timeout_secs = if timeout_secs <= 0 { 10 } else { timeout_secs };
-        let max_iterations = (timeout_secs as usize) * 10;
-
-        let ssh_shell = get_session(&session_var)?;
-        check_session_alive(ssh_shell)?;
-
-        let marker = ssh_shell.prompt_marker.as_deref();
-
-        // Check if there's a pending interactive command
-        {
-            let pending = match ssh_shell.pending_interactive.lock() {
-                Ok(guard) => guard,
-                Err(_) => {
-                    mark_session_corrupted(ssh_shell, "interactive lock poisoned in SendInput");
-                    return Err("Interactive state lock poisoned");
-                }
-            };
-            if pending.is_none() {
-                return Err("No interactive command is pending");
-            }
-        }
-
-        // Record monotonic position before sending input
-        let start_total_bytes = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-
-        // Send input (if not empty)
-        if !input_str.is_empty() {
-            let input_with_newline = format!("{}\n", input_str);
-            shlog_trace!("SendInput: Writing {} bytes: {:?}", input_with_newline.len(), input_with_newline);
-            write_to_channel(ssh_shell, input_with_newline.as_bytes())?;
-            shlog_trace!("SendInput: Write succeeded");
-        }
-
-        // Wait for output
-        std::thread::sleep(Duration::from_millis(SENDINPUT_INITIAL_WAIT_MS));
-        shlog_trace!("SendInput: Starting to read output after input (start_total_bytes={})", start_total_bytes);
-
-        let mut output_buffer = Vec::new();
-        let mut last_total_bytes = start_total_bytes;
-        let mut was_truncated = false;
-        let mut no_data_count = 0;
-        let mut prompt_detected = false;
-
-        for iteration in 0..max_iterations {
-            let current_total = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-            let has_new_data = current_total > last_total_bytes;
-
-            if has_new_data {
-                let snapshot = {
-                    let shared_buffer = ssh_shell.output_buffer.lock()
-                        .map_err(|_| "Buffer lock poisoned")?;
-                    shared_buffer.clone()
-                };
-
-                output_buffer = snapshot;
-                last_total_bytes = current_total;
-
-                if truncate_to_tail(&mut output_buffer, max_output_bytes) {
-                    was_truncated = true;
-                }
-
-                let output_str = String::from_utf8_lossy(&output_buffer);
-                shlog_trace!(
-                    "SendInput: Read data (iteration {}), total_bytes: {}, buffer size: {}",
-                    iteration, current_total, output_buffer.len()
-                );
-
-                no_data_count = 0;
-
-                if is_prompt_or_marker(&output_str, marker) {
-                    shlog_trace!("SendInput: Prompt detected in new output, exiting early");
-                    prompt_detected = true;
-                    break;
-                }
-            } else {
-                no_data_count += 1;
-                shlog_trace!("SendInput: No new data (iteration {}), no_data_count: {}",
-                    iteration, no_data_count);
-
-                if no_data_count >= SENDINPUT_NO_DATA_THRESHOLD {
-                    let output_str = String::from_utf8_lossy(&output_buffer);
-                    if is_prompt_or_marker(&output_str, marker) {
-                        shlog_trace!("SendInput: Prompt detected after silence, exiting");
-                        prompt_detected = true;
-                        break;
-                    }
-                }
-            }
-            std::thread::sleep(Duration::from_millis(ITERATION_SLEEP_MS));
-        }
-
-        // Final prompt check
-        if !prompt_detected {
-            let output_str = String::from_utf8_lossy(&output_buffer);
-            prompt_detected = is_prompt_or_marker(&output_str, marker);
-        }
-
-        // Clean output
-        let output_str = String::from_utf8_lossy(&output_buffer).to_string();
-        let stripped_bytes = strip_ansi_escapes::strip(&output_str);
-        let cleaned = String::from_utf8_lossy(&stripped_bytes);
-        let mut lines: Vec<&str> = cleaned.lines().collect();
-        if prompt_detected && !lines.is_empty() {
-            lines.pop();
-        }
-        let final_output = lines.join("\n");
-
-        let mut result_table = AutoTableVar::new();
-
-        if prompt_detected {
-            {
-                let mut pending = ssh_shell.pending_interactive.lock()
-                    .map_err(|_| "Interactive state lock poisoned")?;
-                *pending = None;
-            }
-            shlog_trace!("Interactive session completed");
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("completed"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        } else {
-            result_table.0.insert_fast_static("status", &Var::ephemeral_string("pending_output"));
-            result_table.0.insert_fast_static("output", &Var::ephemeral_string(&final_output));
-            result_table.0.insert_fast_static(
-                "message",
-                &Var::ephemeral_string("Command still running. Use SSH.SendInput to continue.")
-            );
-            if was_truncated {
-                result_table.0.insert_fast_static("truncated", &true.into());
-            }
-        }
-
-        // Sync read position
-        let final_total = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-        ssh_shell.read_position.store(final_total, Ordering::Release);
-
-        self.output = result_table.to_cloned();
-        Ok(self.output.0)
-    }
+    let s = get_session(&session_var)?;
+    self.output = sc::send_input(
+      s,
+      input_str,
+      timeout_secs,
+      max_output_bytes,
+      "Command still running. Use SSH.SendInput to continue.",
+    )?;
+    Ok(self.output.0)
+  }
 }
 
 // ============================================================================
@@ -1361,58 +620,55 @@ impl BlockingShard for SendInputShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "SSH.IsConnected",
-    "Check if SSH session is still connected"
-)]
+#[shard_info("SSH.IsConnected", "Check if SSH session is still connected")]
 pub struct IsConnectedShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for IsConnectedShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for IsConnectedShard {
-    fn input_types(&mut self) -> &Types {
-        &SSH_SHELL_TYPE_VEC
-    }
+  fn input_types(&mut self) -> &Types {
+    &SSH_SHELL_TYPE_VEC
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &BOOL_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &BOOL_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(common_type::bool)
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(common_type::bool)
+  }
 
-    fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        let ssh_shell = get_session(input)?;
-        let is_connected = ssh_shell.is_connected.load(Ordering::Acquire);
-        self.output = is_connected.into();
-        Ok(Some(self.output.0))
-    }
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let s = get_session(input)?;
+    let is_connected = s.is_alive.load(Ordering::Acquire);
+    self.output = is_connected.into();
+    Ok(Some(self.output.0))
+  }
 }
 
 // ============================================================================
@@ -1420,148 +676,77 @@ impl Shard for IsConnectedShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "SSH.Read",
-    "Read raw output from SSH session (non-blocking)"
-)]
+#[shard_info("SSH.Read", "Read raw output from SSH session (non-blocking)")]
 pub struct ReadShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("MaxBytes", "Maximum bytes to read (default: 65536)", [common_type::int, common_type::int_var])]
-    max_bytes: ParamVar,
+  #[shard_param("MaxBytes", "Maximum bytes to read (default: 65536)", [common_type::int, common_type::int_var])]
+  max_bytes: ParamVar,
 
-    #[shard_param("StripAnsi", "Strip ANSI escape sequences (default: false)", [common_type::bool, common_type::bool_var])]
-    strip_ansi: ParamVar,
+  #[shard_param("StripAnsi", "Strip ANSI escape sequences (default: false)", [common_type::bool, common_type::bool_var])]
+  strip_ansi: ParamVar,
 
-    #[shard_param("Timeout", "Timeout in milliseconds, 0 = immediate (default: 0)", [common_type::int, common_type::int_var])]
-    timeout_ms: ParamVar,
+  #[shard_param("Timeout", "Timeout in milliseconds, 0 = immediate (default: 0)", [common_type::int, common_type::int_var])]
+  timeout_ms: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ReadShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            max_bytes: ParamVar::new(65536i64.into()),
-            strip_ansi: ParamVar::new(false.into()),
-            timeout_ms: ParamVar::new(0i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      max_bytes: ParamVar::new(65536i64.into()),
+      strip_ansi: ParamVar::new(false.into()),
+      timeout_ms: ParamVar::new(0i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ReadShard {
-    fn input_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
-        let session_var = *self.session.get();
-        let max_bytes: i64 = self.max_bytes.get().as_ref().try_into()?;
-        let max_bytes = if max_bytes <= 0 { 65536usize } else { max_bytes as usize };
-        let strip: bool = self.strip_ansi.get().as_ref().try_into()?;
-        let timeout_ms: i64 = self.timeout_ms.get().as_ref().try_into()?;
-        let timeout_ms = if timeout_ms < 0 { 0u64 } else { timeout_ms as u64 };
+  fn activate(&mut self, context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
+    let session_var = *self.session.get();
+    let max_bytes: i64 = self.max_bytes.get().as_ref().try_into()?;
+    let strip: bool = self.strip_ansi.get().as_ref().try_into()?;
+    let timeout_ms: i64 = self.timeout_ms.get().as_ref().try_into()?;
 
-        let ssh_shell = get_session(&session_var)?;
-        check_session_alive(ssh_shell)?;
+    let s = get_session(&session_var)?;
+    let output_str = sc::read_raw(s, context, max_bytes, strip, timeout_ms)?;
 
-        let read_pos = &ssh_shell.read_position;
-
-        let deadline = if timeout_ms > 0 {
-            Some(std::time::Instant::now() + Duration::from_millis(timeout_ms))
-        } else {
-            None
-        };
-
-        let mut result_data = Vec::new();
-
-        // Settle time scales with timeout
-        let settle_ms = if timeout_ms > 0 {
-            (timeout_ms / 5).max(100).min(2000)
-        } else {
-            100
-        };
-        let mut last_data_time: Option<std::time::Instant> = None;
-        let mut prev_total = read_pos.load(Ordering::Acquire);
-
-        loop {
-            let current_total = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-
-            if current_total > prev_total {
-                last_data_time = Some(std::time::Instant::now());
-                prev_total = current_total;
-            }
-
-            if let Some(dl) = deadline {
-                if std::time::Instant::now() >= dl {
-                    break;
-                }
-                if let Some(ldt) = last_data_time {
-                    if std::time::Instant::now().duration_since(ldt) >= Duration::from_millis(settle_ms) {
-                        break;
-                    }
-                }
-                shards::core::suspend(context, 0.01);
-            } else {
-                break;
-            }
-        }
-
-        // Final snapshot of accumulated data
-        let final_total = ssh_shell.total_bytes_written.load(Ordering::Acquire);
-        let final_consumed = read_pos.load(Ordering::Acquire);
-        if final_total > final_consumed {
-            let snapshot = {
-                let buf = ssh_shell.output_buffer.lock()
-                    .map_err(|_| "Buffer lock poisoned")?;
-                buf.clone()
-            };
-
-            let new_byte_count = final_total - final_consumed;
-            let available = snapshot.len().min(new_byte_count).min(max_bytes);
-            result_data = snapshot[snapshot.len().saturating_sub(available)..].to_vec();
-            read_pos.store(final_total, Ordering::Release);
-        }
-
-        let output_str = if strip {
-            let term_rows = ssh_shell.term_rows.load(Ordering::Acquire);
-            let term_cols = ssh_shell.term_cols.load(Ordering::Acquire);
-            render_through_virtual_terminal(&result_data, term_rows, term_cols)
-        } else {
-            String::from_utf8_lossy(&result_data).to_string()
-        };
-
-        self.output = Var::ephemeral_string(&output_str).into();
-        Ok(Some(self.output.0))
-    }
+    self.output = Var::ephemeral_string(&output_str).into();
+    Ok(Some(self.output.0))
+  }
 }
 
 // ============================================================================
@@ -1569,78 +754,69 @@ impl Shard for ReadShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "SSH.Write",
-    "Write raw bytes to SSH session"
-)]
+#[shard_info("SSH.Write", "Write raw bytes to SSH session")]
 pub struct WriteShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("AppendNewline", "Append newline after input (default: false)", [common_type::bool, common_type::bool_var])]
-    append_newline: ParamVar,
+  #[shard_param("AppendNewline", "Append newline after input (default: false)", [common_type::bool, common_type::bool_var])]
+  append_newline: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for WriteShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            append_newline: ParamVar::new(false.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      append_newline: ParamVar::new(false.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for WriteShard {
-    fn input_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &STRING_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &STRING_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
-        let input_str: &str = input.try_into()?;
-        let session_var = *self.session.get();
-        let append_nl: bool = self.append_newline.get().as_ref().try_into()?;
+  fn activate(&mut self, _context: &Context, input: &Var) -> Result<Option<Var>, &str> {
+    let input_str: &str = input.try_into()?;
+    let session_var = *self.session.get();
+    let append_nl: bool = self.append_newline.get().as_ref().try_into()?;
 
-        let ssh_shell = get_session(&session_var)?;
-        check_session_alive(ssh_shell)?;
+    let s = get_session(&session_var)?;
+    sc::write_raw(s, input_str, append_nl)?;
 
-        let bytes = interpret_escape_sequences(input_str);
-        write_to_channel(ssh_shell, &bytes)?;
-        if append_nl {
-            write_to_channel(ssh_shell, b"\r")?;
-        }
-
-        // Passthrough input
-        self.output = input.into();
-        Ok(Some(self.output.0))
-    }
+    // Passthrough input
+    self.output = input.into();
+    Ok(Some(self.output.0))
+  }
 }
 
 // ============================================================================
@@ -1648,98 +824,71 @@ impl Shard for WriteShard {
 // ============================================================================
 
 #[derive(shards::shard)]
-#[shard_info(
-    "SSH.Resize",
-    "Resize the PTY terminal of an SSH session"
-)]
+#[shard_info("SSH.Resize", "Resize the PTY terminal of an SSH session")]
 pub struct ResizeShard {
-    #[shard_required]
-    required: ExposedTypes,
+  #[shard_required]
+  required: ExposedTypes,
 
-    #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
-    session: ParamVar,
+  #[shard_param("Session", "SSH shell session object", [*SSH_SHELL_TYPE, *SSH_SHELL_VAR_TYPE])]
+  session: ParamVar,
 
-    #[shard_param("Rows", "Number of rows", [common_type::int, common_type::int_var])]
-    rows: ParamVar,
+  #[shard_param("Rows", "Number of rows", [common_type::int, common_type::int_var])]
+  rows: ParamVar,
 
-    #[shard_param("Cols", "Number of columns", [common_type::int, common_type::int_var])]
-    cols: ParamVar,
+  #[shard_param("Cols", "Number of columns", [common_type::int, common_type::int_var])]
+  cols: ParamVar,
 
-    output: ClonedVar,
+  output: ClonedVar,
 }
 
 impl Default for ResizeShard {
-    fn default() -> Self {
-        Self {
-            required: ExposedTypes::new(),
-            session: ParamVar::default(),
-            rows: ParamVar::new(24i64.into()),
-            cols: ParamVar::new(80i64.into()),
-            output: ClonedVar::default(),
-        }
+  fn default() -> Self {
+    Self {
+      required: ExposedTypes::new(),
+      session: ParamVar::default(),
+      rows: ParamVar::new(24i64.into()),
+      cols: ParamVar::new(80i64.into()),
+      output: ClonedVar::default(),
     }
+  }
 }
 
 #[shards::shard_impl]
 impl Shard for ResizeShard {
-    fn input_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn input_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn output_types(&mut self) -> &Types {
-        &NONE_TYPES
-    }
+  fn output_types(&mut self) -> &Types {
+    &NONE_TYPES
+  }
 
-    fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
-        self.warmup_helper(ctx)?;
-        Ok(())
-    }
+  fn warmup(&mut self, ctx: &Context) -> Result<(), &str> {
+    self.warmup_helper(ctx)?;
+    Ok(())
+  }
 
-    fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
-        self.cleanup_helper(ctx)?;
-        self.output = ClonedVar::default();
-        Ok(())
-    }
+  fn cleanup(&mut self, ctx: Option<&Context>) -> Result<(), &str> {
+    self.cleanup_helper(ctx)?;
+    self.output = ClonedVar::default();
+    Ok(())
+  }
 
-    fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
-        self.compose_helper(data)?;
-        Ok(self.output_types()[0])
-    }
+  fn compose(&mut self, data: &InstanceData) -> Result<Type, &str> {
+    self.compose_helper(data)?;
+    Ok(self.output_types()[0])
+  }
 
-    fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
-        let session_var = *self.session.get();
-        let rows_val: i64 = self.rows.get().as_ref().try_into()?;
-        let cols_val: i64 = self.cols.get().as_ref().try_into()?;
+  fn activate(&mut self, _context: &Context, _input: &Var) -> Result<Option<Var>, &str> {
+    let session_var = *self.session.get();
+    let rows_val: i64 = self.rows.get().as_ref().try_into()?;
+    let cols_val: i64 = self.cols.get().as_ref().try_into()?;
 
-        let rows = rows_val.max(1).min(u16::MAX as i64) as u16;
-        let cols = cols_val.max(1).min(u16::MAX as i64) as u16;
+    let s = get_session(&session_var)?;
+    sc::resize(s, rows_val, cols_val)?;
 
-        let ssh_shell = get_session(&session_var)?;
-        check_session_alive(ssh_shell)?;
-
-        // Set blocking for the resize request
-        if let Ok(sess) = ssh_shell.session.lock() {
-            sess.set_blocking(true);
-        }
-
-        {
-            let mut channel = ssh_shell.channel.lock()
-                .map_err(|_| "Channel lock poisoned")?;
-            channel.request_pty_size(cols as u32, rows as u32, None, None)
-                .map_err(|_| "Failed to resize PTY")?;
-        }
-
-        // Restore non-blocking
-        if let Ok(sess) = ssh_shell.session.lock() {
-            sess.set_blocking(false);
-        }
-
-        ssh_shell.term_rows.store(rows, Ordering::Release);
-        ssh_shell.term_cols.store(cols, Ordering::Release);
-        shlog_trace!("SSH PTY resized to {}x{}", cols, rows);
-
-        Ok(None)
-    }
+    Ok(None)
+  }
 }
 
 // ============================================================================
@@ -1748,23 +897,23 @@ impl Shard for ResizeShard {
 
 #[no_mangle]
 pub extern "C" fn shardsRegister_ssh_rust(core: *mut shards::shardsc::SHCore) {
-    unsafe {
-        shards::core::Core = core;
-    }
+  unsafe {
+    shards::core::Core = core;
+  }
 
-    // Register SSHShell object type
-    let mut info = shards::SHObjectInfo::default();
-    info.name = cstr!("SSH.Shell").as_ptr() as shards::SHString;
-    shards::core::register_object_type_internal(FRAG_CC, fourCharacterCode(*b"sshs"), info);
+  // Register SSHShell object type
+  let mut info = shards::SHObjectInfo::default();
+  info.name = cstr!("SSH.Shell").as_ptr() as shards::SHString;
+  shards::core::register_object_type_internal(FRAG_CC, fourCharacterCode(*b"sshs"), info);
 
-    // Register shards
-    register_shard::<ConnectShard>();
-    register_shard::<ExecuteShard>();
-    register_shard::<SendInputShard>();
-    register_shard::<IsConnectedShard>();
-    register_shard::<ReadShard>();
-    register_shard::<WriteShard>();
-    register_shard::<ResizeShard>();
+  // Register shards
+  register_shard::<ConnectShard>();
+  register_shard::<ExecuteShard>();
+  register_shard::<SendInputShard>();
+  register_shard::<IsConnectedShard>();
+  register_shard::<ReadShard>();
+  register_shard::<WriteShard>();
+  register_shard::<ResizeShard>();
 
-    shlog_trace!("SSH module registered");
+  shlog_trace!("SSH module registered");
 }

--- a/shards/tests/localshell.shs
+++ b/shards/tests/localshell.shs
@@ -185,6 +185,18 @@ big-result.status | Assert.Is("completed")
 big-result.output | ExpectString | String.Contains("5000") | Assert.Is(true)
 "Large output completed without hanging" | Log
 
+; Regression: a tiny MaxOutputBytes (smaller than the prompt marker) must not
+; panic in truncation and must still detect completion. Detection runs on the
+; full buffer; only the returned output is capped.
+"Testing tiny MaxOutputBytes (truncation panic + detection regression)" | Log
+"for i in $(seq 1 200); do echo -n X; done; echo" | LocalShell.Execute(Session: shell-session MaxOutputBytes: 10) >= tiny-result
+tiny-result.status | ExpectString | Assert.Is("completed")
+tiny-result.truncated | Assert.Is(true)
+; boundary value that previously triggered the out-of-bounds drain panic
+"for i in $(seq 1 200); do echo -n Y; done; echo" | LocalShell.Execute(Session: shell-session MaxOutputBytes: 29) >= tiny-result2
+tiny-result2.status | ExpectString | Assert.Is("completed")
+"Tiny MaxOutputBytes handled without panic" | Log
+
 ; Test Read with StripAnsi
 "Testing StripAnsi on Read" | Log
 ; Use Execute to produce ANSI output, then Read with StripAnsi

--- a/shards/tests/localshell.shs
+++ b/shards/tests/localshell.shs
@@ -229,6 +229,28 @@ heredoc-result.output | ExpectString | String.Contains("heredoc_line_1") | Asser
 heredoc-result.output | ExpectString | String.Contains("heredoc_line_2") | Assert.Is(true)
 "Heredoc completed correctly" | Log
 
+; Test: WaitFor waits for a regex on the output stream
+"Testing WaitFor" | Log
+LocalShell.Create >= wait-session
+; Background a delayed echo. The command line itself contains "READY_$((20+2))"
+; which does NOT match READY_<digits>, so a match proves we waited for the
+; actual (delayed) output, not the command echo.
+"(sleep 1 && echo \"READY_$((20+2))\") &" | LocalShell.Write(Session: wait-session AppendNewline: true)
+LocalShell.WaitFor(Session: wait-session Pattern: """READY_(\d+)""" Timeout: 8000) >= wf-match
+wf-match | Log("WaitFor matched")
+wf-match | String.Contains("READY_22") | Assert.Is(true)
+"WaitFor works" | Log
+
+; Test: WaitFor times out (errors) when the pattern never appears
+"Testing WaitFor timeout" | Log
+Maybe({
+  LocalShell.WaitFor(Session: wait-session Pattern: """THIS_NEVER_APPEARS_ZZZ""" Timeout: 1000)
+  false  ; reached only if no error was raised
+} {
+  true   ; timeout raised an error, as expected
+}) | Assert.Is(true)
+"WaitFor timeout works" | Log
+
 ; Test session alive check
 "Testing session alive check" | Log
 shell-session | LocalShell.IsAlive | Assert.Is(true)


### PR DESCRIPTION
## What

`localshell` and `ssh` were ~95% duplicated — both implement the same persistent interactive shell-session model (background reader thread filling a shared buffer, monotonic byte counter immune to truncation, sentinel `PS1` prompt detection) and differed only in their transport (PTY vs SSH channel).

This extracts a new internal crate **`shards-shell-common`** that owns everything transport-agnostic, behind a `ShellTransport` trait.

## Layout

**`shards-shell-common`** (new)
- `ShellTransport` trait — `read_into → ReadOutcome`, `write_all → TransportError`, `resize`, `close`, `poll_interval_ms`
- `ShellSession` state, unified `Drop`, and the generic reader thread
- all text helpers (prompt/interactive detection, ANSI cleaning, buffer truncation, VT100 rendering, escape interpretation)
- generic `Execute` / `SendInput` / `Read` / `Write` / `Resize` logic, exit-code capture, and the `Create`/`Connect` bootstrap helpers

**`localshell`** → `PtyTransport` (portable-pty) + `Create` + thin delegating shards
**`ssh`** → `SshTransport` (ssh2, preserving the session/channel lock ordering that avoids the reader/writer deadlock) + `Connect` + thin delegating shards

Each leaf wraps `ShellSession` in a local newtype so the `ref_counted_object_type_impl!` macro stays orphan-rule-legal. **Shard names, object type codes (`lshl`/`sshs`), registration entrypoints, and CMake wiring are unchanged** — purely an internal refactor.

## Verification

- `cargo check` clean on all three crates
- Full Release build links the rust union + `shards` binary
- `shards/tests/localshell.shs` passes end-to-end (Create, Execute, env/cwd persistence, interactive detection, SendInput, exit codes, PTY size/resize, raw Read/Write, `top` snapshot, auto-interrupt, incremental reads, truncation, StripAnsi, slow commands, heredoc). This exercises 100% of the shared code path.
- `SSH.Connect` registers + composes + enters its transport. The live SSH round-trip (`ssh-test.shs`) was **not** run — it needs the Docker SSH server on :2222 and Docker wasn't available in this environment. The SSH-specific transport (read/write/resize over a real channel) is therefore the only path not exercised end-to-end; its session logic is shared and validated via localshell.

## Behavioral note

One small change: previously a *poisoned writer/channel mutex* marked the session `Corrupted`; now `session_write` surfaces it as a plain error string without flipping session state (lock-poisoning of the buffer/interactive mutexes still marks `Corrupted` as before). Easy to restore the exact old behavior if preferred.

## Diffstat

The two leaf modules drop from ~1740/1771 lines to thin transports + shard scaffolding (**+1261 / −2979** across changed files), with the shared session logic now in one place.