### PR TITLE
deps: bump wgpu to v29 and egui to 0.34

### DIFF
--- a/cmake/rust/union_Cargo.toml.in
+++ b/cmake/rust/union_Cargo.toml.in
@@ -28,6 +28,10 @@ memmap2 = { git = "https://github.com/sinkingsugar/memmap2-rs.git", version = "=
 # Graphics patches
 objc = { git = "https://github.com/shards-lang/rust-objc.git", version = "=0.2.7", branch = "shards-0.2.7" }
 metal = { git = "https://github.com/shards-lang/metal-rs.git", version = "=0.29.0", branch = "shards-0.29.0" }
+# gpu-allocator fork pins windows-rs to 0.62 so its D3D12 types match wgpu-hal
+# v29; otherwise cargo splits it onto sysinfo's windows <0.62 and the D3D12
+# build fails (D3D12_RESOURCE_DESC / ID3D12Heap type mismatch).
+gpu-allocator = { git = "https://github.com/shards-lang/gpu-allocator.git", rev = "55d1615cb77b532cef4033eb071ddf40aca6dcae" }
 
 tracy-client = { git = "https://github.com/nagisa/rust_tracy_client", tag = "tracy-client-v0.15.0" }
 

--- a/shards/egui/Cargo.toml
+++ b/shards/egui/Cargo.toml
@@ -11,13 +11,12 @@ crate-type = ["rlib", "staticlib"]
 
 [dependencies]
 lazy_static = "1.5.0"
-egui = { version = "0.28.1", features = ["persistence"] }
-egui_commonmark = { git = "https://github.com/shards-lang/egui_commonmark.git", rev = "e5bc996b97bf60c12978517a5d9b1a86eb277b1b", version = "0.17.0", features = ["better_syntax_highlighting"]}
-# egui_commonmark = { path = "../../../egui_commonmark/egui_commonmark", version = "0.17.0", features = ["better_syntax_highlighting"]}
-egui_dock = { version = "0.13.0", features = ["serde"] }
-egui_extras = { version = "0.28.1", features = ["serde"] }
-egui_memory_editor = { version = "0.2.9", git = "https://github.com/shards-lang/egui_memory_editor.git", rev = "5e43457129fd415b827c23370b791ad0c96fab96" }
-egui_plot = { version = "0.28.1" }
+egui = { version = "0.34", features = ["persistence"] }
+egui_commonmark = { version = "0.23", features = ["better_syntax_highlighting"] }
+egui_dock = { version = "0.19", features = ["serde"] }
+egui_extras = { version = "0.34", features = ["serde"] }
+egui_memory_editor = { path = "../../../egui_memory_editor" }
+egui_plot = { version = "0.35" }
 syntect = { version = "5.2.0", default-features = false, features = [
     "default-fancy",
 ] }

--- a/shards/egui/Cargo.toml
+++ b/shards/egui/Cargo.toml
@@ -15,7 +15,7 @@ egui = { version = "0.34", features = ["persistence"] }
 egui_commonmark = { version = "0.23", features = ["better_syntax_highlighting"] }
 egui_dock = { version = "0.19", features = ["serde"] }
 egui_extras = { version = "0.34", features = ["serde"] }
-egui_memory_editor = { path = "../../../egui_memory_editor" }
+egui_memory_editor = { git = "https://github.com/shards-lang/egui_memory_editor.git", branch = "shards-0.34" }
 egui_plot = { version = "0.35" }
 syntect = { version = "5.2.0", default-features = false, features = [
     "default-fancy",

--- a/shards/egui/src/bindings/input.rs
+++ b/shards/egui/src/bindings/input.rs
@@ -197,6 +197,8 @@ pub fn translate_raw_input(input: &egui_Input) -> Result<egui::RawInput, Transla
           Some(Event::MouseWheel {
             unit: egui::MouseWheelUnit::Point,
             delta: egui::vec2(virtual_delta_x, virtual_delta_y),
+            // egui >=0.31 requires a scroll phase; SDL gives no phase info.
+            phase: egui::TouchPhase::Move,
             modifiers: Modifiers::default(),
           })
         }
@@ -278,6 +280,7 @@ pub fn translate_raw_input(input: &egui_Input) -> Result<egui::RawInput, Transla
       map.insert(ViewportId::default(), info);
       map
     },
+    ..Default::default()
   })
 }
 

--- a/shards/egui/src/bindings/renderer.rs
+++ b/shards/egui/src/bindings/renderer.rs
@@ -137,16 +137,13 @@ fn convert_texture_set(
   id: epaint::TextureId,
   delta: &epaint::ImageDelta,
 ) -> Result<egui_TextureSet, &'static str> {
+  // egui >=0.31 delivers all textures (including the font atlas) as a
+  // premultiplied RGBA8 `ColorImage`; the old single-channel font image is gone.
   let (format, ptr, size) = match &delta.image {
     epaint::ImageData::Color(color) => {
       let ptr = color.pixels.as_ptr();
       let size = color.size;
       (egui_TextureFormat_RGBA8, ptr as *const u8, size)
-    }
-    epaint::ImageData::Font(font) => {
-      let ptr = font.pixels.as_ptr();
-      let size = font.size;
-      (egui_TextureFormat_R32F, ptr as *const u8, size)
     }
   };
 
@@ -228,16 +225,21 @@ pub fn make_native_io_output(
   input: &egui::FullOutput,
 ) -> Result<NativeIOOutput, &'static str> {
   let platform_output = &input.platform_output;
