### PR TITLE
chore(deps): bump JoltPhysics v5.2.0 → v5.5.0

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -59,7 +59,7 @@ if(PHYSICS_ENABLED)
   CPMAddPackage(
     NAME JoltPhysics
     GITHUB_REPOSITORY shards-lang/JoltPhysics
-    GIT_TAG 018df332c9dbc7e2fff9502799e77c2e2494809d
+    GIT_TAG 2f94d15c7709e1a111ac7d659b3c31f36c91167b
     SOURCE_SUBDIR Build
   )
 endif()


### PR DESCRIPTION
Bumps JoltPhysics from v5.2.0 to v5.5.0.

## Fork rebase
The `shards-lang/JoltPhysics` fork carried three build-only patches on top of v5.2.0. Rebasing onto v5.5.0 leaves only one still needed:

| Patch | v5.5.0 status |
|-------|---------------|
| Disable source group (unused/slow) | **kept** |
| Remove emscripten stack/memory flags from the Jolt lib | upstreamed — lib no longer hardcodes `-sSTACK_SIZE`/`-sINITIAL_MEMORY`; the consuming app sets them (shards already does) |
| Prevent `$<CONFIG:Debug>:_DEBUG` define | upstreamed — removed upstream |

New fork branch: `shards-lang/JoltPhysics@shards-5.5` (`2f94d15c`).

## C++ impact: none
Audited the physics module against every compile-affecting v5.2→v5.5 API change:
- Derives from `JPH::ContactListener` (body-body, stable) — **not** `CharacterContactListener`, whose added virtuals (`OnContactPersisted`/`OnContactRemoved`/…) are the only contact-listener change.
- Uses none of the renamed/moved symbols: `mManifoldToleranceSq`→`mManifoldTolerance`, `SoftBodySharedSettings::mVertexRadius`→`SoftBodyCreationSettings::mVertexRadius`, `JPH_CPU_ADDRESS_BITS`→`JPH_CPU_ARCH_BITS`.
- Soft bodies are built at runtime via `CreateConstraints`, so the *SBS* serialization-format changes don't apply.

## Verification
- Release build clean (Jolt v5.5.0 compiles without warnings on our side).
- `shards/tests/physics.shs` passes — all 8 sub-tests (basic, DOF×2, filters, constraints×2, soft-body, 2D-triangle-custom-mass), exit 0.