### PR TITLE
deps: bump spdlog to 1.15.3 (fmt 11), fix Windows-Debug VS 2026 build

### DIFF
--- a/shards/core/exception.hpp
+++ b/shards/core/exception.hpp
@@ -7,7 +7,7 @@
 namespace shards {
 
 template <typename S, typename... TArgs> std::runtime_error formatException(const S &format, TArgs &&...args) {
-  return std::runtime_error(fmt::format(format, std::forward<TArgs>(args)...));
+  return std::runtime_error(fmt::format(fmt::runtime(format), std::forward<TArgs>(args)...));
 }
 
 } // namespace shards

--- a/shards/core/ops_internal.hpp
+++ b/shards/core/ops_internal.hpp
@@ -87,14 +87,9 @@ inline std::ostream &operator<<(std::ostream &os, const SHTypesInfo &v) { return
 inline std::ostream &operator<<(std::ostream &os, const SHTrait &v) { return shards::defaultFormatter.format(os, v); }
 
 template <typename T> struct StringStreamFormatter {
-  constexpr auto parse(fmt::format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw fmt::format_error("invalid format");
-    return it;
-  }
+  constexpr auto parse(fmt::format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
-  template <typename FormatContext> auto format(const T &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const T &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     std::stringstream ss;
     ss << v;
     return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -104,7 +99,7 @@ template <typename T> struct StringStreamFormatter {
 template <> struct fmt::formatter<SHStringWithLen> {
   StringStreamFormatter<SHStringWithLen> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const SHStringWithLen &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const SHStringWithLen &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };
@@ -112,7 +107,7 @@ template <> struct fmt::formatter<SHStringWithLen> {
 template <> struct fmt::formatter<SHTrait> {
   StringStreamFormatter<SHTrait> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const SHTrait &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const SHTrait &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };
@@ -120,7 +115,7 @@ template <> struct fmt::formatter<SHTrait> {
 template <> struct fmt::formatter<SHVar> {
   StringStreamFormatter<SHVar> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const SHVar &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const SHVar &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };
@@ -128,7 +123,7 @@ template <> struct fmt::formatter<SHVar> {
 template <> struct fmt::formatter<SHTypeInfo> {
   StringStreamFormatter<SHTypeInfo> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const SHTypeInfo &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const SHTypeInfo &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };
@@ -136,19 +131,14 @@ template <> struct fmt::formatter<SHTypeInfo> {
 template <> struct fmt::formatter<SHTypesInfo> {
   StringStreamFormatter<SHTypesInfo> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const SHTypesInfo &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const SHTypesInfo &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };
 
 template <> struct fmt::formatter<SHType> {
-  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw format_error("invalid format");
-    return it;
-  }
-  template <typename FormatContext> auto format(const SHType &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+  template <typename FormatContext> auto format(const SHType &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return format_to(ctx.out(), "{}", magic_enum::enum_name(v));
   }
 };
@@ -156,7 +146,7 @@ template <> struct fmt::formatter<SHType> {
 template <> struct fmt::formatter<shards::Type> {
   fmt::formatter<SHTypeInfo> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const shards::Type &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const shards::Type &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };
@@ -164,7 +154,7 @@ template <> struct fmt::formatter<shards::Type> {
 template <> struct fmt::formatter<shards::Types> {
   fmt::formatter<SHTypesInfo> base;
   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return base.parse(ctx); }
-  template <typename FormatContext> auto format(const shards::Types &v, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const shards::Types &v, FormatContext &ctx) const -> decltype(ctx.out()) {
     return base.format(v, ctx);
   }
 };

--- a/shards/core/pmr/shared_temp_allocator.cpp
+++ b/shards/core/pmr/shared_temp_allocator.cpp
@@ -1,5 +1,6 @@
 #include "shared_temp_allocator.hpp"
 #include <shards/log/log.hpp>
+#include <spdlog/fmt/std.h>
 #include <tracy/Wrapper.hpp>
 
 static shards::logging::Logger getLogger() {

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -1432,7 +1432,7 @@ bool validateWireTraits(const SHWire *wire, const SHComposeResult &cr, SHInstanc
     if (!tm(cr.exposedInfo, trait)) {
       auto pct = reinterpret_cast<CompositionContext *>(data.privateContext);
       shassert(pct);
-      pct->errorStack.emplace_back(fmt::format("Wire {} does not implement {}", wire->name, trait, tm.error));
+      pct->errorStack.emplace_back(fmt::format("Wire {} does not implement {}", wire->name, (const SHTrait &)trait, tm.error));
       pct->errorStack.emplace_back(tm.error);
       return false;
     }
@@ -1660,7 +1660,7 @@ void error_handler(int err_sig) {
 
   if (crashed) {
 #ifndef __EMSCRIPTEN__
-    SHLOG_ERROR(boost::stacktrace::stacktrace());
+    SHLOG_ERROR("{}", boost::stacktrace::to_string(boost::stacktrace::stacktrace()));
 #endif
 
     auto handler = GetGlobals().CrashHandler;

--- a/shards/core/trait.cpp
+++ b/shards/core/trait.cpp
@@ -45,7 +45,7 @@ SHTrait cloneTrait(const SHTrait &other) {
 template <typename S, typename... Args> inline auto formatLineInto(std::string &str, const S &format_str, Args &&...args) {
   if (!str.empty())
     str.push_back('\n');
-  fmt::format_to(std::back_inserter(str), format_str, std::forward<Args>(args)...);
+  fmt::format_to(std::back_inserter(str), fmt::runtime(format_str), std::forward<Args>(args)...);
 }
 
 bool TraitMatcher::operator()(SHExposedTypesInfo exposedVariables, const SHTrait &trait) {

--- a/shards/fast_string/fast_string.hpp
+++ b/shards/fast_string/fast_string.hpp
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <string>
 #include <functional>
+#include <spdlog/fmt/fmt.h>
 
 namespace shards::fast_string {
 struct FastString {
@@ -67,6 +68,15 @@ private:
 
 template <> struct std::hash<shards::fast_string::FastString> {
   size_t operator()(const shards::fast_string::FastString &str) const { return std::hash<uint64_t>()(str.id); }
+};
+
+// fmt formatter lives with the type so it is visible to every consumer (fmt 11
+// no longer formats arbitrary string_view-convertible types implicitly).
+template <> struct fmt::formatter<shards::fast_string::FastString> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(const shards::fast_string::FastString &str, FormatContext &ctx) const -> decltype(ctx.out()) {
+    return fmt::formatter<std::string_view>::format(str.str(), ctx);
+  }
 };
 
 #endif /* EC76A763_D9F1_4187_B602_A2E23F686D7F */

--- a/shards/fast_string/fmt.hpp
+++ b/shards/fast_string/fmt.hpp
@@ -1,21 +1,8 @@
 #ifndef C15A8B87_4A27_4D56_AD9E_4DA2AACA21FE
 #define C15A8B87_4A27_4D56_AD9E_4DA2AACA21FE
 
+// The fmt::formatter<FastString> now lives in fast_string.hpp so it is always
+// visible with the type. This header is kept for backward compatibility.
 #include "fast_string.hpp"
-#include <spdlog/fmt/fmt.h>
-
-// template<> struct fmt::formatter<shards::fast_string::FastString> {
-//   constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-//     auto it = ctx.begin(), end = ctx.end();
-//     if (it != end)
-//       throw format_error("invalid format");
-//     return it;
-//   }
-
-//   template <typename FormatContext>
-//   auto format(const shards::fast_string::FastString &str, FormatContext &ctx) -> decltype(ctx.out()) {
-//     return format_to(ctx.out(), "{}", str.str());
-//   }
-// };
 
 #endif /* C15A8B87_4A27_4D56_AD9E_4DA2AACA21FE */

--- a/shards/gfx/error_utils.hpp
+++ b/shards/gfx/error_utils.hpp
@@ -6,7 +6,7 @@
 
 namespace gfx {
 template <typename... TArgs> std::runtime_error formatException(const char *format, TArgs... args) {
-  return std::runtime_error(fmt::format(format, args...));
+  return std::runtime_error(fmt::format(fmt::runtime(format), args...));
 }
 } // namespace gfx
 

--- a/shards/gfx/fmt.hpp
+++ b/shards/gfx/fmt.hpp
@@ -6,14 +6,9 @@
 #include <sstream>
 
 template <class T, int M> struct fmt::formatter<linalg::vec<T, M>> {
-  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw format_error("invalid format");
-    return it;
-  }
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
-  template <typename FormatContext> auto format(const linalg::vec<T, M> &vec, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const linalg::vec<T, M> &vec, FormatContext &ctx) const -> decltype(ctx.out()) {
     using namespace linalg::ostream_overloads;
     std::stringstream ss;
     ss << vec;

--- a/shards/gfx/gfx_wgpu.hpp
+++ b/shards/gfx/gfx_wgpu.hpp
@@ -80,4 +80,15 @@ inline constexpr size_t WGPU_COPY_BYTES_PER_ROW_ALIGNMENT = 256;
 #include "rust/gfx/bindings.hpp"
 #endif
 
+#ifndef RUST_BINDGEN
+// fmt 11 no longer formats enums implicitly; preserve the integer rendering of
+// WGPUTextureFormat that fmt 7 produced (used in logs and WGSL type strings).
+#include <spdlog/fmt/fmt.h>
+template <> struct fmt::formatter<WGPUTextureFormat> : fmt::formatter<int> {
+  template <typename FormatContext> auto format(WGPUTextureFormat v, FormatContext &ctx) const -> decltype(ctx.out()) {
+    return fmt::formatter<int>::format((int)v, ctx);
+  }
+};
+#endif
+
 #endif // GFX_GFX_WGPU

--- a/shards/gfx/render_graph_builder.hpp
+++ b/shards/gfx/render_graph_builder.hpp
@@ -15,15 +15,10 @@
 #include <boost/tti/has_member_data.hpp>
 
 template <> struct fmt::formatter<gfx::detail::graph_build_data::FrameSizing> {
-  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw format_error("invalid format");
-    return it;
-  }
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const gfx::detail::graph_build_data::FrameSizing &size, FormatContext &ctx) -> decltype(ctx.out()) {
+  auto format(const gfx::detail::graph_build_data::FrameSizing &size, FormatContext &ctx) const -> decltype(ctx.out()) {
     using namespace linalg::ostream_overloads;
     std::stringstream ss;
     std::visit(

--- a/shards/gfx/shader/fmt.hpp
+++ b/shards/gfx/shader/fmt.hpp
@@ -9,15 +9,10 @@
 #include <variant>
 
 template <> struct fmt::formatter<gfx::shader::NumType> {
-  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw format_error("invalid format");
-    return it;
-  }
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const gfx::shader::NumType &fieldType, FormatContext &ctx) -> decltype(ctx.out()) {
+  auto format(const gfx::shader::NumType &fieldType, FormatContext &ctx) const -> decltype(ctx.out()) {
     auto baseTypeName = magic_enum::enum_name(fieldType.baseType);
     if (fieldType.matrixDimension > 1) {
       return format_to(ctx.out(), "{{{}, {}x{}}}", baseTypeName, fieldType.numComponents, fieldType.matrixDimension);
@@ -28,14 +23,9 @@ template <> struct fmt::formatter<gfx::shader::NumType> {
 };
 
 template <> struct fmt::formatter<gfx::shader::Type> {
-  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw format_error("invalid format");
-    return it;
-  }
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
-  template <typename FormatContext> auto format(const gfx::shader::Type &fieldType, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const gfx::shader::Type &fieldType, FormatContext &ctx) const -> decltype(ctx.out()) {
     return std::visit(
         [&](auto &arg) {
           using T = std::decay_t<decltype(arg)>;
@@ -50,20 +40,16 @@ template <> struct fmt::formatter<gfx::shader::Type> {
 };
 
 template <> struct fmt::formatter<gfx::shader::LayoutPath> {
-  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end)
-      throw format_error("invalid format");
-    return it;
-  }
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
-  template <typename FormatContext> auto format(const gfx::shader::LayoutPath &lp, FormatContext &ctx) -> decltype(ctx.out()) {
+  template <typename FormatContext> auto format(const gfx::shader::LayoutPath &lp, FormatContext &ctx) const -> decltype(ctx.out()) {
     for (size_t i = 0; i < lp.path.size(); i++) {
       if (i > 0) {
         format_to(ctx.out(), ".");
       }
       format_to(ctx.out(), "{}", lp.path[i]);
     }
+    return ctx.out();
   }
 };
 

--- a/shards/gfx/shader/generator.hpp
+++ b/shards/gfx/shader/generator.hpp
@@ -34,7 +34,7 @@ struct IGeneratorDynamicHandler {
 };
 
 template <typename... TArgs> static GeneratorError formatError(const char *format, TArgs... args) {
-  return GeneratorError(fmt::format(format, args...));
+  return GeneratorError(fmt::format(fmt::runtime(format), args...));
 }
 
 struct GeneratorDefinitions {

--- a/shards/gfx/unique_id.hpp
+++ b/shards/gfx/unique_id.hpp
@@ -7,6 +7,7 @@
 #ifndef RUST_BINDGEN
 #include <atomic>
 #include <compare>
+#include <spdlog/fmt/fmt.h>
 #endif
 
 namespace gfx {
@@ -87,6 +88,13 @@ public:
 
 template <> struct std::hash<gfx::UniqueId> {
   size_t operator()(gfx::UniqueId v) const { return size_t(v.value); }
+};
+
+template <> struct fmt::formatter<gfx::UniqueId> : fmt::formatter<gfx::UniqueIdValue> {
+  template <typename FormatContext>
+  auto format(const gfx::UniqueId &v, FormatContext &ctx) const -> decltype(ctx.out()) {
+    return fmt::formatter<gfx::UniqueIdValue>::format(v.value, ctx);
+  }
 };
 #endif
 

--- a/shards/modules/fs/fs.cpp
+++ b/shards/modules/fs/fs.cpp
@@ -427,7 +427,7 @@ struct Read {
         // First activation or reset: validate and open file
         _currentPath = pathStr;
         if (!fs::exists(p)) {
-          SHLOG_ERROR("File is missing: {}", p);
+          SHLOG_ERROR("File is missing: {}", p.string());
           throw FileNotFoundException("FS.Read, file does not exist.");
         }
 
@@ -477,7 +477,7 @@ struct Read {
     } else {
       // Normal mode: read entire file with size validation
       if (!fs::exists(p)) {
-        SHLOG_ERROR("File is missing: {}", p);
+        SHLOG_ERROR("File is missing: {}", p.string());
         throw FileNotFoundException("FS.Read, file does not exist.");
       }
 
@@ -680,7 +680,7 @@ struct Size {
     ErrorCode ec;
     auto size = fs::file_size(p, ec);
     if (ec.failed()) {
-      throw FileNotFoundException(fmt::format("FS.Size, file {} does not exist.", p));
+      throw FileNotFoundException(fmt::format("FS.Size, file {} does not exist.", p.string()));
     }
     return Var(static_cast<int64_t>(size));
   }
@@ -695,7 +695,7 @@ struct LastWriteTime {
     ErrorCode ec;
     auto lwt = fs::last_write_time(p, ec);
     if (ec.failed()) {
-      throw FileNotFoundException(fmt::format("FS.LastWriteTime, file {} does not exist.", p));
+      throw FileNotFoundException(fmt::format("FS.LastWriteTime, file {} does not exist.", p.string()));
     }
     return Var(static_cast<int64_t>(lwt));
   }
@@ -725,7 +725,7 @@ struct SetWriteTime {
     ErrorCode ec;
     fs::last_write_time(p, time.payload.intValue, ec);
     if (ec.failed()) {
-      throw FileNotFoundException(fmt::format("FS.SetWriteTime, file {} does not exist.", p));
+      throw FileNotFoundException(fmt::format("FS.SetWriteTime, file {} does not exist.", p.string()));
     }
     return input;
   }
@@ -759,7 +759,7 @@ struct CreateDirectories {
 
     if (!fs::exists(p)) {
       if (!fs::create_directories(p)) {
-        throw ActivationError(fmt::format("FS.CreateDirectories, failed to create directories for {}.", p));
+        throw ActivationError(fmt::format("FS.CreateDirectories, failed to create directories for {}.", p.string()));
       }
     }
     return input;
@@ -857,7 +857,7 @@ struct Rename {
 
     // check exists
     if (!fs::exists(p)) {
-      throw ActivationError(fmt::format("FS.Rename, file {} does not exist.", p));
+      throw ActivationError(fmt::format("FS.Rename, file {} does not exist.", p.string()));
     }
 
     auto newName = SHSTRING_PREFER_SHSTRVIEW(_newName.get());

--- a/shards/modules/gfx/gltf.cpp
+++ b/shards/modules/gfx/gltf.cpp
@@ -64,7 +64,7 @@ static OwnedVar getGltfBuiltinTargetPath(animation::BuiltinTarget target) {
     pathStr[1] = 't';
     break;
   default:
-    SHLOG_ERROR("Ignoring builtin target: {}", target);
+    SHLOG_ERROR("Ignoring builtin target: {}", (int)target);
     break;
   }
   pathStr[2] = 0;
@@ -374,7 +374,7 @@ struct GLTFShard {
       node->trs.translation = toVec<float3>(value);
       break;
     default:
-      SHLOG_WARNING("Ignoring builtin target: {}", target);
+      SHLOG_WARNING("Ignoring builtin target: {}", (int)target);
       break;
     }
     node->update();

--- a/shards/modules/gfx/shader/math_shards.cpp
+++ b/shards/modules/gfx/shader/math_shards.cpp
@@ -50,9 +50,9 @@ template <typename TShard> struct ToNumberTranslator {
       std::string prefix = fmt::format("{}((", getWGSLTypeName(unitFieldType));
       std::string suffix{};
       if (requireSourceSwizzle)
-        suffix = fmt::format((isLast ? ").{})" : ").{}), "), componentNames[i]);
+        suffix = fmt::format(fmt::runtime(isLast ? ").{})" : ").{}), "), componentNames[i]);
       else
-        suffix = fmt::format((isLast ? "))" : ")), "));
+        suffix = fmt::format(fmt::runtime(isLast ? "))" : ")), "));
 
       sourceComponentList->children.emplace_back(
           blocks::makeCompoundBlock(std::move(prefix), std::move(inner), std::move(suffix)));
@@ -80,7 +80,7 @@ template <typename TShard> struct ToNumberTranslator {
         if (!isLast)
           fmt += ", ";
 
-        compound->children.emplace_back(blocks::makeBlock<blocks::Direct>(fmt::format(fmt, 0.)));
+        compound->children.emplace_back(blocks::makeBlock<blocks::Direct>(fmt::format(fmt::runtime(fmt), 0.)));
       }
 
       compound->children.emplace_back(blocks::makeBlock<blocks::Direct>(")"));

--- a/shards/modules/http/http.cpp
+++ b/shards/modules/http/http.cpp
@@ -1229,7 +1229,7 @@ struct Read {
       _output[Var("method")] = Var("OPTIONS");
       break;
     default:
-      throw ActivationError(fmt::format("Unsupported HTTP method {}.", request.method()));
+      throw ActivationError(fmt::format("Unsupported HTTP method {}.", boost::beast::http::to_string(request.method())));
     }
 
     _headers.clear();

--- a/shards/modules/run/run.cpp
+++ b/shards/modules/run/run.cpp
@@ -152,7 +152,7 @@ struct Run {
           }
         }
 
-        SHLOG_DEBUG("Mesh (detached) is done, terminating, without errors: {}", noErrors);
+        SHLOG_DEBUG("Mesh (detached) is done, terminating, without errors: {}", noErrors.load());
 
         // Terminate the mesh
         mesh->terminate();

--- a/shards/tests/http.shs
+++ b/shards/tests/http.shs
@@ -5,24 +5,66 @@
 
 @mesh(root)
 
-false >= timed-out
-Maybe({
-  none
-  Http.Get("https://httpstat.us/200?sleep=5000" Timeout: 1)
-  Log
-} {true > timed-out})
-timed-out | Assert.Is(true)
+// Local test server replacing the previously-used third-party endpoints
+// (httpstat.us / httpbin.org), which made this test flaky and CI-blocking
+// whenever those services hiccuped. Serves two endpoints:
+//   /slow - delays past a short client timeout (client-timeout coverage)
+//   /post - echoes the request body back as application/json (POST coverage)
+@wire(local-http-handler {
+  Maybe({
+    Http.Read = request
+    request | Take("target") | ExpectString
+    Match([
+      "/slow" {
+        Pause(2.0)
+        "slow" | Http.Response(Status: 200 ContentType: "text/plain")
+      }
+      "/post" {
+        request | Take("body") | ExpectString
+        Http.Response(Status: 200 ContentType: "application/json")
+      }
+      none {
+        "not found" | Http.Response(Status: 404 ContentType: "text/plain")
+      }
+    ] Passthrough: false)
+  } {
+    // Tolerate aborted connections (e.g. the client-timeout case below) so the
+    // looped handler keeps serving subsequent requests.
+    Pass
+  })
+} Looped: true)
 
+@wire(local-http-server {
+  Http.Server(local-http-handler Port: 18088)
+} Looped: true)
+
+// Phase 1 - client timeout coverage: a 1s timeout against the 2s /slow endpoint
+// must fail (any failure flips timed-out, so a connect error is acceptable too).
+@wire(timeout-test {
+  false >= timed-out
+  Maybe({
+    none
+    Http.Get("http://127.0.0.1:18088/slow" Timeout: 1)
+    Log
+  } {true > timed-out})
+  timed-out | Assert.Is(true)
+})
+@schedule(root local-http-server)
+@schedule(root timeout-test)
+@run(root FPS: 10 Iterations: 30) | Assert.Is(true)
+
+// Phase 2 - URI escaping, a real GET (+JSON parse) and POST echo against the
+// local server. No /slow here, so the shared handler is never blocked.
 @wire(test {
   "Hello world, this is an escaping test ////"
   String.EncodeURI | Log
   Assert.Is("Hello%20world%2C%20this%20is%20an%20escaping%20test%20%2F%2F%2F%2F" true)
   String.DecodeURI | Log
   Assert.Is("Hello world, this is an escaping test ////" true)
-  
+
   1 | ToString
   Set(params "postId")
-  
+
   params
   Http.Get("https://raw.githubusercontent.com/fragcolor-xyz/vscode-shards-syntax/main/package.json") = json
   FromJson
@@ -31,13 +73,13 @@ timed-out | Assert.Is(true)
   ExpectString
   Assert.Is("Fragcolor and contributors" true)
   Log
-  
+
   json
-  Http.Post("https://httpbin.org/post")
+  Http.Post("http://127.0.0.1:18088/post")
   Log
 
   json
-  Http.Post("https://httpbin.org/post" FullResponse: true)
+  Http.Post("http://127.0.0.1:18088/post" FullResponse: true)
   Log
   Take("headers")
   Take("content-type") | ExpectString
@@ -45,10 +87,12 @@ timed-out | Assert.Is(true)
   String.Starts("application/json") | Assert.Is(true)
 } Looped: true)
 
+@schedule(root local-http-server)
 @schedule(root test)
 @run(root FPS: 10 Iterations: 20) | Assert.Is(true)
 
 // test reusing sockets/streams
+@schedule(root local-http-server)
 @schedule(root test)
 @run(root FPS: 10 Iterations: 20) | Assert.Is(true)
 
@@ -57,19 +101,19 @@ timed-out | Assert.Is(true)
   Http.Get("https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.png" Bytes: true Timeout: 60) = shards
   Log
   "shards.png" | FS.Write(shards Overwrite: true)
-  
+
   // Emscripten doesn't have streaming support yet
   @if(#(@platform | IsNot("emscripten")) {
     none
     Http.Get("https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.png" Streaming: true Timeout: 60) = picture-stream
-    
+
     Sequence(chunks Type: @type([Type::Bytes]))
     Repeat({
       Http.Stream(picture-stream) = chunk | Log
       Count(chunk) | When(Is(0) Return)
       chunk >> chunks
     })
-    
+
     chunks | Bytes.Join = shards2
     shards2 | Assert.Is(shards)
   } none)
@@ -77,30 +121,3 @@ timed-out | Assert.Is(true)
 
 @schedule(root download)
 @run(root FPS: 10) | Assert.Is(true)
-
-// ; wire, to keep same state
-// @wire(send-chunk {Http.Chunk})
-
-// @wire(server-handler {
-//   Msg("handled")
-//   Http.Read | Take("target")
-//   When(Is("/") {
-//     Log
-//     "Message\n" | Log("Responding")
-//     Do(send-chunk) | Log("Responded")
-//     "Message\n" | Log("Responding")
-//     Do(send-chunk) | Log("Responded")
-//     "Message\n" | Log("Responding")
-//     Do(send-chunk) | Log("Responded")
-//     "" | Log("Responding")
-//     Do(send-chunk) | Log("Responded")
-//   })
-// } Looped: true)
-
-// @wire(test-server {
-//   Http.Server(Handler: server-handler)
-// } Looped: true)
-
-// @schedule(root test-server)
-// @run(root FPS: 10) | Assert.Is(true)
-


### PR DESCRIPTION
## Why

GitHub moved the `windows-latest` CI image to a **Visual Studio 2026** image (`win25-vs2026`), whose MSVC STL **removed the legacy non-standard `stdext::checked_array_iterator`**. spdlog 1.8.5's bundled **fmt 7.1.3** still referenced it on its Debug-only `_SECURE_SCL` path, so only **Windows-Debug / Build** broke — Release compiles the plain-pointer path. Our code didn't change; the compiler under it did (`14e7733a` was green on the VS 2022 image on May 25 / `a2b034f8` green Jun 10; first red Jun 13 when the image flipped).

## What

- **`deps/spdlog` 1.8.5 → 1.15.3** (bundled fmt 7.1.3 → 11.2.0), which removed the `stdext` path entirely. The fork (`shards-lang/spdlog`) is a plain mirror; tag `v1.15.3` was pushed there so the submodule pin resolves.
- **fmt 11 migration of shards' usage** (18 files, net −17 lines):
  - Custom formatters: const-qualify every `format()` (fmt 10+ calls it on a const formatter) and drop the throwing `parse()` (broke fmt 11's `consteval` format-string check). Covers `ops_internal`, `gfx/fmt`, `gfx/shader/fmt`, `render_graph_builder`; also fixes a latent missing `return` in `LayoutPath::format`.
  - Add formatters fmt 11 no longer synthesizes implicitly, placed with the type so they're always visible: **FastString**, **gfx::UniqueId**, **WGPUTextureFormat**.
  - Wrap runtime/ternary format strings in `fmt::runtime()` (`exception.hpp`, gfx error helpers, `trait.cpp`, `math_shards.cpp`).
  - `#include <spdlog/fmt/std.h>` for `std::thread::id`.
  - Behavior-preserving call-site fixes: `SHTrait` cast, `boost::stacktrace::to_string`, `path.string()`, `http::to_string(verb)`, enum→int (matches fmt 7's implicit enum rendering).

## Verification

- Clean **Release** build locally (0 errors, links).
- **Full local suite: 367 pass / 1 fail** — the one failure is `llm.shs`, which shells out to the `hf` CLI (not installed on the dev machine); it dies at `Process.Run` before any LLM/fmt code. No formatter regressions.
- Cross-platform (esp. **Windows-Debug VS 2026**), iOS, and wasm are validated by this PR's CI.