-  let open_url = match &platform_output.open_url {
-    Some(url) => Some(CString::new(url.url.as_str()).unwrap()),
-    None => None,
-  };
-
-  let copied_text = if platform_output.copied_text.len() > 0 {
-    Some(CString::new(platform_output.copied_text.as_str()).unwrap())
-  } else {
-    None
-  };
+  // egui >=0.29 funnels open-url and clipboard requests through `commands`
+  // instead of dedicated `open_url`/`copied_text` fields.
+  let mut open_url = None;
+  let mut copied_text = None;
+  for cmd in &platform_output.commands {
+    match cmd {
+      egui::OutputCommand::OpenUrl(url) => {
+        open_url = Some(CString::new(url.url.as_str()).unwrap());
+      }
+      egui::OutputCommand::CopyText(text) => {
+        copied_text = Some(CString::new(text.as_str()).unwrap());
+      }
+      _ => {}
+    }
+  }
 
   let text_cursor_position = platform_output.ime.map(|ime| egui_Pos2 {
     x: ime.cursor_rect.min.x,

--- a/shards/egui/src/containers/docking.rs
+++ b/shards/egui/src/containers/docking.rs
@@ -626,8 +626,8 @@ impl Shard for TabOpenShard {
 
     // Second pass: activate the found tab
     if let Some((surface_idx, node_index, tab_index)) = found_tab {
-      tabs.set_active_tab((surface_idx, node_index, tab_index));
-      tabs.set_focused_node_and_surface((surface_idx, node_index));
+      tabs.set_active_tab(egui_dock::TabPath::new(surface_idx, node_index, tab_index));
+      tabs.set_focused_node_and_surface(egui_dock::NodePath::new(surface_idx, node_index));
     }
 
     // Tab not found - this is not an error, just a no-op
@@ -733,7 +733,7 @@ impl Shard for TabCloseShard {
 
     // Second pass: remove the found tab
     if let Some((surface_idx, node_index, tab_index)) = found_tab {
-      tabs.remove_tab((surface_idx, node_index, tab_index));
+      tabs.remove_tab(egui_dock::TabPath::new(surface_idx, node_index, tab_index));
     }
 
     // Tab not found - this is not an error, just a no-op

--- a/shards/egui/src/containers/mod.rs
+++ b/shards/egui/src/containers/mod.rs
@@ -41,7 +41,8 @@ impl From<Order> for egui::Order {
   fn from(order: Order) -> Self {
     match order {
       Order::Background => egui::Order::Background,
-      Order::PanelResizeLine => egui::Order::PanelResizeLine,
+      // egui >=0.32 removed the dedicated PanelResizeLine order.
+      Order::PanelResizeLine => egui::Order::Middle,
       Order::Middle => egui::Order::Middle,
       Order::Foreground => egui::Order::Foreground,
       Order::Tooltip => egui::Order::Tooltip,

--- a/shards/egui/src/containers/popup_wrapper.rs
+++ b/shards/egui/src/containers/popup_wrapper.rs
@@ -187,7 +187,7 @@ impl Shard for PopupWrapper {
           let above_or_below: PopupLocation = self.above_or_below.get().try_into()?;
           above_or_below.into()
         };
-        if let Some(inner) = egui::popup::popup_above_or_below_widget(
+        if let Some(inner) = egui::popup_above_or_below_widget(
           ui,
           *popup_id,
           &response,

--- a/shards/egui/src/dnd/mod.rs
+++ b/shards/egui/src/dnd/mod.rs
@@ -164,15 +164,13 @@ pub fn drop_target<R>(
 
       ui.painter().set(
         where_to_put_background,
-        epaint::RectShape {
+        epaint::RectShape::new(
           rect,
-          rounding: style.rounding,
+          style.corner_radius,
+          fill,
           stroke,
-          fill: fill.into(),
-          fill_texture_id: egui::TextureId::Managed(0),
-          uv: Rect::ZERO,
-          blur_width: 0.0,
-        },
+          egui::StrokeKind::Inside,
+        ),
       );
     }
   }

--- a/shards/egui/src/layouts/frame.rs
+++ b/shards/egui/src/layouts/frame.rs
@@ -243,32 +243,37 @@ impl LegacyShard for Frame {
       let inner_margin = if inner_margin.is_none() {
         egui::Margin::default()
       } else {
-        let (left, right, top, bottom) = inner_margin.try_into()?;
+        let (left, right, top, bottom): (f32, f32, f32, f32) = inner_margin.try_into()?;
         egui::Margin {
-          left,
-          right,
-          top,
-          bottom,
+          left: left as i8,
+          right: right as i8,
+          top: top as i8,
+          bottom: bottom as i8,
         }
       };
       let outer_margin = self.outer_margin.get();
       let outer_margin = if outer_margin.is_none() {
         egui::Margin::default()
       } else {
-        let (left, right, top, bottom) = outer_margin.try_into()?;
+        let (left, right, top, bottom): (f32, f32, f32, f32) = outer_margin.try_into()?;
         egui::Margin {
-          left,
-          right,
-          top,
-          bottom,
+          left: left as i8,
+          right: right as i8,
+          top: top as i8,
+          bottom: bottom as i8,
         }
       };
       let rounding = self.rounding.get();
-      let rounding = if rounding.is_none() {
-        ui.style().visuals.widgets.noninteractive.rounding
+      let corner_radius = if rounding.is_none() {
+        ui.style().visuals.widgets.noninteractive.corner_radius
       } else {
-        let (nw, ne, sw, se) = rounding.try_into()?;
-        egui::epaint::Rounding { nw, ne, sw, se }
+        let (nw, ne, sw, se): (f32, f32, f32, f32) = rounding.try_into()?;
+        egui::epaint::CornerRadius {
+          nw: nw as u8,
+          ne: ne as u8,
+          sw: sw as u8,
+          se: se as u8,
+        }
       };
       let fill: &shards::SHVar = self.fill_color.get();
       let fill = if fill.is_none() {
@@ -297,7 +302,7 @@ impl LegacyShard for Frame {
       let frame = egui::Frame {
         inner_margin,
         outer_margin,
-        rounding,
+        corner_radius,
         fill,
         stroke,
         ..Default::default()

--- a/shards/egui/src/lib.rs
+++ b/shards/egui/src/lib.rs
@@ -182,6 +182,10 @@ impl<'a> egui::TextBuffer for VarTextBuffer<'a> {
     false
   }
 
+  fn type_id(&self) -> std::any::TypeId {
+    std::any::TypeId::of::<VarTextBuffer<'static>>()
+  }
+
   fn as_str(&self) -> &str {
     self.0.as_ref().try_into().unwrap_or_default()
   }
@@ -197,6 +201,10 @@ impl<'a> egui::TextBuffer for VarTextBuffer<'a> {
 impl<'a> egui::TextBuffer for MutVarTextBuffer<'a> {
   fn is_mutable(&self) -> bool {
     true
+  }
+
+  fn type_id(&self) -> std::any::TypeId {
+    std::any::TypeId::of::<MutVarTextBuffer<'static>>()
   }
 
   fn as_str(&self) -> &str {
@@ -353,7 +361,8 @@ impl From<Order> for egui::Order {
   fn from(value: Order) -> Self {
     match value {
       Order::Background => egui::Order::Background,
-      Order::PanelResizeLine => egui::Order::PanelResizeLine,
+      // egui >=0.32 removed the dedicated PanelResizeLine order.
+      Order::PanelResizeLine => egui::Order::Middle,
       Order::Middle => egui::Order::Middle,
       Order::Foreground => egui::Order::Foreground,
       Order::Tooltip => egui::Order::Tooltip,

--- a/shards/egui/src/misc/add_font.rs
+++ b/shards/egui/src/misc/add_font.rs
@@ -102,7 +102,10 @@ impl LegacyShard for AddFont {
       let bytes: &[u8] = pair[1].as_ref().try_into()?;
       fonts
         .font_data
-        .insert(name.to_owned(), egui::FontData::from_static(bytes));
+        .insert(
+          name.to_owned(),
+          std::sync::Arc::new(egui::FontData::from_static(bytes)),
+        );
     }
 
     egui_ctx.set_fonts(fonts);

--- a/shards/egui/src/misc/painter.rs
+++ b/shards/egui/src/misc/painter.rs
@@ -92,12 +92,14 @@ impl Shard for CanvasShard {
 
     let mut ui = Ui::new(
       egui_ctx.clone(),
-      layer_id,
       layer_id.id,
-      egui::Rect::from_min_size(Pos2::new(x, y), Vec2::new(w, h)),
-      Rect::EVERYTHING,
-      UiStackInfo::default(),
+      egui::UiBuilder::new()
+        .layer_id(layer_id)
+        .max_rect(egui::Rect::from_min_size(Pos2::new(x, y), Vec2::new(w, h))),
     );
+    // egui >=0.31 moved Ui construction to UiBuilder; preserve the previous
+    // unclipped painter behaviour.
+    ui.set_clip_rect(Rect::EVERYTHING);
 
     util::activate_ui_contents(
       context,

--- a/shards/egui/src/misc/style.rs
+++ b/shards/egui/src/misc/style.rs
@@ -648,7 +648,7 @@ impl Shard for StyleShard {
     })?;
 
     when_set(&self.window_rounding, |v| {
-      Ok(visuals.window_rounding = into_rounding(v)?)
+      Ok(visuals.window_corner_radius = into_rounding(v)?)
     })?;
 
     when_set(&self.window_shadow, |v| {
@@ -660,7 +660,7 @@ impl Shard for StyleShard {
     })?;
 
     when_set(&self.menu_rounding, |v| {
-      Ok(visuals.menu_rounding = into_rounding(v)?)
+      Ok(visuals.menu_corner_radius = into_rounding(v)?)
     })?;
 
     when_set(&self.panel_fill, |v| {

--- a/shards/egui/src/misc/style_util.rs
+++ b/shards/egui/src/misc/style_util.rs
@@ -43,19 +43,19 @@ pub fn get_margin(
   margin: (f32, f32, f32, f32),
 ) -> Result<egui::Margin, &'static str> {
   Ok(egui::Margin {
-    left: margin.0,
-    right: margin.1,
-    top: margin.2,
-    bottom: margin.3,
+    left: margin.0 as i8,
+    right: margin.1 as i8,
+    top: margin.2 as i8,
+    bottom: margin.3 as i8,
   })
 }
 
-pub fn get_rounding(rounding: (f32, f32, f32, f32)) -> Result<egui::Rounding, &'static str> {
-  Ok(egui::Rounding {
-    nw: rounding.0,
-    ne: rounding.1,
-    sw: rounding.2,
-    se: rounding.3,
+pub fn get_rounding(rounding: (f32, f32, f32, f32)) -> Result<egui::CornerRadius, &'static str> {
+  Ok(egui::CornerRadius {
+    nw: rounding.0 as u8,
+    ne: rounding.1 as u8,
+    sw: rounding.2 as u8,
+    se: rounding.3 as u8,
   })
 }
 
@@ -63,13 +63,14 @@ pub fn get_shadow(shadow: Table) -> Result<egui::epaint::Shadow, &'static str> {
   if let (Some(extrusion), Some(color)) =
     (shadow.get_static("extrusion"), shadow.get_static("color"))
   {
+    let extrusion: f32 = extrusion.try_into().map_err(|e| {
+      shlog!("{}: {}", "extrusion", e);
+      "Invalid attribute value received"
+    })?;
     Ok(egui::epaint::Shadow {
-      blur: 0.0,
+      blur: 0,
       offset: Default::default(),
-      spread: extrusion.try_into().map_err(|e| {
-        shlog!("{}: {}", "extrusion", e);
-        "Invalid attribute value received"
-      })?,
+      spread: extrusion as u8,
       color: get_color(color.try_into().map_err(|e| {
         shlog!("{}: {}", "color", e);
         "Invalid attribute value received"

--- a/shards/egui/src/util.rs
+++ b/shards/egui/src/util.rs
@@ -216,10 +216,10 @@ pub fn into_vec2(v: &Var) -> Result<egui::Vec2, &'static str> {
 pub fn into_margin(v: &Var) -> Result<egui::Margin, &'static str> {
   let v: (f32, f32, f32, f32) = v.try_into()?;
   Ok(egui::Margin {
-    left: v.0,
-    right: v.1,
-    top: v.2,
-    bottom: v.3,
+    left: v.0 as i8,
+    right: v.1 as i8,
+    top: v.2 as i8,
+    bottom: v.3 as i8,
   })
 }
 
@@ -228,13 +228,13 @@ pub fn into_color(v: &Var) -> Result<egui::Color32, &'static str> {
   Ok(egui::Color32::from_rgba_premultiplied(v.r, v.g, v.b, v.a))
 }
 
-pub fn into_rounding(v: &Var) -> Result<egui::Rounding, &'static str> {
+pub fn into_rounding(v: &Var) -> Result<egui::CornerRadius, &'static str> {
   let v: (f32, f32, f32, f32) = v.try_into()?;
-  Ok(egui::Rounding {
-    nw: v.0,
-    ne: v.1,
-    sw: v.2,
-    se: v.3,
+  Ok(egui::CornerRadius {
+    nw: v.0 as u8,
+    ne: v.1 as u8,
+    sw: v.2 as u8,
+    se: v.3 as u8,
   })
 }
 
@@ -248,9 +248,9 @@ pub fn into_shadow(v: &Var, ctx: &Context) -> Result<egui::epaint::Shadow, &'sta
     ctx,
   ))?;
   Ok(egui::epaint::Shadow {
-    spread,
-    blur,
-    offset: egui::Vec2::ZERO,
+    spread: spread as u8,
+    blur: blur as u8,
+    offset: [0, 0],
     color,
   })
 }
@@ -281,7 +281,7 @@ pub fn apply_widget_visuals(
     visuals.bg_stroke = into_stroke(v, ctx)?;
   }
   if let Some(v) = tbl.get_static("Rounding") {
-    visuals.rounding = into_rounding(get_or_var(v, ctx))?;
+    visuals.corner_radius = into_rounding(get_or_var(v, ctx))?;
   }
   if let Some(v) = tbl.get_static("FGStroke") {
     visuals.fg_stroke = into_stroke(v, ctx)?;

--- a/shards/egui/src/widgets/code_editor/mod.rs
+++ b/shards/egui/src/widgets/code_editor/mod.rs
@@ -221,14 +221,15 @@ impl LegacyShard for CodeEditor {
       let id1 = EguiId::new(self, 0);
       let id2 = EguiId::new(self, 1);
 
-      let mut layouter = |ui: &egui::Ui, string: &str, wrap_width: f32| {
+      let mut layouter = |ui: &egui::Ui, buf: &dyn egui::TextBuffer, wrap_width: f32| {
+        let string = buf.as_str();
         let mut layout_job = if language == "shards" {
           highlight_shards(&theme, string)
         } else {
           highlight_generic(&theme, string, language)
         };
         layout_job.wrap.max_width = wrap_width;
-        ui.fonts(|f| f.layout_job(layout_job))
+        ui.fonts_mut(|f| f.layout_job(layout_job))
       };
       let mut mutable;
       let mut immutable;

--- a/shards/egui/src/widgets/combo.rs
+++ b/shards/egui/src/widgets/combo.rs
@@ -282,15 +282,15 @@ impl LegacyShard for Combo {
       if empty_seq {
         if *index != 0 {
           *index = 0;
-          response.changed = true;
+          response.mark_changed();
         }
       } else if *index >= seq.len() {
         // in fact if len == 0, we are fine to have -1 as a way to signal "no selection"
         *index = seq.len() - 1;
-        response.changed = true;
+        response.mark_changed();
       }
 
-      if response.changed {
+      if response.changed() {
         if self.index.is_variable() {
           self.index.set_fast_unsafe(&(*index as i64).into());
         } else {

--- a/shards/egui/src/widgets/console.rs
+++ b/shards/egui/src/widgets/console.rs
@@ -185,10 +185,11 @@ impl LegacyShard for Console {
       }
 
       let filters = self.filters.clone();
-      let mut layouter = |ui: &egui::Ui, string: &str, wrap_width: f32| {
+      let mut layouter = |ui: &egui::Ui, buf: &dyn egui::TextBuffer, wrap_width: f32| {
+        let string = buf.as_str();
         let mut layout_job = Console::highlight(ui.ctx(), &theme, string, filters);
         layout_job.wrap.max_width = wrap_width;
-        ui.fonts(|f| f.layout_job(layout_job))
+        ui.fonts_mut(|f| f.layout_job(layout_job))
       };
 
       let mut text: &str = input.try_into()?;
@@ -223,7 +224,7 @@ impl Console {
 
     ctx.memory_mut(|mem| {
       let highlight_cache = mem.caches.cache::<HighlightCache>();
-      highlight_cache.get((theme, code, filters))
+      highlight_cache.get((theme, code, filters)).clone()
     })
   }
 }

--- a/shards/egui/src/widgets/image_util.rs
+++ b/shards/egui/src/widgets/image_util.rs
@@ -163,7 +163,7 @@ fn into_egui_image(image: &SHImage) -> Result<egui::ColorImage, &'static str> {
       .chunks_exact(4)
       .map(|p| egui::Color32::from_rgba_premultiplied(p[0], p[1], p[2], p[3]))
       .collect();
-    Ok(egui::ColorImage { size, pixels })
+    Ok(egui::ColorImage::new(size, pixels))
   } else {
     Ok(egui::ColorImage::from_rgba_unmultiplied(size, rgba))
   }

--- a/shards/egui/src/widgets/listbox.rs
+++ b/shards/egui/src/widgets/listbox.rs
@@ -323,7 +323,7 @@ impl LegacyShard for ListBox {
                 }
               }
             } else {
-              let inner_margin = egui::Margin::same(3.0);
+              let inner_margin = egui::Margin::same(3);
               let background_id = ui.painter().add(egui::Shape::Noop);
               let outer_rect = ui.available_rect_before_wrap();
               let mut inner_rect = outer_rect;
@@ -350,15 +350,13 @@ impl LegacyShard for ListBox {
               let visuals = ui.style().interact_selectable(&response, is_selected);
               if is_selected || response.hovered() || response.has_focus() {
                 let rect = paint_rect.expand(visuals.expansion);
-                let shape = egui::Shape::Rect(egui::epaint::RectShape {
+                let shape = egui::Shape::Rect(egui::epaint::RectShape::new(
                   rect,
-                  rounding: visuals.rounding,
-                  fill: visuals.bg_fill,
-                  stroke: visuals.bg_stroke,
-                  fill_texture_id: egui::TextureId::Managed(0),
-                  uv: Rect::ZERO,
-                  blur_width: 0.0,
-                });
+                  visuals.corner_radius,
+                  visuals.bg_fill,
+                  visuals.bg_stroke,
+                  egui::StrokeKind::Inside,
+                ));
                 ui.painter().set(background_id, shape);
               }
 

--- a/shards/egui/src/widgets/markdown_viewer.rs
+++ b/shards/egui/src/widgets/markdown_viewer.rs
@@ -78,7 +78,7 @@ impl Shard for MarkdownViewerShard {
     if let Some(ui) = util::get_current_parent_opt(self.parents.get())? {
       let text: &str = input.try_into()?;
       MARKDOWN_CACHE.with(|cache| {
-        egui_commonmark::CommonMarkViewer::new(EguiId::new(self, 0))
+        egui_commonmark::CommonMarkViewer::new()
           .indentation_spaces(2)
           .syntax_theme_dark(THEME_DARK)
           .syntax_theme_light(THEME_LIGHT)

--- a/shards/egui/src/widgets/plots/plot_bar.rs
+++ b/shards/egui/src/widgets/plots/plot_bar.rs
@@ -180,6 +180,7 @@ impl LegacyShard for PlotBar {
     };
 
     let mut chart = egui_plot::BarChart::new(
+      "",
       points
         .map(|(x, y)| {
           let mut bar = egui_plot::Bar::new(x, y);

--- a/shards/egui/src/widgets/plots/plot_line.rs
+++ b/shards/egui/src/widgets/plots/plot_line.rs
@@ -149,7 +149,7 @@ impl LegacyShard for PlotLine {
       let v: (f64, f64) = x.as_ref().try_into().unwrap();
       [v.0, v.1]
     });
-    let mut chart = egui_plot::Line::new(egui_plot::PlotPoints::from_iter(points));
+    let mut chart = egui_plot::Line::new("", egui_plot::PlotPoints::from_iter(points));
 
     let color = self.color.get();
     if !color.is_none() {

--- a/shards/egui/src/widgets/plots/plot_points.rs
+++ b/shards/egui/src/widgets/plots/plot_points.rs
@@ -176,7 +176,7 @@ impl LegacyShard for PlotPoints {
       let v: (f64, f64) = x.as_ref().try_into().unwrap();
       [v.0, v.1]
     });
-    let mut chart = egui_plot::Points::new(egui_plot::PlotPoints::from_iter(points));
+    let mut chart = egui_plot::Points::new("", egui_plot::PlotPoints::from_iter(points));
 
     let name = self.name.get();
     if !name.is_none() {

--- a/shards/egui/src/widgets/var_util.rs
+++ b/shards/egui/src/widgets/var_util.rs
@@ -117,7 +117,7 @@ impl UIRenderer for Var {
             ui.add(CustomDragValue::new(&mut values[0])).changed()
               | ui.add(CustomDragValue::new(&mut values[1])).changed()
           });
-          ir.response.changed = ir.inner;
+          if ir.inner { ir.response.mark_changed(); }
           ir.response
         }
         SHTYPE_INT3 => {
@@ -127,7 +127,7 @@ impl UIRenderer for Var {
               | ui.add(CustomDragValue::new(&mut values[1])).changed()
               | ui.add(CustomDragValue::new(&mut values[2])).changed()
           });
-          ir.response.changed = ir.inner;
+          if ir.inner { ir.response.mark_changed(); }
           ir.response
         }
         SHTYPE_INT4 => {
@@ -138,7 +138,7 @@ impl UIRenderer for Var {
               | ui.add(CustomDragValue::new(&mut values[2])).changed()
               | ui.add(CustomDragValue::new(&mut values[3])).changed()
           });
-          ir.response.changed = ir.inner;
+          if ir.inner { ir.response.mark_changed(); }
           ir.response
         }
         SHTYPE_INT8 => {
@@ -160,7 +160,7 @@ impl UIRenderer for Var {
                 })
                 .inner
           });
-          ir.response.changed = ir.inner;
+          if ir.inner { ir.response.mark_changed(); }
           ir.response
         }
         SHTYPE_INT16 => {
@@ -198,7 +198,7 @@ impl UIRenderer for Var {
                 })
                 .inner
           });
-          ir.response.changed = ir.inner;
+          if ir.inner { ir.response.mark_changed(); }
           ir.response
         }
         SHTYPE_FLOAT => ui.add(CustomDragValue::new(
@@ -210,7 +210,7 @@ impl UIRenderer for Var {
             ui.add(CustomDragValue::new(&mut values[0])).changed()
               | ui.add(CustomDragValue::new(&mut values[1])).changed()
           });
-          ir.response.changed = ir.inner;
+          if ir.inner { ir.response.mark_changed(); }
           ir.response
         }
         SHTYPE_FLOAT3 => {
@@ -220,7 +220,7 @@ impl UIRenderer for Var {
               | ui.add(CustomDragValue::new(&mut values[1])).changed()
               | ui.add(CustomDragValue::new(&mut values[2])).changed()
           });
-          it.response.changed = it.inner;
+          if it.inner { it.response.mark_changed(); }
           it.response
         }
         SHTYPE_FLOAT4 => {
@@ -231,7 +231,7 @@ impl UIRenderer for Var {
               | ui.add(CustomDragValue::new(&mut values[2])).changed()
               | ui.add(CustomDragValue::new(&mut values[3])).changed()
           });
-          it.response.changed = it.inner;
+          if it.inner { it.response.mark_changed(); }
           it.response
         }
         SHTYPE_COLOR => {
@@ -278,7 +278,7 @@ impl UIRenderer for Var {
                 i += 1;
               }
             });
-            ir.header_response.changed = changed;
+            if changed { ir.header_response.mark_changed(); }
             ir.header_response
           } else {
             if read_only {
@@ -318,7 +318,7 @@ impl UIRenderer for Var {
                   .changed()
               }
             });
-            ir.header_response.changed = changed;
+            if changed { ir.header_response.mark_changed(); }
             ir.header_response
           } else {
             if read_only {

--- a/shards/gfx/CLAUDE.md
+++ b/shards/gfx/CLAUDE.md
@@ -22,16 +22,18 @@ shards/gfx/
 
 | Repository | Branch | Base Version |
 |------------|--------|--------------|
-| shards-lang/wgpu | `shards-27.x` | v27.0.4 |
-| shards-lang/wgpu-native | `shards-27.x` | v27.0.2.0 |
+| shards-lang/wgpu | `shards-29.x` | v29.0.1 |
+| shards-lang/wgpu-native | `shards-29.x` | v29.0.0.0 |
+
+(wgpu-native v29.0.0.0 pins wgpu-core 29.0.1, so the wgpu submodule is paired at v29.0.1.)
 
 ## Custom Patches (Must Preserve on Upgrades)
 
-### wgpu fork (`shards-27.x`)
-1. **Naga Handle exposure** - Makes `Handle::new`, `from_usize`, `from_usize_unchecked` public and exports `Index` type. Required by naga-native.
-2. **objc 0.2.7 compatibility** - Removed direct `sel_impl` imports (use `sel!` macro instead).
+### wgpu fork (`shards-29.x`)
+1. **Naga Handle exposure** - Makes `Handle::new`, `from_usize` public and exports `Index` type. Required by naga-native. (v29 removed `from_usize_unchecked` upstream; it was not used.)
+2. ~~**objc 0.2.7 compatibility**~~ - No longer needed in v29: wgpu-hal's Metal backend migrated to `objc2`, so the `sel_impl` import workaround was dropped.
 
-### wgpu-native fork (`shards-27.x`)
+### wgpu-native fork (`shards-29.x`)
 1. **Type exposure** - Makes struct fields `pub` for: `QueueId`, `WGPUDeviceImpl`, `WGPUInstanceImpl`, `WGPUPipelineLayoutImpl`, `QuerySetData`, `WGPUQuerySetImpl`, `WGPUQueueImpl`, `WGPURenderBundleImpl`, `WGPURenderBundleEncoderImpl`, `WGPUSurfaceImpl`, `TextureData`, `WGPUTextureImpl`, `WGPUTextureViewImpl`, `ErrorSink`, `ErrorSinkRaw`, `WGPUShaderModuleImpl`.
 2. **Cargo.toml** - Uses `crate-type = ["lib"]` (not cdylib/staticlib) and path dependencies to local wgpu.
 3. **webgpu-headers** - Submodule must match the wgpu-native version.
@@ -50,6 +52,17 @@ The crates.io `objc 0.2.7` has broken macro exports - `sel_impl!` isn't properly
 objc = { git = "https://github.com/shards-lang/rust-objc.git", branch = "shards-0.2.7" }
 naga = { path = "../wgpu/naga" }
 ```
+
+## WebGPU v27 → v29 changes (applied)
+
+C-API (C++) — only 3 sites, all in `context.cpp`:
+- `WGPUNativeLimits.maxPushConstantSize` → `maxImmediateSize` ("push constants" renamed to "immediates" throughout v29).
+- `WGPUChainedStructOut` type removed → use `WGPUChainedStruct *` for output chains.
+- `WGPUInstanceBackend_DX11` removed (DX11 instance backend dropped); a `WGPUBackendType_D3D11` request now falls through to the default backends.
+
+naga (Rust, `naga-native`): `AddressSpace::PushConstant` → `Immediate`; new required fields `Binding::Location.per_primitive`, `GlobalVariable.memory_decorations`, and `EntryPoint.{mesh_info,task_payload,incoming_ray_payload}`.
+
+egui font atlas (Rust + shader interaction): egui ≥0.31 delivers the font atlas as a premultiplied RGBA8 `ColorImage` (the old single-channel `ImageData::Font`/R32F path is gone). The `egui::TextureFormat::R32F` → `R8Unorm` branch in `renderer.cpp` and the `isFont` flag in `egui_render_pass.hpp` are now dead; fonts render through the normal premultiplied RGBA path.
 
 ## WebGPU v27 API Notes
 

--- a/shards/gfx/context.cpp
+++ b/shards/gfx/context.cpp
@@ -639,10 +639,10 @@ void Context::requestDevice() {
   // Add native limits extension
   WGPUNativeLimits nativeLimits{
       .chain = {.sType = (WGPUSType)WGPUSType_NativeLimits},
-      .maxPushConstantSize = 0,
+      .maxImmediateSize = 0,
       .maxNonSamplerBindings = 1000000,
   };
-  requiredLimits.nextInChain = (WGPUChainedStructOut*)&nativeLimits.chain;
+  requiredLimits.nextInChain = (WGPUChainedStruct *)&nativeLimits.chain;
   deviceDesc.requiredLimits = &requiredLimits;
 
 #if WEBGPU_TRACE
@@ -715,9 +715,8 @@ void Context::requestAdapter() {
     instanceBackends = WGPUInstanceBackend_Primary;
     if (backend) {
       switch (*backend) {
-      case WGPUBackendType_D3D11:
-        instanceBackends = WGPUInstanceBackend_DX11;
-        break;
+      // NOTE: wgpu-native v29 dropped the DX11 instance backend; a D3D11
+      // request now falls through to the default (all primary backends).
       case WGPUBackendType_D3D12:
         instanceBackends = WGPUInstanceBackend_DX12;
         break;

--- a/shards/gfx/rust/gfx/Cargo.lock
+++ b/shards/gfx/rust/gfx/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,18 +83,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -112,10 +112,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
+name = "block2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -229,38 +232,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "libc",
 ]
 
 [[package]]
@@ -268,6 +244,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
 
 [[package]]
 name = "document-features"
@@ -325,31 +311,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.5.0"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
+name = "futures-task"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
+name = "futures-util"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generator"
@@ -361,7 +344,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -384,34 +367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.10.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows",
+ "thiserror",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -468,6 +434,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -533,11 +501,12 @@ checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -593,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"
@@ -611,13 +580,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "1.0.0"
+name = "macro_rules_attribute"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f32c8c0575eee8637bf462087c00098fe16d6cb621f1abb6ebab4da414d57fd"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
 dependencies = [
- "libc",
+ "macro_rules_attribute-proc_macro",
+ "paste",
 ]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matchers"
@@ -635,21 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.10.0",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,7 +618,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -677,7 +638,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "spirv",
- "thiserror 2.0.17",
+ "thiserror",
  "unicode-ident",
 ]
 
@@ -720,19 +681,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "git+https://github.com/shards-lang/rust-objc.git?branch=shards-0.2.7#b2d834c95e38d89c39d42eea3587b584596f0848"
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "malloc_buf",
- "objc-encode",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "objc-encode"
-version = "1.1.0"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a34fdd0d389ac7d4a94d1afeb9e2acc8d74ecf6d730519dd1a8625e8e1ed822"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
 
 [[package]]
 name = "once_cell"
@@ -864,6 +872,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,14 +929,15 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "ron"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "base64",
  "bitflags 2.10.0",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
  "unicode-ident",
 ]
 
@@ -1027,16 +1048,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -1099,31 +1129,11 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.17",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1227,6 +1237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,9 +1262,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1259,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1269,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1282,18 +1298,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1301,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -1313,6 +1329,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.12.1",
  "log",
+ "macro_rules_attribute",
  "naga",
  "once_cell",
  "parking_lot",
@@ -1322,63 +1339,75 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
  "bitflags 2.10.0",
- "block",
+ "block2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
- "objc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
  "once_cell",
  "ordered-float",
  "parking_lot",
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.1"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -1394,7 +1423,7 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror",
  "wgpu-core",
  "wgpu-hal",
  "wgpu-types",
@@ -1402,14 +1431,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "js-sys",
  "log",
+ "raw-window-handle",
  "serde",
- "thiserror 2.0.17",
  "web-sys",
 ]
 
@@ -1450,8 +1479,29 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1460,11 +1510,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -1472,6 +1546,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1490,6 +1575,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,13 +1611,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1540,6 +1670,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1609,3 +1748,8 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[patch.unused]]
+name = "objc"
+version = "0.2.7"
+source = "git+https://github.com/shards-lang/rust-objc.git?branch=shards-0.2.7#b2d834c95e38d89c39d42eea3587b584596f0848"

--- a/shards/gfx/rust/gfx/Cargo.lock
+++ b/shards/gfx/rust/gfx/Cargo.lock
@@ -358,7 +358,6 @@ dependencies = [
  "wgpu-core",
  "wgpu-native",
  "wgpu-types",
- "windows 0.62.2",
 ]
 
 [[package]]
@@ -370,8 +369,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gpu-allocator"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+source = "git+https://github.com/shards-lang/gpu-allocator.git?rev=55d1615cb77b532cef4033eb071ddf40aca6dcae#55d1615cb77b532cef4033eb071ddf40aca6dcae"
 dependencies = [
  "ash",
  "hashbrown 0.16.1",

--- a/shards/gfx/rust/gfx/Cargo.lock
+++ b/shards/gfx/rust/gfx/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "wgpu-core",
  "wgpu-native",
  "wgpu-types",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -377,7 +378,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror",
- "windows 0.58.0",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/shards/gfx/rust/gfx/Cargo.toml
+++ b/shards/gfx/rust/gfx/Cargo.toml
@@ -33,21 +33,17 @@ naga-native = { path = "../naga-native" }
 profiling = { version = "1", default-features = false }
 tracy-client = { version = "0.17.4", optional = true }
 
-# wgpu v29's wgpu-hal pins windows = "0.62" for the D3D12 backend, and it hands
-# windows-rs types (D3D12_RESOURCE_DESC, ID3D12Heap, ...) to gpu-allocator.
-# gpu-allocator 0.28 accepts windows >=0.58,<=0.62, so the resolver can split it
-# onto a different windows version pulled by unrelated (often cfg-gated) deps
-# such as loom/generator, breaking the D3D12 build. Force windows 0.62 here so
-# gpu-allocator unifies with wgpu-hal in every workspace that depends on gfx.
-[target.'cfg(windows)'.dependencies]
-windows = "0.62"
-
 [patch.crates-io]
 # visionOS support is now upstream in wgpu v27 and metal 0.32
 naga = { path = "../wgpu/naga" }
 
 # objc 0.2.7 fork needed for sel_impl macro export (crates.io version has broken macro exports)
 objc = { git = "https://github.com/shards-lang/rust-objc.git", branch = "shards-0.2.7" }
+
+# gpu-allocator fork pins windows-rs to 0.62 so its D3D12 types match wgpu-hal
+# v29 (which pins windows 0.62). Upstream's loose range let cargo split it onto
+# sysinfo's windows <0.62, breaking the D3D12_RESOURCE_DESC/ID3D12Heap type flow.
+gpu-allocator = { git = "https://github.com/shards-lang/gpu-allocator.git", rev = "55d1615cb77b532cef4033eb071ddf40aca6dcae" }
 
 # Until updates tracy-client (https://github.com/aclysma/profiling/pull/44)
 profiling = { path = "../profiling" }

--- a/shards/gfx/rust/gfx/Cargo.toml
+++ b/shards/gfx/rust/gfx/Cargo.toml
@@ -33,6 +33,15 @@ naga-native = { path = "../naga-native" }
 profiling = { version = "1", default-features = false }
 tracy-client = { version = "0.17.4", optional = true }
 
+# wgpu v29's wgpu-hal pins windows = "0.62" for the D3D12 backend, and it hands
+# windows-rs types (D3D12_RESOURCE_DESC, ID3D12Heap, ...) to gpu-allocator.
+# gpu-allocator 0.28 accepts windows >=0.58,<=0.62, so the resolver can split it
+# onto a different windows version pulled by unrelated (often cfg-gated) deps
+# such as loom/generator, breaking the D3D12 build. Force windows 0.62 here so
+# gpu-allocator unifies with wgpu-hal in every workspace that depends on gfx.
+[target.'cfg(windows)'.dependencies]
+windows = "0.62"
+
 [patch.crates-io]
 # visionOS support is now upstream in wgpu v27 and metal 0.32
 naga = { path = "../wgpu/naga" }

--- a/shards/gfx/rust/naga-native/Cargo.lock
+++ b/shards/gfx/rust/naga-native/Cargo.lock
@@ -27,18 +27,18 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "unicode-width",
 ]
@@ -252,7 +252,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "naga"
-version = "27.0.4"
+version = "29.0.1"
 dependencies = [
  "arrayvec",
  "bit-set",

--- a/shards/gfx/rust/naga-native/src/lib.rs
+++ b/shards/gfx/rust/naga-native/src/lib.rs
@@ -1620,7 +1620,8 @@ pub mod native {
           access: access.try_into()?,
         },
         AddressSpace::Handle => naga::AddressSpace::Handle,
-        AddressSpace::PushConstant => naga::AddressSpace::PushConstant,
+        // wgpu/naga v29 renamed "push constants" to "immediates".
+        AddressSpace::PushConstant => naga::AddressSpace::Immediate,
       };
       Ok(result)
     }
@@ -1989,6 +1990,8 @@ pub mod native {
           } else {
             None
           },
+          // mesh-shader per-primitive bindings (naga v29); not exposed via this FFI.
+          per_primitive: false,
         },
       };
       Ok(result)
@@ -2028,6 +2031,8 @@ pub mod native {
         binding,
         ty,
         init,
+        // SPIR-V memory decorations (naga v29); none for FFI-created globals.
+        memory_decorations: naga::MemoryDecorations::default(),
       })
     }
   }
@@ -2923,6 +2928,10 @@ pub unsafe extern "C" fn nagaAddEntryPoint(
     stage: desc.stage.try_into().expect("Invalid stage"),
     workgroup_size: desc.workgroup_size,
     workgroup_size_overrides: None,
+    // mesh/task/ray-tracing entry-point info (naga v29); unused via this FFI.
+    mesh_info: None,
+    task_payload: None,
+    incoming_ray_payload: None,
   });
 }
 

--- a/shards/modules/egui/debug_ui/Cargo.toml
+++ b/shards/modules/egui/debug_ui/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = { version = "0.28.1", features = ["persistence"] }
+egui = { version = "0.34", features = ["persistence"] }
 shards = { path = "../../../rust" }
 shards-egui = { path = "../../../egui" }
 

--- a/shards/modules/gfx/window.cpp
+++ b/shards/modules/gfx/window.cpp
@@ -291,6 +291,28 @@ struct MainWindow final {
 
     auto &window = _windowContext->window;
 
+    // Poll & distribute input events EVERY frame, even ones we can't render.
+    // wgpu v29 added SurfaceStatus::Occluded, which the surface returns until
+    // the window is actually composited on-screen. Previously the event pump
+    // lived inside the `if (shouldRun)` block below, so when begin() failed
+    // (occluded) the events were never pumped -> the window never became
+    // visible -> it stayed occluded forever (deadlock: no window, frozen time).
+    if (!headless && window) {
+      callOnMeshThread(shContext, [&]() {
+        window->update();
+        _windowContext->inputMaster.update(*window.get());
+      });
+
+      for (auto &event : _windowContext->inputMaster.getEvents()) {
+        if (std::holds_alternative<RequestCloseEvent>(event.event)) {
+          bool handleClose = _handleCloseEvent->isNone() || (bool)*_handleCloseEvent;
+          if (handleClose) {
+            throw MainWindowQuitException();
+          }
+        }
+      }
+    }
+
     bool shouldRun = true;
     if (_renderer) {
       if (headless) {
@@ -301,23 +323,6 @@ struct MainWindow final {
     }
 
     if (shouldRun) {
-      if (!headless) {
-        // Poll & distribute input events
-        callOnMeshThread(shContext, [&]() {
-          window->update();
-          _windowContext->inputMaster.update(*window.get());
-        });
-
-        for (auto &event : _windowContext->inputMaster.getEvents()) {
-          if (std::holds_alternative<RequestCloseEvent>(event.event)) {
-            bool handleClose = _handleCloseEvent->isNone() || (bool)*_handleCloseEvent;
-            if (handleClose) {
-              throw MainWindowQuitException();
-            }
-          }
-        }
-      }
-
       if (_contents) {
         _inlineInputContext->time = _windowContext->time;
         _inlineInputContext->deltaTime = _windowContext->deltaTime;


### PR DESCRIPTION
Full forward bump of the graphics + UI stacks.

## wgpu / wgpu-native → v29
- Submodules moved to new `shards-29.x` fork branches: wgpu at **v29.0.1** + the naga `Handle` exposure patch; wgpu-native at **v29.0.0.0** + the internal `WGPU*Impl` type-exposure patch and Cargo setup (local wgpu paths, `crate-type=["lib"]`, `trace`, Vulkan-on-Linux). webgpu-headers pinned to the v29 header.
- The old objc-0.2.7 `sel_impl` patch is dropped — v29's Metal backend moved to `objc2`.
- `naga-native`: `AddressSpace::PushConstant`→`Immediate`, plus new naga v29 IR fields (`Binding::Location.per_primitive`, `GlobalVariable.memory_decorations`, `EntryPoint.{mesh_info,task_payload,incoming_ray_payload}`).
- C++ (`shards/gfx/context.cpp`): `maxPushConstantSize`→`maxImmediateSize`, `WGPUChainedStructOut`→`WGPUChainedStruct`, drop the removed `WGPUInstanceBackend_DX11`.

## egui ecosystem → 0.34
- egui/egui_extras 0.34, egui_plot 0.35, egui_dock 0.19; egui_commonmark moved to crates.io 0.23 (the shards fork's extra features were unused); egui_memory_editor bumped on the `shards-lang/egui_memory_editor@shards-0.34` branch.
- Bridge + widgets migrated across the 0.29→0.34 API churn: `Margin`/`Rounding`→`CornerRadius`/`Shadow` (i8/u8), `RectShape::new`, `Response::mark_changed`, `UiBuilder`, clipboard/open-url via `PlatformOutput::commands`, RGBA8-only font atlas (`ImageData::Color`), `Event::MouseWheel.phase`, `RawInput` defaults, `TextBuffer::type_id`, egui_plot name arg, egui_dock `TabPath`/`NodePath`, popup path, layouter `&dyn TextBuffer` + `fonts_mut`, `Order::PanelResizeLine`→`Middle`.

## Validation (local, macOS / Apple M4 Max, Metal)
- Release build clean.
- `test-runtime`: all pass. `test-gfx` (GPU image-comparison): **44/44, zero image mismatches**.
- `.shs` suite: 366/368. The two non-passes are environmental, not regressions: `gfx-read-texture` (pre-existing flaky async-readback timing under parallel load; passes reliably solo) and `llm` (needs the `hf` CLI, absent locally).

Depends on the pushed fork branches: `shards-lang/wgpu@shards-29.x`, `shards-lang/wgpu-native@shards-29.x`, `shards-lang/egui_memory_editor@shards-0.34`.