### PR TITLE
feat(pak): `shards pak` — single-file Shards apps

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -190,6 +190,10 @@ jobs:
           echo "Running language formatter tests"
           cd shards/lang/src/tests
           $SH test
+      - name: Pak (single-file packaging) smoke test
+        env:
+          RUST_BACKTRACE: full
+        run: bash shards/tests/pak.sh build/shards
       # Minimize disk usage to prevent the next steps getting stuck due to no disk space
       - name: Minimize disk usage
         env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -177,6 +177,12 @@ jobs:
             echo "Running sample $i";
             ../../build/shards new run-sample.shs file:"$i" looped:false;
           done
+      - name: Pak (single-file packaging) smoke test
+        env:
+          RUST_BACKTRACE: full
+        run: |
+          chmod +x build/shards
+          bash shards/tests/pak.sh build/shards
   macOS-dll-shard:
     if: ${{ needs.macOS.outputs.run-subproject-tests == 'true' }}
     needs: macOS

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -406,3 +406,8 @@ jobs:
           cd build
           echo "Running subwires"
           ./shards new ../shards/tests/subwires.shs
+      - name: Pak (single-file packaging) smoke test
+        env:
+          RUST_BACKTRACE: full
+        shell: bash
+        run: bash shards/tests/pak.sh build/shards

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8328,6 +8328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shards",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/docs/shards-pak.md
+++ b/docs/shards-pak.md
@@ -1,0 +1,164 @@
+# `shards pak` — single-file Shards apps
+
+Turn any Shards script into a standalone, signed executable with one command:
+
+```sh
+shards pak main.shs            # -> ./main  (or main.exe on Windows)
+./main                         # runs the embedded script — no interpreter, no runtime files
+```
+
+No C++ toolchain, no CMake. The produced binary embeds the compiled script and
+carries the whole Shards runtime (every module linked into the `shards` binary
+you packed with).
+
+## How it works
+
+The `shards` executable *is* the runtime, and `langffi` already knows how to run
+a compiled script (`.sho`). So a "pak" compiles no C/C++ — it embeds the compiled
+script into a copy of the runtime that is already on disk, using each platform's
+**native container mechanism** so the result stays structurally valid and
+signable (it does *not* rely on appending bytes after the end of the image, which
+breaks code-signing and trips antivirus heuristics).
+
+`shards pak main.shs`:
+
+1. Parses and compiles `main.shs` to its binary `.sho` form **in memory**
+   (`"SHRD"` FourCC + ABI version + flexbuffers AST — the exact bytes
+   `shards build` would write).
+2. Copies the running `shards` executable (`std::env::current_exe()`).
+3. Embeds the payload and (re-)signs, per platform:
+
+| Platform | Embedding | Runtime lookup | Signing |
+|----------|-----------|----------------|---------|
+| **macOS** | inside the `__LINKEDIT` segment (grown to cover it) | payload sits just before `LC_CODE_SIGNATURE.dataoff` | `codesign` (ad-hoc by default) |
+| **Windows** | `RT_RCDATA` resource via `UpdateResource` | `FindResource`/`LoadResource` (in-memory) | `signtool` (Authenticode) |
+| **Linux** | `.shards_pak` ELF section via `objcopy` (overlay fallback) | section in `/proc/self/exe` (EOF fallback) | n/a |
+
+A fixed 8-byte magic (`SHRDPAK1`) plus a `u64` length form a 16-byte footer on the
+payload, so a plain, un-packed `shards` binary is never mistaken for a packed one.
+
+### Why not just append to the end of the file?
+
+Appending bytes after the image (an "overlay") is the simplest trick but the worst
+for signing/AV:
+
+- **macOS** rejects it outright — `codesign` fails with *"main executable failed
+  strict validation"* when there is data after the Mach-O, and arm64 refuses to
+  run a binary whose signature doesn't cover it. The payload **must** live inside
+  a segment and before the signature, which is why it goes into `__LINKEDIT`
+  (which is grown so `codeLimit` includes it). Verified: the packed binary reports
+  `codesign --verify` → *valid on disk*.
+- **Windows** Authenticode *can* tolerate an overlay if you sign last, but a large
+  appended overlay on an unsigned binary is a classic AV/SmartScreen heuristic. A
+  proper `RT_RCDATA` resource keeps the PE conventional and clean.
+- **Linux** has no signing/Gatekeeper gate, so an overlay is harmless — but a real
+  `.shards_pak` section is tidier, so we use one when `objcopy` is available.
+
+### Startup
+
+Every `shards` binary, on launch (after core init, before argv parsing), asks the
+platform extractor whether *this* executable carries a payload (reads its own
+`__LINKEDIT`/section/resource). If so it runs the embedded script via the normal
+`execute_seq` path, forwarding extra argv to the script as `key:value` defines. A
+plain binary has no payload, so the check returns instantly.
+
+## Usage
+
+```
+shards pak <file.shs> [-o <output>] [-I <dir>...] [signing options]
+
+  -o, --output <path>        Output executable (default: script name, no extension)
+  -I, --include <dir>        Additional include directories for @include / @read
+
+  --sign <identity>          Signing identity.
+                               macOS:   codesign -s <identity>   (default: ad-hoc "-")
+                               Windows: signtool /n <subject>
+  --no-sign                  Do not sign (macOS leaves an invalid signature; testing only)
+  --notarize                 macOS: submit for notarization after signing
+  --notarize-profile <name>  macOS: xcrun notarytool --keychain-profile <name>
+```
+
+Examples:
+
+```sh
+shards pak game.shs                                   # ad-hoc signed, runs locally
+shards pak game.shs --sign "Developer ID Application: Acme (TEAMID)" \
+                    --notarize --notarize-profile acme   # distributable on macOS
+shards pak game.shs --sign "Acme Code Signing"        # Windows Authenticode
+./game arg1:hello arg2:world                           # extra args -> script defines
+```
+
+## Resources
+
+What ends up inside the single binary is whatever is in the **compiled AST**:
+
+- **Embedded (packs):** `@include("other.shs")` and
+  `@read("logo.png" Bytes: true)` are resolved at *parse time* and baked into the
+  `.sho` as constants. Use `@read` to embed images, data files, etc. (Verified: a
+  file embedded via `@read` is readable from a packed binary run in a directory
+  where the original file does not exist.)
+- **Not embedded:** anything loaded at **runtime by path** — `FS.Read`,
+  `LoadImage`, audio/glTF/shader loaders — reads from disk at run time. The path
+  string is in the binary; the file is not. Pack such assets via `@read`, or ship
+  them alongside the executable.
+
+```clojure
+; baked into the binary:
+@define(logo @read("logo.png" Bytes: true))
+; runtime path-load — needs logo.png on disk next to the app:
+"logo.png" | LoadImage
+```
+
+(There is no embedded virtual filesystem in shards-core; only Formabble has one.)
+
+## Limitations & notes
+
+- **Size**: the packed binary is a full copy of `shards` (all linked modules), so
+  it is as large as `shards`. To shrink it, build a `shards` with only the modules
+  you need (`SHARDS_WITH_*` options) and pak with that binary.
+- **Same platform/ABI**: the embedded `.sho` is tied to `SHARDS_CURRENT_ABI`; a
+  packed binary refuses a payload from a different ABI. You pak on the platform you
+  target (no cross-pak).
+- **macOS universal binaries**: not supported — pak a thin (single-arch) `shards`.
+- **Reputation ≠ validity**: ad-hoc signing makes the binary *valid* (it runs
+  locally without the arm64 "killed: invalid signature"), but Gatekeeper /
+  SmartScreen clear downloads based on a real signing identity (+ notarization on
+  macOS). For non-flagged distribution, sign with a Developer ID / Authenticode
+  cert via `--sign` (and `--notarize` on macOS).
+- **The runtime is fixed at pak time** — you cannot add native (C++/Rust)
+  extensions this way. For a customizable native app, bundle scripts at build time
+  with CMake (`shards_build` + `target_bundle_files` + `target_generate_bundle_manifest`).
+
+## Implementation
+
+- `shards/lang/src/pak.rs` — platform embedders/extractors (`embed_payload`,
+  `load_self_payload`) and `SignOpts`.
+- `shards/lang/src/cli.rs` — the `pak` subcommand, the startup self-check in
+  `process_args`, and shared helpers `read_program` / `serialize_sho` /
+  `deserialize_sho` (also used by `build` / `load`).
+
+### Testing
+
+`shards/tests/pak.sh` is a self-contained smoke test (runnable locally and in CI;
+Windows via Git Bash). It packs a script that embeds a resource via `@read`, runs
+the produced binary **from a clean directory** with neither the source nor the
+resource present, and asserts the marker output, the embedded resource byte count,
+that extra argv does not break it, and — on macOS — that `codesign --verify`
+passes:
+
+```sh
+shards/tests/pak.sh build/shards     # or build/Release/shards
+```
+
+It runs in CI on all three platforms as a step in each build's test job
+(`build-linux.yml`, `build-macos.yml`, `build-windows.yml`), so the Linux ELF
+section and Windows PE-resource round-trips are exercised on real runners.
+
+### Validation status
+
+- **macOS (arm64):** fully validated on-device — `codesign --verify` valid, runs,
+  self-contained, `@read` resources embed correctly; covered by CI.
+- **Linux / Windows:** implemented and **type-checked** via cross-compilation
+  (`cargo check --target x86_64-unknown-linux-gnu` / `x86_64-pc-windows-msvc`), and
+  exercised by the CI smoke test above — run the CI to confirm the round-trip on
+  those runners.

