### PR TITLE
chore(deps): drop dead tracy-client v0.15.0 patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,3 @@ memmap2 = { git = "https://github.com/sinkingsugar/memmap2-rs.git", version = "=
 
 # objc 0.2.7 fork needed for sel_impl macro export (crates.io version has broken macro exports)
 objc = { git = "https://github.com/shards-lang/rust-objc.git", version = "=0.2.7", branch = "shards-0.2.7" }
-
-tracy-client = { git = "https://github.com/nagisa/rust_tracy_client", tag = "tracy-client-v0.15.0" }

--- a/cmake/rust/union_Cargo.toml.in
+++ b/cmake/rust/union_Cargo.toml.in
@@ -33,8 +33,6 @@ metal = { git = "https://github.com/shards-lang/metal-rs.git", version = "=0.29.
 # build fails (D3D12_RESOURCE_DESC / ID3D12Heap type mismatch).
 gpu-allocator = { git = "https://github.com/shards-lang/gpu-allocator.git", rev = "55d1615cb77b532cef4033eb071ddf40aca6dcae" }
 
-tracy-client = { git = "https://github.com/nagisa/rust_tracy_client", tag = "tracy-client-v0.15.0" }
-
 # Optimize all dependencies in debug builds for usable performance.
 # Using a single opt-level for all deps avoids symbol visibility mismatches
 # between crates compiled at different levels (which breaks GNU ld).


### PR DESCRIPTION
The root and union `[patch.crates-io]` pinned tracy-client to the old git `v0.15.0`, but the `profiling` fork and the gfx crate already depend on crates.io `0.17.4` — so the patch was never applied (cargo flagged it as unused). Removing it unifies tracy-client on 0.17.4 and stops fetching the stale git repo. No functional change.