### PR TITLE
chore(deps): bump llama.cpp b9191 → b9628, whisper.cpp v1.8.4 → v1.8.6

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -493,7 +493,7 @@ if(LLM_ENABLED AND NOT EMSCRIPTEN AND NOT WATCHOS)
   CPMAddPackage(
     NAME llama.cpp
     GITHUB_REPOSITORY ggml-org/llama.cpp
-    GIT_TAG b9191
+    GIT_TAG b9628
   )
 
   # llama.cpp >= b9019 uses dynamic_cast<llama_model_base*> in src/llama.cpp and
@@ -514,7 +514,7 @@ if(LLM_ENABLED AND NOT EMSCRIPTEN AND NOT WATCHOS)
   CPMAddPackage(
     NAME whisper.cpp
     GITHUB_REPOSITORY ggml-org/whisper.cpp
-    GIT_TAG v1.8.4
+    GIT_TAG v1.8.6
   )
 endif()
 


### PR DESCRIPTION
Bumps the two ggml-org pins to latest:
- **llama.cpp** `b9191` → `b9628`
- **whisper.cpp** `v1.8.4` → `v1.8.6`

Both are direct upstream pins (no shards-lang fork to rebase).

## C++ impact: none
Audited every llama/whisper/common symbol `shards/modules/llm` uses against the header deltas:
- **llama.h** — no signature change for any symbol we call.
- **common.h / sampling.h** — the only two changed helpers aren't called by the module:
  - `common_init_from_params` gained a *defaulted* `bool model_only = false` (source-compatible anyway).
  - `common_sampler_types_from_names` dropped `allow_alt_names`.
- **whisper.h** — no signature change for any symbol we call.

## RTTI workaround still correct
The b9019+ `-frtti` workaround still covers every `dynamic_cast` site: at b9628 those live only in `src/llama.cpp` and `src/llama-quant.cpp`, both compiled into the `llama` target the existing `foreach` already targets.

## Verification (macOS, Apple M4 Max, Metal)
- Release build clean — no warnings on our side, `llama` / `llama-common` / `shards` all link.
- `shards/tests/llm.shs` runs real **Qwen3-0.6B** inference end-to-end (`LLM.Model` → `LLM.Chat` → `LLM.AddText` → `LLM.Generate` → `LLM.Reset` → generate again). Both generations non-empty, final `Assert.Is(true)` passes.
- whisper.cpp v1.8.6 links clean; `whisper.shs` self-skips without a downloaded model (patch-level bump).