--- a/shards/lang/Cargo.toml
+++ b/shards/lang/Cargo.toml
@@ -27,6 +27,13 @@ dashmap = "6.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+# Used by `shards pak` to embed/read the payload as a PE resource.
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_System_LibraryLoader",
+] }
+
 
 [features]
 default = ["exported"]

--- a/shards/lang/src/cli.rs
+++ b/shards/lang/src/cli.rs
@@ -27,6 +27,10 @@ extern "C" {
   fn shards_decompress_strings();
 }
 
+// `shards pak` (single-file packaging) lives in the `pak` module. The startup
+// self-check below asks it whether *this* executable carries an embedded script.
+use crate::pak;
+
 #[derive(Debug, clap::Args)]
 struct RunArgs {
   /// The script file to execute
@@ -96,6 +100,34 @@ enum Commands {
     /// Generate dependency file in Makefile format
     #[arg(long, short = 'd')]
     depfile: Option<String>,
+  },
+  /// Pack a Shards script into a standalone, single-file executable
+  ///
+  /// Compiles the script and appends it to a copy of this `shards` binary,
+  /// producing a self-contained executable that runs the script directly with
+  /// no interpreter, runtime files or toolchain required.
+  Pak {
+    /// The script source file to pack
+    #[arg(value_hint = clap::ValueHint::FilePath)]
+    file: String,
+    /// Output executable path (defaults to the script name without extension)
+    #[arg(long, short = 'o')]
+    output: Option<String>,
+    /// Additional include directories for imports
+    #[arg(long, short = 'I')]
+    include: Vec<String>,
+    /// Signing identity (macOS: codesign -s <id>, default ad-hoc; Windows: signtool /n <subject>)
+    #[arg(long)]
+    sign: Option<String>,
+    /// Do not sign the produced binary (macOS: leaves an invalid signature; testing only)
+    #[arg(long, action)]
+    no_sign: bool,
+    /// macOS: notarize the produced binary after signing (requires --notarize-profile)
+    #[arg(long, action)]
+    notarize: bool,
+    /// macOS notarization keychain profile (xcrun notarytool --keychain-profile)
+    #[arg(long)]
+    notarize_profile: Option<String>,
   },
   /// Generate JSON AST from a Shards source file
   AST {
@@ -182,6 +214,24 @@ pub fn process_args(argc: i32, argv: *const *const c_char, _no_cancellation: boo
     shlog_debug!("Shards git version: {}", GIT_VERSION);
   }
 
+  // Self-extracting path: if this executable was produced by `shards pak`, it
+  // carries an embedded compiled script. Detect and run it directly, ignoring
+  // normal subcommand parsing. Extra argv is forwarded to the script as defines.
+  match pak::load_self_payload() {
+    Ok(Some(payload)) => {
+      let res = deserialize_sho(&payload).and_then(|ast| {
+        let script_args: Vec<String> = args.iter().skip(1).cloned().collect();
+        execute_seq(&script_args, ast, cancellation_token).map_err(|e| -> Error { e.into() })
+      });
+      return finish(res);
+    }
+    Ok(None) => {} // not a packed binary, continue with normal CLI handling
+    Err(e) => {
+      shlog_error!("Failed to load embedded script: {}", e);
+      return 1;
+    }
+  }
+
   let cli = Cli::try_parse_from(args.clone());
   let res = match cli {
     Ok(cli) => match &cli.command {
@@ -192,6 +242,25 @@ pub fn process_args(argc: i32, argv: *const *const c_char, _no_cancellation: boo
         depfile,
         json,
       } => build(file, &output, include.to_vec(), depfile.as_deref(), *json),
+      Commands::Pak {
+        file,
+        output,
+        include,
+        sign,
+        no_sign,
+        notarize,
+        notarize_profile,
+      } => pak(
+        file,
+        output.as_deref(),
+        include.to_vec(),
+        pak::SignOpts {
+          no_sign: *no_sign,
+          identity: sign.clone(),
+          notarize: *notarize,
+          notarize_profile: notarize_profile.clone(),
+        },
+      ),
       Commands::AST {
         file,
         output,
@@ -250,6 +319,11 @@ pub fn process_args(argc: i32, argv: *const *const c_char, _no_cancellation: boo
     },
   };
 
+  finish(res)
+}
+
+/// Map a command result onto a process exit code, logging any error.
+fn finish(res: Result<(), Error>) -> i32 {
   if let Err(e) = res {
     shlog_error!("Error: {}", e);
     1
@@ -535,24 +609,8 @@ fn load(
   shlog!("Parsing binary file: {}", file);
 
   let ast = {
-    // deserialize from flexbuffers, skipping the first 8 bytes
-    let mut file_content = std::fs::read(file).map_err(|_| "File not found")?;
-    let magic: i32 = i32::from_be_bytes([
-      file_content[0],
-      file_content[1],
-      file_content[2],
-      file_content[3],
-    ]);
-    assert_eq!(magic, fourCharacterCode(*b"SHRD"));
-    let version = u32::from_le_bytes([
-      file_content[4],
-      file_content[5],
-      file_content[6],
-      file_content[7],
-    ]);
-    assert_eq!(version, SHARDS_CURRENT_ABI); // todo backwards compatibility
-    file_content.drain(0..8);
-    flexbuffers::from_slice(file_content.as_slice()).unwrap()
+    let file_content = std::fs::read(file).map_err(|_| "File not found")?;
+    deserialize_sho(&file_content)?
   };
 
   Ok(execute_seq(&args, ast, cancellation_token)?)
@@ -625,6 +683,112 @@ fn execute_seq(
   }
 }
 
+/// Parse a Shards source file into its AST, returning (dependency paths, ast).
+fn read_program(file: &str, include: Vec<String>) -> Result<(Vec<String>, Program), Error> {
+  let file_path = Path::new(&file);
+  let file_path = dunce::canonicalize(file_path).map_err(|_| format!("Input file {} not found", file))?;
+  let mut file_content = std::fs::read_to_string(&file_path).map_err(|_| "File not found")?;
+  // add new line at the end of the file to be able to parse it correctly
+  file_content.push('\n');
+
+  // get absolute parent path of the file
+  let parent_path = file_path.parent().unwrap().to_str().unwrap();
+
+  let mut env = ReadEnv::new(file_path.to_str().unwrap(), parent_path.to_string(), include);
+  let ast = read_with_env(&file_content, &mut env).map_err(|e| {
+    shlog!("Error: {:?}", e);
+    "Failed to parse file"
+  })?;
+  let mut deps = get_dependencies(&env)
+    .iter()
+    .map(|x| {
+      dunce::canonicalize(x)
+        .map_err(|_| "Failed to canonicalize path")
+        .map(|x| x.to_string_lossy().to_string())
+    })
+    .collect::<Result<Vec<String>, _>>()?;
+  // Add the main file as well
+  let p = dunce::canonicalize(&file_path)
+    .map_err(|_| "Failed to canonicalize path")?
+    .to_string_lossy()
+    .to_string();
+  deps.push(p);
+  Ok((deps, ast))
+}
+
+/// Serialize an AST into the binary `.sho` representation:
+/// `"SHRD"` (big-endian FourCC) + ABI version (little-endian u32) + flexbuffers AST.
+fn serialize_sho(ast: &Program) -> Vec<u8> {
+  let encoded_bin = flexbuffers::to_vec(ast).unwrap();
+  let mut out = Vec::with_capacity(8 + encoded_bin.len());
+  out.extend_from_slice(fourCharacterCode(*b"SHRD").to_be_bytes().as_ref());
+  out.extend_from_slice(SHARDS_CURRENT_ABI.to_le_bytes().as_ref());
+  out.extend_from_slice(&encoded_bin);
+  out
+}
+
+/// Deserialize a binary `.sho` payload, validating the `SHRD`+ABI header.
+fn deserialize_sho(bytes: &[u8]) -> Result<Program, Error> {
+  if bytes.len() < 8 {
+    return Err("Invalid .sho payload: too small".into());
+  }
+  let magic = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+  if magic != fourCharacterCode(*b"SHRD") {
+    return Err("Invalid .sho payload: bad magic".into());
+  }
+  let version = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+  if version != SHARDS_CURRENT_ABI {
+    return Err(format!("Incompatible .sho ABI version {} (expected {})", version, SHARDS_CURRENT_ABI).into());
+  }
+  flexbuffers::from_slice(&bytes[8..]).map_err(|e| format!("Failed to decode .sho: {}", e).into())
+}
+
+/// Detect and load a script packed into this executable by `shards pak`.
+/// Returns `Ok(None)` when this is a plain (un-packed) `shards` binary.
+/// Pack a script into a standalone executable: compile it, then embed it into a
+/// copy of this `shards` binary using the platform-native container mechanism
+/// (see the `pak` module). The result is a signed, runnable single file.
+fn pak(
+  file: &str,
+  output: Option<&str>,
+  include: Vec<String>,
+  sign: pak::SignOpts,
+) -> Result<(), Error> {
+  shlog!("Packing file: {}", file);
+
+  // Compile the script to its binary .sho representation (in memory).
+  let (_deps, ast) = read_program(file, include)?;
+  let payload = serialize_sho(&ast);
+
+  // Determine the output path: default to the script's stem (no extension),
+  // adding `.exe` on Windows.
+  let out_path = match output {
+    Some(o) => o.to_string(),
+    None => {
+      let stem = Path::new(file)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("app")
+        .to_string();
+      if cfg!(windows) {
+        format!("{}.exe", stem)
+      } else {
+        stem
+      }
+    }
+  };
+
+  pak::embed_payload(&payload, &out_path, &sign)?;
+
+  shlog!(
+    "Packed '{}' -> '{}' ({} bytes script embedded)",
+    file,
+    out_path,
+    payload.len()
+  );
+  Ok(())
+}
+
 fn build(
   file: &str,
   output: &str,
@@ -634,41 +798,7 @@ fn build(
 ) -> Result<(), Error> {
   shlog!("Parsing file: {}", file);
 
-  let (deps, ast) = {
-    let file_path = Path::new(&file);
-    let file_path = dunce::canonicalize(file_path).map_err(|_| format!("Input file {} not found", file))?;
-    let mut file_content = std::fs::read_to_string(file).map_err(|_| "File not found")?;
-    // add new line at the end of the file to be able to parse it correctly
-    file_content.push('\n');
-
-    // get absolute parent path of the file
-    let parent_path = file_path.parent().unwrap().to_str().unwrap();
-
-    let mut env = ReadEnv::new(
-      file_path.to_str().unwrap(),
-      parent_path.to_string(),
-      include,
-    );
-    let ast = read_with_env(&file_content, &mut env).map_err(|e| {
-      shlog!("Error: {:?}", e);
-      "Failed to parse file"
-    })?;
-    let mut deps = get_dependencies(&env)
-      .iter()
-      .map(|x| {
-        dunce::canonicalize(x)
-          .map_err(|_| "Failed to canonicalize path")
-          .map(|x| x.to_string_lossy().to_string())
-      })
-      .collect::<Result<Vec<String>, _>>()?;
-    // Add the main file as well
-    let p = dunce::canonicalize(file_path)
-      .map_err(|_| "Failed to canonicalize path")?
-      .to_string_lossy()
-      .to_string();
-    deps.push(p);
-    (deps, ast)
-  };
+  let (deps, ast) = read_program(file, include)?;
 
   // write sequence to file
   {
@@ -676,15 +806,7 @@ fn build(
     let mut writer = std::io::BufWriter::new(&mut file);
 
     if !as_json {
-      // Serialize using flexbuffers
-      let encoded_bin = flexbuffers::to_vec(&ast).unwrap();
-      writer
-        .write(fourCharacterCode(*b"SHRD").to_be_bytes().as_ref())
-        .unwrap();
-      writer
-        .write(SHARDS_CURRENT_ABI.to_le_bytes().as_ref())
-        .unwrap();
-      writer.write_all(encoded_bin.as_slice()).unwrap();
+      writer.write_all(&serialize_sho(&ast)).unwrap();
     } else {
       let encoded_json = serde_json::to_string_pretty(&ast).unwrap();
       writer.write_all(encoded_json.as_bytes()).unwrap();

--- a/shards/lang/src/lib.rs
+++ b/shards/lang/src/lib.rs
@@ -12,6 +12,7 @@ pub mod directory;
 mod error;
 pub mod eval;
 mod formatter;
+pub mod pak;
 pub mod print;
 pub mod read;
 pub mod rule_visitor;

--- a/shards/lang/src/pak.rs
+++ b/shards/lang/src/pak.rs
@@ -1,0 +1,585 @@
+//! Self-extracting single-file apps: `shards pak`.
+//!
+//! `shards pak main.shs` produces a standalone executable that embeds a compiled
+//! script (`.sho`) and carries the whole Shards runtime (the `shards` binary you
+//! packed with). No interpreter, runtime files or toolchain are needed to run it.
+//!
+//! Unlike a naive "append to the end of the file" trick, the payload is embedded
+//! in a way that keeps the container **structurally valid and signable**, so it
+//! does not trip code-signing / antivirus heuristics:
+//!
+//! * **macOS** — the payload is placed inside the `__LINKEDIT` segment (which is
+//!   grown to cover it) and the binary is then (re-)signed with `codesign`, so the
+//!   signature's `codeLimit` includes the payload. `codesign` rejects data that
+//!   sits *after* the Mach-O image ("strict validation"), so the payload must live
+//!   inside a segment — which this does. At runtime the payload is found
+//!   immediately before the code-signature blob (`LC_CODE_SIGNATURE.dataoff`).
+//! * **Windows** — the payload is added as an `RT_RCDATA` resource via
+//!   `UpdateResource`. The PE stays well-formed and Authenticode-signable (sign
+//!   last). At runtime it is read with `FindResource`/`LoadResource` — no file I/O.
+//! * **Linux** — the payload is added as a real `.shards_pak` ELF section when an
+//!   `objcopy`/`llvm-objcopy` is available, otherwise appended as an overlay
+//!   (ELF has no signing/Gatekeeper gate, so an overlay is harmless). At runtime
+//!   it is read from the section in `/proc/self/exe`, falling back to the overlay.
+//!
+//! In every case a fixed 8-byte magic (`SHRDPAK1`) marks the payload so a plain,
+//! un-packed `shards` binary is never mistaken for a packed one.
+
+use crate::error::Error;
+
+/// Magic marking a packed payload. Bump the trailing digit on format changes.
+pub const PAK_MAGIC: &[u8; 8] = b"SHRDPAK1";
+
+/// Name of the ELF section / Windows resource used to carry the payload.
+#[allow(dead_code)]
+const PAK_SECTION: &str = ".shards_pak";
+#[allow(dead_code)]
+const PAK_RESOURCE_ID: u16 = 1;
+
+/// How the produced executable should be signed.
+#[derive(Debug, Default, Clone)]
+pub struct SignOpts {
+  /// Do not sign at all (macOS: leaves an invalid signature — for testing only).
+  pub no_sign: bool,
+  /// Signing identity. macOS: `codesign -s <identity>` (default ad-hoc `-`).
+  /// Windows: certificate subject/thumbprint passed to `signtool`.
+  pub identity: Option<String>,
+  /// macOS: run `xcrun notarytool` + staple after signing (requires creds).
+  pub notarize: bool,
+  /// Notarization keychain profile name (`xcrun notarytool ... --keychain-profile`).
+  pub notarize_profile: Option<String>,
+}
+
+/// Embed `payload` (the compiled `.sho` bytes) into a copy of the currently
+/// running `shards` executable, writing the standalone app to `out_path`.
+pub fn embed_payload(payload: &[u8], out_path: &str, sign: &SignOpts) -> Result<(), Error> {
+  #[cfg(target_os = "macos")]
+  {
+    embed_macho(payload, out_path, sign)
+  }
+  #[cfg(target_os = "windows")]
+  {
+    embed_pe(payload, out_path, sign)
+  }
+  #[cfg(target_os = "linux")]
+  {
+    embed_elf(payload, out_path, sign)
+  }
+  #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+  {
+    let _ = (payload, out_path, sign);
+    Err("pak: unsupported platform".into())
+  }
+}
+
+/// Detect and return the payload embedded in *this* executable, if any.
+/// Returns `Ok(None)` for a plain (un-packed) `shards` binary.
+pub fn load_self_payload() -> Result<Option<Vec<u8>>, Error> {
+  #[cfg(target_os = "macos")]
+  {
+    extract_macho()
+  }
+  #[cfg(target_os = "windows")]
+  {
+    extract_pe()
+  }
+  #[cfg(target_os = "linux")]
+  {
+    extract_elf()
+  }
+  #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+  {
+    Ok(None)
+  }
+}
+
+/// Build the 16-byte trailer `[u64 LE payload_len][8-byte magic]`.
+fn make_footer(payload_len: usize) -> [u8; 16] {
+  let mut footer = [0u8; 16];
+  footer[0..8].copy_from_slice(&(payload_len as u64).to_le_bytes());
+  footer[8..16].copy_from_slice(PAK_MAGIC);
+  footer
+}
+
+/// Mark a file executable on Unix (no-op elsewhere).
+#[allow(unused_variables)]
+fn set_executable(path: &str) -> Result<(), Error> {
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)?;
+  }
+  Ok(())
+}
+
+// =============================================================================
+// macOS — embed inside __LINKEDIT, then codesign
+// =============================================================================
+
+#[cfg(target_os = "macos")]
+mod macho {
+  pub const MH_MAGIC_64: u32 = 0xFEED_FACF;
+  pub const FAT_MAGIC: u32 = 0xCAFE_BABE;
+  pub const FAT_CIGAM: u32 = 0xBEBA_FECA;
+  pub const LC_SEGMENT_64: u32 = 0x19;
+  pub const LC_CODE_SIGNATURE: u32 = 0x1D;
+  pub const HEADER_64_SIZE: usize = 32;
+  pub const PAGE_SIZE: u64 = 0x4000; // 16 KiB pages on arm64 macOS
+
+  #[inline]
+  pub fn u32_at(b: &[u8], o: usize) -> u32 {
+    u32::from_le_bytes(b[o..o + 4].try_into().unwrap())
+  }
+  #[inline]
+  pub fn u64_at(b: &[u8], o: usize) -> u64 {
+    u64::from_le_bytes(b[o..o + 8].try_into().unwrap())
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn embed_macho(payload: &[u8], out_path: &str, sign: &SignOpts) -> Result<(), Error> {
+  use macho::*;
+
+  let exe = std::env::current_exe()?;
+  std::fs::copy(&exe, out_path)?;
+
+  // Strip the existing signature so the file ends exactly at the __LINKEDIT data.
+  let _ = std::process::Command::new("codesign")
+    .args(["--remove-signature", out_path])
+    .output();
+
+  let mut data = std::fs::read(out_path)?;
+  if data.len() < HEADER_64_SIZE {
+    return Err("pak: host executable too small".into());
+  }
+  let magic = u32_at(&data, 0);
+  if magic == FAT_MAGIC || magic == FAT_CIGAM {
+    return Err("pak: universal (fat) Mach-O is not supported; pak a thin (single-arch) `shards`".into());
+  }
+  if magic != MH_MAGIC_64 {
+    return Err("pak: host executable is not a 64-bit Mach-O".into());
+  }
+
+  // Locate the __LINKEDIT segment load command.
+  let ncmds = u32_at(&data, 16) as usize;
+  let mut off = HEADER_64_SIZE;
+  let mut le_off = None;
+  for _ in 0..ncmds {
+    if off + 8 > data.len() {
+      break;
+    }
+    let cmd = u32_at(&data, off);
+    let cmdsize = u32_at(&data, off + 4) as usize;
+    if cmdsize == 0 {
+      break;
+    }
+    if cmd == LC_SEGMENT_64 && data[off + 8..off + 24].starts_with(b"__LINKEDIT") {
+      le_off = Some(off);
+    }
+    off += cmdsize;
+  }
+  let le_off = le_off.ok_or("pak: no __LINKEDIT segment found")?;
+  // segment_command_64: ... vmsize@32, fileoff@40, filesize@48
+  let vmsize = u64_at(&data, le_off + 32);
+  let fileoff = u64_at(&data, le_off + 40);
+  let filesize = u64_at(&data, le_off + 48);
+  let le_end = (fileoff + filesize) as usize;
+  if le_end > data.len() {
+    return Err("pak: malformed __LINKEDIT (extends past EOF)".into());
+  }
+
+  // After stripping the signature the file ends at the __LINKEDIT data; drop slack.
+  data.truncate(le_end);
+
+  // Append [pad][payload][footer] so that the 16-byte footer ends on a 16-byte
+  // boundary and the payload sits immediately before the footer. codesign aligns
+  // the signature to 16 bytes and places it right after, so at runtime the footer
+  // is exactly at `LC_CODE_SIGNATURE.dataoff - 16`.
+  let footer = make_footer(payload.len());
+  let unaligned_footer_start = data.len() + payload.len();
+  let pad = (16 - (unaligned_footer_start % 16)) % 16;
+  data.extend(std::iter::repeat(0u8).take(pad));
+  data.extend_from_slice(payload);
+  data.extend_from_slice(&footer);
+
+  // Grow __LINKEDIT to cover the appended bytes.
+  let added = (data.len() - le_end) as u64;
+  let new_filesize = filesize + added;
+  let mut new_vmsize = vmsize + added;
+  if new_vmsize % PAGE_SIZE != 0 {
+    new_vmsize = (new_vmsize + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+  }
+  data[le_off + 32..le_off + 40].copy_from_slice(&new_vmsize.to_le_bytes());
+  data[le_off + 48..le_off + 56].copy_from_slice(&new_filesize.to_le_bytes());
+
+  std::fs::write(out_path, &data)?;
+  set_executable(out_path)?;
+
+  // (Re-)sign so the payload is inside the signed region.
+  if !sign.no_sign {
+    let identity = sign.identity.as_deref().unwrap_or("-");
+    let out = std::process::Command::new("codesign")
+      .args(["--force", "--timestamp=none", "--sign", identity, out_path])
+      .output()?;
+    if !out.status.success() {
+      return Err(format!(
+        "pak: codesign failed: {}",
+        String::from_utf8_lossy(&out.stderr).trim()
+      )
+      .into());
+    }
+    if sign.notarize {
+      notarize_macos(out_path, sign)?;
+    }
+  }
+  Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn notarize_macos(path: &str, sign: &SignOpts) -> Result<(), Error> {
+  let profile = sign
+    .notarize_profile
+    .as_deref()
+    .ok_or("pak: --notarize requires --notarize-profile <keychain-profile>")?;
+  shards::shlog!("Submitting {} for notarization (profile {})", path, profile);
+  let out = std::process::Command::new("xcrun")
+    .args(["notarytool", "submit", path, "--keychain-profile", profile, "--wait"])
+    .output()?;
+  if !out.status.success() {
+    return Err(format!(
+      "pak: notarization failed: {}",
+      String::from_utf8_lossy(&out.stderr).trim()
+    )
+    .into());
+  }
+  // Stapling a bare executable is not supported (only bundles/dmgs); the ticket is
+  // served online. We still surface notarytool output for the user.
+  shards::shlog!("{}", String::from_utf8_lossy(&out.stdout).trim());
+  Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn extract_macho() -> Result<Option<Vec<u8>>, Error> {
+  use macho::*;
+  use std::io::Read;
+
+  let exe = std::env::current_exe()?;
+  let mut f = std::fs::File::open(&exe)?;
+
+  let mut header = [0u8; HEADER_64_SIZE];
+  if f.read_exact(&mut header).is_err() {
+    return Ok(None);
+  }
+  if u32_at(&header, 0) != MH_MAGIC_64 {
+    return Ok(None); // not a thin 64-bit Mach-O; nothing we can do
+  }
+  let ncmds = u32_at(&header, 16) as usize;
+  let sizeofcmds = u32_at(&header, 20) as usize;
+  let mut cmds = vec![0u8; sizeofcmds];
+  if f.read_exact(&mut cmds).is_err() {
+    return Ok(None);
+  }
+
+  // Find the code signature offset (the payload footer is right before it).
+  let mut off = 0usize;
+  let mut sig_dataoff: Option<u64> = None;
+  for _ in 0..ncmds {
+    if off + 8 > cmds.len() {
+      break;
+    }
+    let cmd = u32_at(&cmds, off);
+    let cmdsize = u32_at(&cmds, off + 4) as usize;
+    if cmd == LC_CODE_SIGNATURE {
+      sig_dataoff = Some(u32_at(&cmds, off + 8) as u64);
+    }
+    if cmdsize == 0 {
+      break;
+    }
+    off += cmdsize;
+  }
+
+  let total = f.metadata()?.len();
+  // Try the footer just before the signature first, then the bare EOF (unsigned).
+  for footer_end in [sig_dataoff, Some(total)].into_iter().flatten() {
+    if let Some(p) = read_footer_payload(&mut f, footer_end)? {
+      return Ok(Some(p));
+    }
+  }
+  Ok(None)
+}
+
+/// Read a payload whose 16-byte footer ends at `footer_end`. Returns `None` if
+/// the magic does not match.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn read_footer_payload(
+  f: &mut std::fs::File,
+  footer_end: u64,
+) -> Result<Option<Vec<u8>>, Error> {
+  use std::io::{Read, Seek, SeekFrom};
+  if footer_end < 16 {
+    return Ok(None);
+  }
+  f.seek(SeekFrom::Start(footer_end - 16))?;
+  let mut footer = [0u8; 16];
+  if f.read_exact(&mut footer).is_err() {
+    return Ok(None);
+  }
+  if &footer[8..16] != PAK_MAGIC {
+    return Ok(None);
+  }
+  let plen = u64::from_le_bytes(footer[0..8].try_into().unwrap());
+  if plen == 0 || plen + 16 > footer_end {
+    return Ok(None);
+  }
+  f.seek(SeekFrom::Start(footer_end - 16 - plen))?;
+  let mut payload = vec![0u8; plen as usize];
+  f.read_exact(&mut payload)?;
+  Ok(Some(payload))
+}
+
+// =============================================================================
+// Linux — real .shards_pak section via objcopy when available, else an overlay
+// =============================================================================
+
+#[cfg(target_os = "linux")]
+fn embed_elf(payload: &[u8], out_path: &str, _sign: &SignOpts) -> Result<(), Error> {
+  let exe = std::env::current_exe()?;
+  std::fs::copy(&exe, out_path)?;
+
+  // Prefer a proper, named ELF section if an objcopy is on PATH.
+  if let Some(objcopy) = ["objcopy", "llvm-objcopy"]
+    .into_iter()
+    .find(|c| which(c).is_some())
+  {
+    let tmp = format!("{}.pak.bin", out_path);
+    // The section payload carries its own footer so the runtime can validate it.
+    let mut blob = Vec::with_capacity(payload.len() + 16);
+    blob.extend_from_slice(payload);
+    blob.extend_from_slice(&make_footer(payload.len()));
+    std::fs::write(&tmp, &blob)?;
+    // A plain --add-section creates a non-allocated read-only section, which is
+    // exactly what we want: the runtime reads it by file offset from
+    // /proc/self/exe, so it never needs to be mapped into the process image.
+    let status = std::process::Command::new(objcopy)
+      .arg("--add-section")
+      .arg(format!("{}={}", PAK_SECTION, tmp))
+      .arg(out_path)
+      .arg(out_path)
+      .status();
+    let _ = std::fs::remove_file(&tmp);
+    if matches!(status, Ok(s) if s.success()) {
+      set_executable(out_path)?;
+      return Ok(());
+    }
+    // fall through to overlay on objcopy failure
+  }
+
+  // Fallback: append the payload + footer as an overlay (harmless on ELF).
+  let mut data = std::fs::read(out_path)?;
+  let footer = make_footer(payload.len());
+  data.extend_from_slice(payload);
+  data.extend_from_slice(&footer);
+  std::fs::write(out_path, &data)?;
+  set_executable(out_path)?;
+  Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn extract_elf() -> Result<Option<Vec<u8>>, Error> {
+  let mut f = std::fs::File::open("/proc/self/exe")?;
+
+  // First try the named .shards_pak section.
+  if let Some((sec_off, sec_size)) = elf_find_section(&mut f, PAK_SECTION)? {
+    if sec_size >= 16 {
+      if let Some(p) = read_footer_payload(&mut f, sec_off + sec_size)? {
+        return Ok(Some(p));
+      }
+    }
+  }
+
+  // Fallback: overlay at EOF.
+  let total = f.metadata()?.len();
+  if let Some(p) = read_footer_payload(&mut f, total)? {
+    return Ok(Some(p));
+  }
+  Ok(None)
+}
+
+/// Minimal ELF64 section lookup by name. Returns `(file_offset, size)`.
+#[cfg(target_os = "linux")]
+fn elf_find_section(
+  f: &mut std::fs::File,
+  name: &str,
+) -> Result<Option<(u64, u64)>, Error> {
+  use std::io::{Read, Seek, SeekFrom};
+
+  let mut ident = [0u8; 64];
+  f.seek(SeekFrom::Start(0))?;
+  if f.read_exact(&mut ident).is_err() {
+    return Ok(None);
+  }
+  if &ident[0..4] != b"\x7fELF" || ident[4] != 2 {
+    return Ok(None); // not ELF64
+  }
+  let rd_u16 = |b: &[u8], o: usize| u16::from_le_bytes(b[o..o + 2].try_into().unwrap());
+  let rd_u64 = |b: &[u8], o: usize| u64::from_le_bytes(b[o..o + 8].try_into().unwrap());
+  // ELF64 header: e_shoff@40, e_shentsize@58, e_shnum@60, e_shstrndx@62
+  let e_shoff = rd_u64(&ident, 40);
+  let e_shentsize = rd_u16(&ident, 58) as u64;
+  let e_shnum = rd_u16(&ident, 60) as u64;
+  let e_shstrndx = rd_u16(&ident, 62) as u64;
+  if e_shoff == 0 || e_shnum == 0 {
+    return Ok(None);
+  }
+
+  // Read the section header table.
+  let sh_table_size = (e_shentsize * e_shnum) as usize;
+  let mut sh = vec![0u8; sh_table_size];
+  f.seek(SeekFrom::Start(e_shoff))?;
+  f.read_exact(&mut sh)?;
+
+  // Locate the section header string table (.shstrtab).
+  let shstr_hdr = (e_shstrndx * e_shentsize) as usize;
+  // section_header: sh_offset@24, sh_size@32
+  let shstr_off = rd_u64(&sh, shstr_hdr + 24);
+  let shstr_size = rd_u64(&sh, shstr_hdr + 32);
+  let mut shstr = vec![0u8; shstr_size as usize];
+  f.seek(SeekFrom::Start(shstr_off))?;
+  f.read_exact(&mut shstr)?;
+
+  for i in 0..e_shnum as usize {
+    let base = i * e_shentsize as usize;
+    let name_off = u32::from_le_bytes(sh[base..base + 4].try_into().unwrap()) as usize;
+    let end = shstr[name_off..].iter().position(|&c| c == 0).unwrap_or(0) + name_off;
+    if &shstr[name_off..end] == name.as_bytes() {
+      let off = rd_u64(&sh, base + 24);
+      let size = rd_u64(&sh, base + 32);
+      return Ok(Some((off, size)));
+    }
+  }
+  Ok(None)
+}
+
+#[cfg(target_os = "linux")]
+fn which(cmd: &str) -> Option<std::path::PathBuf> {
+  let path = std::env::var_os("PATH")?;
+  for dir in std::env::split_paths(&path) {
+    let candidate = dir.join(cmd);
+    if candidate.is_file() {
+      return Some(candidate);
+    }
+  }
+  None
+}
+
+// =============================================================================
+// Windows — payload as an RT_RCDATA resource via UpdateResource
+// =============================================================================
+
+// RT_RCDATA == MAKEINTRESOURCE(10); resource type/name are PCWSTR (= *const u16)
+// values whose integer lives in the low word.
+#[cfg(target_os = "windows")]
+const RT_RCDATA_W: *const u16 = 10usize as *const u16;
+
+#[cfg(target_os = "windows")]
+fn embed_pe(payload: &[u8], out_path: &str, sign: &SignOpts) -> Result<(), Error> {
+  use std::os::windows::ffi::OsStrExt;
+  use windows_sys::Win32::System::LibraryLoader::{
+    BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
+  };
+
+  let exe = std::env::current_exe()?;
+  std::fs::copy(&exe, out_path)?;
+
+  let wide: Vec<u16> = std::path::Path::new(out_path)
+    .as_os_str()
+    .encode_wide()
+    .chain(std::iter::once(0))
+    .collect();
+
+  // The resource payload carries its own footer (for symmetry / validation).
+  let mut blob = Vec::with_capacity(payload.len() + 16);
+  blob.extend_from_slice(payload);
+  blob.extend_from_slice(&make_footer(payload.len()));
+
+  let res_name = PAK_RESOURCE_ID as usize as *const u16;
+
+  unsafe {
+    let h = BeginUpdateResourceW(wide.as_ptr(), 0);
+    if h.is_null() {
+      return Err("pak: BeginUpdateResource failed".into());
+    }
+    let ok = UpdateResourceW(
+      h,
+      RT_RCDATA_W,
+      res_name,
+      0, // neutral language
+      blob.as_ptr().cast(),
+      blob.len() as u32,
+    );
+    if ok == 0 {
+      EndUpdateResourceW(h, 1);
+      return Err("pak: UpdateResource failed".into());
+    }
+    if EndUpdateResourceW(h, 0) == 0 {
+      return Err("pak: EndUpdateResource failed".into());
+    }
+  }
+
+  // Authenticode signing (optional; user supplies the certificate).
+  if !sign.no_sign {
+    if let Some(identity) = sign.identity.as_deref() {
+      let out = std::process::Command::new("signtool")
+        .args(["sign", "/fd", "SHA256", "/n", identity, out_path])
+        .output()?;
+      if !out.status.success() {
+        return Err(format!(
+          "pak: signtool failed: {}",
+          String::from_utf8_lossy(&out.stderr).trim()
+        )
+        .into());
+      }
+    }
+  }
+  Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn extract_pe() -> Result<Option<Vec<u8>>, Error> {
+  use windows_sys::Win32::System::LibraryLoader::{
+    FindResourceW, GetModuleHandleW, LoadResource, LockResource, SizeofResource,
+  };
+
+  let res_name = PAK_RESOURCE_ID as usize as *const u16;
+
+  unsafe {
+    let module = GetModuleHandleW(std::ptr::null());
+    // FindResourceW(hModule, lpName, lpType)
+    let res = FindResourceW(module, res_name, RT_RCDATA_W);
+    if res.is_null() {
+      return Ok(None);
+    }
+    let size = SizeofResource(module, res) as usize;
+    let handle = LoadResource(module, res);
+    if handle.is_null() || size < 16 {
+      return Ok(None);
+    }
+    let ptr = LockResource(handle) as *const u8;
+    if ptr.is_null() {
+      return Ok(None);
+    }
+    let blob = std::slice::from_raw_parts(ptr, size);
+    // Validate footer and strip it.
+    let footer = &blob[size - 16..];
+    if &footer[8..16] != PAK_MAGIC {
+      return Ok(None);
+    }
+    let plen = u64::from_le_bytes(footer[0..8].try_into().unwrap()) as usize;
+    if plen == 0 || plen + 16 > size {
+      return Ok(None);
+    }
+    Ok(Some(blob[size - 16 - plen..size - 16].to_vec()))
+  }
+}

--- a/shards/tests/pak.sh
+++ b/shards/tests/pak.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Smoke-test `shards pak` (single-file packaging) on the current platform.
+#
+# Packs a script (which also embeds a resource via @read), then runs the produced
+# standalone binary from a clean directory — with neither the source script nor
+# the resource file present — and verifies:
+#   * the embedded script executes (marker on stdout),
+#   * a compile-time @read resource is baked in (correct byte count),
+#   * extra argv does not break execution,
+#   * (macOS) the produced Mach-O has a valid code signature.
+#
+# Usage: shards/tests/pak.sh [path-to-shards]   (default: ./shards)
+# Runnable locally and from CI (Windows via Git Bash; `.exe` is auto-resolved).
+
+set -euo pipefail
+
+SHARDS="${1:-./shards}"
+# Resolve `.exe` on Windows/Git Bash, then make it an absolute path.
+if [ ! -e "$SHARDS" ] && [ -e "${SHARDS}.exe" ]; then
+  SHARDS="${SHARDS}.exe"
+fi
+if [ ! -e "$SHARDS" ]; then
+  echo "pak.sh: shards binary not found: $SHARDS" >&2
+  exit 1
+fi
+SHARDS="$(cd "$(dirname "$SHARDS")" && pwd)/$(basename "$SHARDS")"
+chmod +x "$SHARDS" 2>/dev/null || true
+
+WORK="$(mktemp -d 2>/dev/null || mktemp -d -t pak)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+MARKER="PAK_SMOKE_OK_42"
+
+# A binary resource to embed at compile time via @read.
+printf 'shards-pak-embedded-resource-payload' > asset.bin   # 36 bytes
+ASSET_LEN="$(wc -c < asset.bin | tr -d '[:space:]')"
+
+cat > app.shs <<EOF
+@wire(main {
+  @read("asset.bin" Bytes: true) | Count | Log("asset-bytes")
+  "${MARKER}" | Log
+} Looped: false)
+@mesh(root)
+@schedule(root main)
+@run(root)
+EOF
+
+echo "== packing =="
+# Default output naming: `app` (Unix) / `app.exe` (Windows) from the script stem.
+"$SHARDS" pak app.shs
+
+APP="app"
+[ -e "app.exe" ] && APP="app.exe"
+[ -e "$APP" ] || { echo "pak.sh: packed binary '$APP' was not produced" >&2; exit 1; }
+
+# Run from a pristine directory that contains neither app.shs nor asset.bin,
+# proving the single binary is self-contained.
+mkdir run
+cp "$APP" run/
+(
+  cd run
+  echo "== running packed binary (no source/resource present) =="
+  OUT="$("./$APP" extra:ignored 2>&1 || true)"
+  echo "$OUT"
+
+  echo "$OUT" | grep -q "$MARKER" \
+    || { echo "FAIL: marker '$MARKER' not found in output" >&2; exit 1; }
+  echo "$OUT" | grep -q "asset-bytes: ${ASSET_LEN}" \
+    || { echo "FAIL: embedded @read resource missing (expected ${ASSET_LEN} bytes)" >&2; exit 1; }
+
+  # macOS: the produced binary must be a validly signed Mach-O.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    echo "== verifying code signature =="
+    codesign --verify --verbose "$APP" \
+      || { echo "FAIL: codesign --verify rejected the packed binary" >&2; exit 1; }
+  fi
+)
+
+echo "PASS: shards pak smoke test"


### PR DESCRIPTION
## `shards pak` — single-file Shards apps

Turn any Shards script into a standalone, signed executable with one command:

```sh
shards pak main.shs     # -> ./main (or main.exe)
./main                  # runs the embedded script — no interpreter, no runtime files
```

The `shards` binary already *is* the runtime, so packing compiles no C/C++: it embeds the compiled `.sho` into a copy of the running `shards` using each platform's **native container** (no end-of-file overlay, so the binary stays structurally valid and signable / AV-friendly).

### Embedding

| Platform | Container | Runtime lookup | Signing |
|----------|-----------|----------------|---------|
| macOS | inside `__LINKEDIT` (grown to cover it) | just before `LC_CODE_SIGNATURE.dataoff` | `codesign` (ad-hoc default) |
| Windows | `RT_RCDATA` resource (`UpdateResource`) | `FindResource`/`LoadResource` | `signtool` (Authenticode) |
| Linux | `.shards_pak` ELF section (`objcopy`, overlay fallback) | section in `/proc/self/exe` | n/a |

A startup self-check in `process_args` detects an embedded payload and runs it directly (extra argv → script defines). A plain `shards` binary has no payload, so the check returns instantly.

**Why not just append to EOF?** macOS `codesign` rejects trailing data ("main executable failed strict validation"), so the payload must live *inside* a segment and *before* the signature — growing `__LINKEDIT` does exactly that, so `codeLimit` covers it. Verified: packed binaries report `codesign --verify` → *valid on disk*.

### Signing

`--sign <identity>` (macOS Developer ID / Windows subject), `--no-sign`, `--notarize` + `--notarize-profile` (macOS). Default is ad-hoc, so the binary always runs locally; real certs plug in at sign time. (Ad-hoc makes it *valid*; Gatekeeper/SmartScreen *reputation* still needs a real identity + notarization.)

### Resources

`@include` and `@read("x" Bytes: true)` resolve at parse time and are baked into the `.sho` — use `@read` to embed assets. Runtime path-loads (`LoadImage`, `FS.Read`) are **not** embedded (there is no VFS in shards-core).

### Tests

`shards/tests/pak.sh` packs a script (which `@read`s a resource), runs the produced binary **from a clean directory** with neither the source nor the asset present, and asserts the marker output, the embedded resource byte count, that extra argv doesn't break it, and — on macOS — that `codesign --verify` passes. Wired into the Linux/macOS/Windows build test jobs.

### Validation status

- **macOS (arm64):** validated on-device — `codesign --verify` valid, runs, self-contained, `@read` resources embed correctly.
- **Linux / Windows:** implemented and cross-compile **type-checked** (`x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`); the CI smoke test added here exercises the real section/resource round-trip on those runners.

Docs: `docs/shards-pak.md`.

---

**Stacked on #1279** — base is `deps/bump-spdlog-fmt11` so this diff is pak-only. Retarget to `devel` once #1279 merges.
