### PR TITLE
feat(check): `shards check` with structured JSON diagnostics

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -172,6 +172,14 @@ jobs:
           ./shards new ../shards/tests/spreadsheet.shs
           ./shards new ../shards/tests/ai-mistral.shs
           ./shards new ../shards/tests/ai-gguf.shs
+      - name: Test shards check (diagnostics)
+        env:
+          RUST_BACKTRACE: full
+        shell: bash
+        run: |
+          # Eval harness for `shards check`: asserts structured-diagnostic quality
+          # (phases, type-directed candidates, did-you-mean) and a repairability score.
+          SHARDS="$PWD/build/shards" bash shards/tests/check/run.sh
       - name: Test doc samples (non-UI)
         env:
           RUST_BACKTRACE: full

--- a/docs/ai-first-roadmap.md
+++ b/docs/ai-first-roadmap.md
@@ -60,7 +60,7 @@ Items ordered by leverage-per-effort. Items 1–2 are prerequisites for everythi
 
 ### 3.1 `shards check` — the compiler as the agent's tool
 
-**Effort: weeks. Priority: P0.**
+**Effort: weeks. Priority: P0. Status: ✅ shipped (initial) — see "Status" below.**
 
 A compose-only mode with **structured, machine-readable error output**. Today's errors are human prose; an agent repair loop needs data.
 
@@ -78,6 +78,29 @@ Deliverables:
 - Wall-clock budget: `check` on a typical script should stay in low milliseconds. **Compose speed is now an inner-loop metric**, same status as activation speed.
 
 Acceptance: an LLM given a broken script + the JSON diagnostics (and nothing else) fixes typical type errors in one round-trip at a measurably higher rate than with prose errors.
+
+#### Status — shipped (initial)
+
+`shards check [--json]` is implemented end-to-end and verified.
+
+Delivered:
+
+- `shards check <file> [--json]` — parse + compose only, never schedules/warms/runs. Exit codes: `0` ok, `1` problems found, `2` could not run (e.g. missing file).
+- JSON schema per diagnostic: `phase` (`parse` | `construct` | `compose`), `severity`, `kind` (`syntax` | `unknown-shard` | `input-type-mismatch` | `compose-error` | `generic`), `message`, `file`, `line`, `column`, `shard`, structured `actual`/`expected` (each `{name, basic_type}`), `param_index`, `did_you_mean`, `candidates`. (Note the `phase` set gained `construct` — the wire-graph build step between parse and compose, where unknown shards surface.)
+- **`candidates`** — type-directed bridge suggestions, computed by reverse-indexing the registry's input/output types. Scalar-aware, tiered ranking surfaces real converters (e.g. `ParseInt`/`ParseFloat` for `String → Int`) ahead of container/wildcard noise.
+- **`did_you_mean`** — edit distance over the live shard registry for unknown shard names.
+- **Eval harness** (`shards/tests/check/`): a broken-script corpus + `run.sh` that asserts diagnostic quality and reports a *repairability* score — the measuring stick 3.3/3.4 depend on.
+
+Architecture (hybrid): a minimal C++ core change emits structured diagnostics — `SHDiagnostic[]` on `SHComposeResult`, carrying `SHTypeInfo`-derived type descriptors + source location + shard context — plus a non-throwing `composeForCheck` mesh entry that composes with semantics identical to a real schedule. All logic (JSON shaping, did-you-mean, candidates engine) lives in the Rust CLI (`shards/lang/src/check.rs`). Only owned strings + ints cross the ABI; no string re-parsing.
+
+Landed alongside: parse-phase diagnostics now carry precise `line`/`column` (extracted from the pest error, previously `0:0`), and namespaced identifiers render source-faithfully with `/` (e.g. `fbl/set-tracked`) in all messages and the formatter round-trip — previously the display convention `::`.
+
+Not yet (tracked follow-ups):
+
+- **Warnings** (type-widening `If`/`Maybe` → `Any`) — compose currently only throws on hard errors; emitting non-fatal diagnostics with severity levels is a separate change.
+- **Parameter context** — `param_index` is reserved in the schema but not yet populated; the common case is a *flow* input/output mismatch, which carries no parameter.
+- **Candidate refinement** — matching is coarse top-level `basic_type`; seq/table inner-type matching would sharpen it.
+- **Isolated-fragment checking** — a library file that relies on externally-injected definitions (an `@include`d prelude) reports those as unknown when checked standalone. This is the live-environment angle of 3.5; for now, check entry-point files (or pass the prelude via `-I`).
 
 ### 3.2 Agent interface — CLI-first, not MCP-first
 
@@ -257,7 +280,7 @@ Rewrite the public pitch around **verification and trust**, not flow and intuiti
 ## 6. Sequencing summary
 
 ```
-P0 (now, weeks):    3.1 shards check (JSON diagnostics)
+P0 (now, weeks):    3.1 shards check (JSON diagnostics)            ✅ shipped (initial)
                     3.2 agent interface (CLI + SKILL.md + shards-llm.txt) + docs pass
                     3.3 canonical-form decision + generation benchmark
 P1 (next, months):  3.4 synthetic corpus + open-model fine-tune   [after 3.3 freeze]

--- a/include/shards/shards.h
+++ b/include/shards/shards.h
@@ -703,6 +703,37 @@ struct SHRunWireOutput {
   SH_ENUM_DECL SHRunWireOutputState state;
 } SH_STRUCT16;
 
+// Kind of a structured compose-time diagnostic.
+// Stable, machine-readable classification for agent repair loops (`shards check --json`).
+enum SH_ENUM_CLASS SHDiagnosticKind : uint8_t {
+  SHDiag_Generic,           // a compose error without specialized structure
+  SHDiag_InputTypeMismatch, // previous output type does not match this shard's input types
+  SHDiag_ComposeError,      // error returned by a shard's own compose() callback
+  SHDiag_UnknownShard,      // referenced shard does not exist (parse/construct phase)
+};
+
+// A single type rendered for diagnostics: a canonical string plus the top-level
+// basic type id (SHType cast to int32, -1 when unknown) for cheap structured matching.
+struct SHTypeDesc {
+  SHStringWithLen name; // canonical type string (owned by SHComposeResult)
+  int32_t basicType;    // SHType enum value, -1 if unknown
+};
+
+// One structured compose diagnostic. All strings/arrays are owned by the
+// SHComposeResult that carries it and are released by freeComposeResult.
+struct SHDiagnostic {
+  SH_ENUM_DECL SHDiagnosticKind kind;
+  uint32_t line;
+  uint32_t column;
+  SHStringWithLen file;        // resolved source file name (owned, may be empty)
+  SHStringWithLen shardName;   // offending shard name (owned, may be empty)
+  SHStringWithLen message;     // human-readable message (owned)
+  struct SHTypeDesc actual;    // actual.name empty when not applicable
+  struct SHTypeDesc *expected; // owned array of acceptable types (may be null)
+  uint64_t numExpected;        // length of expected
+  int32_t paramIndex;          // parameter index when applicable, -1 otherwise
+};
+
 struct SHComposeResult {
   struct SHTypeInfo outputType;
 
@@ -718,6 +749,11 @@ struct SHComposeResult {
   // used when the last shard of the flow is
   // Restart/Stop/Return etc
   bool flowStopper;
+
+  // Structured, machine-readable diagnostics (owned; freed by freeComposeResult).
+  // Populated on failure; empty/null on success.
+  struct SHDiagnostic *diagnostics;
+  uint64_t numDiagnostics;
 };
 
 struct SHInstanceData {
@@ -958,6 +994,12 @@ typedef struct SHError(__cdecl *SHValidateSetParam)(struct Shard *shard, int ind
 
 typedef struct SHComposeResult(__cdecl *SHComposeShards)(Shards shards, struct SHInstanceData data);
 typedef void(__cdecl *SHFreeComposeResult)(struct SHComposeResult *result);
+
+// Compose-only entry used by `shards check`: composes a wire against a mesh's
+// environment exactly like scheduling would, but never schedules/warms/runs and
+// never throws. Returns a SHComposeResult carrying structured diagnostics on
+// failure. Caller owns the result and must release it via freeComposeResult.
+typedef struct SHComposeResult(__cdecl *SHComposeForCheck)(SHMeshRef mesh, SHWireRef wire);
 
 typedef void(__cdecl *SHPushError)(struct SHContext *context, struct SHStringWithLen error);
 
@@ -1240,6 +1282,7 @@ typedef struct _SHCore {
   SHIsWireRunning isWireRunning;
   SHStopWire stopWire; // must destroyVar once done
   SHComposeWire composeWire;
+  SHComposeForCheck composeForCheck;
   SHRunWire runWire;
   SHGetWireInfo getWireInfo;
 

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -92,6 +92,15 @@ public:
   ContextType type;
   bool fatal;
 
+  // Optional structured diagnostic payload, consumed by getComposeError to build
+  // machine-readable SHDiagnostic entries for `shards check --json`. Defaults make
+  // every Error a plain generic diagnostic unless enriched at the throw site.
+  SHDiagnosticKind diagKind = SHDiagnosticKind::SHDiag_Generic;
+  std::string actualType;                                     // canonical string, empty if N/A
+  int32_t actualBasicType = -1;                               // SHType value, -1 if N/A
+  std::vector<std::pair<std::string, int32_t>> expectedTypes; // {canonical, basicType}
+  int32_t paramIndex = -1;                                    // parameter index, -1 if N/A
+
   explicit Error(Shard *shard, std::string_view msg, bool fatal = true)
       : message(msg.data() ? msg : "Unknown error"), shard(shard), type(CTX_Shard), fatal(fatal) {}
   explicit Error(const SHWire *wire, std::string_view msg, bool fatal = true)

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -902,7 +902,19 @@ void validateConnection(InternalCompositionContext &ctx) {
       }
     }
 #endif
-    throw shards::Error(ctx.bottom, msg);
+    // Attach structured diagnostic data so `shards check --json` can drive an
+    // agent repair loop (and the type-directed candidates engine) without
+    // re-parsing the human message.
+    shards::Error err(ctx.bottom, msg);
+    err.diagKind = SHDiagnosticKind::SHDiag_InputTypeMismatch;
+    err.actualType = fmt::format("{}", ctx.previousOutputType);
+    err.actualBasicType = int32_t(ctx.previousOutputType.basicType);
+    err.expectedTypes.reserve(inputInfos.len);
+    for (uint32_t i = 0; inputInfos.len > i; i++) {
+      auto &inputInfo = inputInfos.elements[i];
+      err.expectedTypes.emplace_back(fmt::format("{}", inputInfo), int32_t(inputInfo.basicType));
+    }
+    throw err;
   }
 
   // infer and specialize types if we need to
@@ -924,7 +936,9 @@ void validateConnection(InternalCompositionContext &ctx) {
     auto composeResult = ctx.bottom->composeV2(ctx.bottom, &data);
     if (composeResult.error.code != SH_ERROR_NONE) {
       const char *errMsg = composeResult.error.message.string ? composeResult.error.message.string : "Unknown composition error";
-      throw shards::Error(ctx.bottom, errMsg);
+      shards::Error err(ctx.bottom, errMsg);
+      err.diagKind = SHDiagnosticKind::SHDiag_ComposeError;
+      throw err;
     }
     ctx.previousOutputType = composeResult.result;
   } else if (ctx.bottom->compose) {
@@ -951,7 +965,9 @@ void validateConnection(InternalCompositionContext &ctx) {
     auto composeResult = ctx.bottom->compose(ctx.bottom, &data);
     if (composeResult.error.code != SH_ERROR_NONE) {
       const char *errMsg = composeResult.error.message.string ? composeResult.error.message.string : "Unknown composition error";
-      throw shards::Error(data.shard, errMsg);
+      shards::Error err(data.shard, errMsg);
+      err.diagKind = SHDiagnosticKind::SHDiag_ComposeError;
+      throw err;
     }
     ctx.previousOutputType = composeResult.result;
   } else {
@@ -1213,14 +1229,85 @@ inline SHStringWithLen toOwnedString(std::string_view s) {
   return r;
 }
 
+// Allocate an owned SHStringWithLen, or {nullptr,0} for empty input (so freeComposeResult
+// can skip it and JSON consumers can treat it as absent).
+static SHStringWithLen ownedOrEmpty(std::string_view s) {
+  if (s.empty())
+    return SHStringWithLen{nullptr, 0};
+  return toOwnedString(s);
+}
+
+static SHTypeDesc makeTypeDesc(std::string_view name, int32_t basicType) {
+  SHTypeDesc d{};
+  d.name = ownedOrEmpty(name);
+  d.basicType = basicType;
+  return d;
+}
+
+// Convert the (structured) compose error stack into an owned SHDiagnostic[] carried by
+// the SHComposeResult. Only owned strings + ints cross the ABI; freeComposeResult releases them.
+static void buildDiagnostics(SHComposeResult &result, const std::vector<shards::Error> &errorStack) {
+  if (errorStack.empty())
+    return;
+
+  auto *diags = new SHDiagnostic[errorStack.size()];
+  std::memset(diags, 0, sizeof(SHDiagnostic) * errorStack.size());
+
+  size_t n = 0;
+  for (auto &err : errorStack) {
+    SHDiagnostic &d = diags[n];
+    d.kind = err.diagKind;
+    d.paramIndex = err.paramIndex;
+    d.message = ownedOrEmpty(err.message);
+
+    // Source location + offending shard name.
+    if (err.type == shards::Error::CTX_Shard && err.shard) {
+      d.line = err.shard->line;
+      d.column = err.shard->column;
+      auto fileName = InternalCore::getSourceFileName(err.shard->file);
+      if (fileName.string && fileName.len > 0)
+        d.file = toOwnedString(std::string_view(fileName.string, fileName.len));
+      if (auto sn = err.shard->name(err.shard))
+        d.shardName = ownedOrEmpty(std::string_view(sn));
+    } else if (err.type == shards::Error::CTX_Wire && err.wire) {
+      if (!err.wire->shards.empty()) {
+        if (auto *blk = err.wire->shards.front()) {
+          d.line = blk->line;
+          d.column = blk->column;
+          auto fileName = InternalCore::getSourceFileName(blk->file);
+          if (fileName.string && fileName.len > 0)
+            d.file = toOwnedString(std::string_view(fileName.string, fileName.len));
+        }
+      }
+    }
+
+    // Structured type information (input-type-mismatch diagnostics).
+    d.actual = makeTypeDesc(err.actualType, err.actualBasicType);
+    if (!err.expectedTypes.empty()) {
+      d.numExpected = err.expectedTypes.size();
+      d.expected = new SHTypeDesc[d.numExpected];
+      std::memset(d.expected, 0, sizeof(SHTypeDesc) * d.numExpected);
+      for (size_t i = 0; i < err.expectedTypes.size(); i++)
+        d.expected[i] = makeTypeDesc(err.expectedTypes[i].first, err.expectedTypes[i].second);
+    }
+
+    n++;
+  }
+
+  result.diagnostics = diags;
+  result.numDiagnostics = n;
+}
+
 SHComposeResult getComposeError(shards::CompositionContext &privateContext) {
   std::string emsg = "Composition failed";
   std::string errorStackTrace = formatErrorStack(privateContext.errorStack, {});
-  return SHComposeResult{
+  SHComposeResult result{
       .failed = true,
       .error = toOwnedString(emsg),
       .errorStackTrace = toOwnedString(errorStackTrace),
   };
+  buildDiagnostics(result, privateContext.errorStack);
+  return result;
 }
 
 SHComposeResult composeWireNoExcept(const SHWire *wire, SHInstanceData &data) noexcept {
@@ -1560,6 +1647,29 @@ void freeComposeResult(SHComposeResult &result) {
   }
   if (result.errorStackTrace.string) {
     delete[] result.errorStackTrace.string;
+  }
+  if (result.diagnostics) {
+    for (uint64_t i = 0; i < result.numDiagnostics; i++) {
+      auto &d = result.diagnostics[i];
+      if (d.file.string)
+        delete[] d.file.string;
+      if (d.shardName.string)
+        delete[] d.shardName.string;
+      if (d.message.string)
+        delete[] d.message.string;
+      if (d.actual.name.string)
+        delete[] d.actual.name.string;
+      if (d.expected) {
+        for (uint64_t j = 0; j < d.numExpected; j++) {
+          if (d.expected[j].name.string)
+            delete[] d.expected[j].name.string;
+        }
+        delete[] d.expected;
+      }
+    }
+    delete[] result.diagnostics;
+    result.diagnostics = nullptr;
+    result.numDiagnostics = 0;
   }
 }
 void InternalCore::freeComposeResult(struct SHComposeResult *result) { shards::freeComposeResult(*result); }
@@ -2936,6 +3046,24 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
   result->composeWire = [](SHWireRef wire, SHInstanceData data) noexcept {
     auto sc = SHWire::sharedFromRef(wire);
     return shards::composeWireNoExcept(sc.get(), data);
+  };
+
+  result->composeForCheck = [](SHMeshRef mesh, SHWireRef wire) noexcept -> SHComposeResult {
+    try {
+      auto smesh = reinterpret_cast<std::shared_ptr<SHMesh> *>(mesh);
+      auto sc = SHWire::sharedFromRef(wire);
+      return (*smesh)->composeForCheck(sc);
+    } catch (const std::exception &e) {
+      SHComposeResult r{};
+      r.failed = true;
+      r.error = shards::toOwnedString(e.what());
+      return r;
+    } catch (...) {
+      SHComposeResult r{};
+      r.failed = true;
+      r.error = shards::toOwnedString("foreign exception during composeForCheck");
+      return r;
+    }
   };
 
   result->freeComposeResult = [](SHComposeResult *result) noexcept { shards::freeComposeResult(*result); };

--- a/shards/core/runtime.hpp
+++ b/shards/core/runtime.hpp
@@ -244,6 +244,7 @@ namespace shards {
 [[nodiscard]] SHComposeResult composeWire(const std::vector<ShardPtr> &wire, SHInstanceData data);
 [[nodiscard]] SHComposeResult composeWire(const Shards wire, SHInstanceData data);
 [[nodiscard]] SHComposeResult composeWire(const SHWire *wire, SHInstanceData data);
+[[nodiscard]] SHComposeResult composeWireNoExcept(const SHWire *wire, SHInstanceData &data) noexcept;
 
 void freeComposeResult(SHComposeResult &result);
 
@@ -560,6 +561,25 @@ struct SHMesh : public std::enable_shared_from_this<SHMesh> {
     DEFER(shards::freeComposeResult(result));
 
     SHLOG_TRACE("Wire {} composed", wire->name);
+  }
+
+  // Compose-only variant for `shards check`: mirrors compose() setup so semantics
+  // match a real schedule, but uses the non-throwing path and RETURNS the
+  // SHComposeResult (carrying structured diagnostics on failure). Never warms up
+  // or runs. The caller owns the result and must release it via freeComposeResult.
+  SHComposeResult composeForCheck(const std::shared_ptr<SHWire> &wire, SHVar input = shards::Var::Empty) {
+    ZoneScoped;
+
+    wire->mesh = shared_from_this();
+    wire->isRoot = true;
+    DEFER(wire->isRoot = false);
+
+    SHInstanceData data = instanceData;
+    data.wire = wire.get();
+    data.inputType = shards::deriveTypeInfo(input, data);
+    DEFER({ shards::freeDerivedInfo(data.inputType); });
+
+    return shards::composeWireNoExcept(wire.get(), data);
   }
 
   struct EmptyObserver {

--- a/shards/lang/src/ast.rs
+++ b/shards/lang/src/ast.rs
@@ -91,9 +91,13 @@ impl fmt::Display for Identifier {
     if self.namespaces.is_empty() {
       write!(f, "{}", self.name)
     } else {
+      // Render exactly as Shards source: namespaces and name are all joined with
+      // '/' (e.g. `fbl/set-tracked`). This is what users write and grep for, and it
+      // keeps the formatter's source round-trip valid. (Note: `::` is the *enum*
+      // separator in source — a different construct, not an Identifier.)
       write!(
         f,
-        "{}::{}",
+        "{}/{}",
         self
           .namespaces
           .iter()

--- a/shards/lang/src/check.rs
+++ b/shards/lang/src/check.rs
@@ -479,6 +479,114 @@ fn parse_unknown_shard(message: &str) -> Option<String> {
   }
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn st(name: &str, inputs: &[i32], outputs: &[i32]) -> ShardTypes {
+    ShardTypes {
+      name: name.to_string(),
+      inputs: inputs.to_vec(),
+      outputs: outputs.to_vec(),
+    }
+  }
+
+  #[test]
+  fn levenshtein_basics() {
+    assert_eq!(levenshtein("Log", "Log"), 0);
+    assert_eq!(levenshtein("Logg", "Log"), 1);
+    assert_eq!(levenshtein("", "abc"), 3);
+    assert_eq!(levenshtein("abc", ""), 3);
+    assert_eq!(levenshtein("kitten", "sitting"), 3);
+    // case-insensitive
+    assert_eq!(levenshtein("LOG", "log"), 0);
+  }
+
+  #[test]
+  fn did_you_mean_finds_close_typo() {
+    let all = vec![
+      "Log".to_string(),
+      "Math.Add".to_string(),
+      "ParseInt".to_string(),
+    ];
+    let s = did_you_mean("Logg", &all, 5);
+    assert!(s.contains(&"Log".to_string()), "got {:?}", s);
+  }
+
+  #[test]
+  fn did_you_mean_empty_for_far_off() {
+    let all = vec!["Log".to_string(), "Math.Add".to_string()];
+    assert!(did_you_mean("CompletelyUnrelatedName", &all, 5).is_empty());
+  }
+
+  #[test]
+  fn is_scalar_classifies() {
+    assert!(is_scalar(52)); // String
+    assert!(is_scalar(4)); // Int
+    assert!(!is_scalar(SHTYPE_ANY));
+    assert!(!is_scalar(SHTYPE_NONE));
+    assert!(!is_scalar(SHTYPE_SEQ));
+    assert!(!is_scalar(SHTYPE_TABLE));
+  }
+
+  #[test]
+  fn parse_unknown_shard_extracts_name() {
+    assert_eq!(
+      parse_unknown_shard("Shard Logg does not exist"),
+      Some("Logg".to_string())
+    );
+    assert_eq!(
+      parse_unknown_shard("Shard fbl/set-tracked does not exist"),
+      Some("fbl/set-tracked".to_string())
+    );
+    assert_eq!(parse_unknown_shard("some other error"), None);
+    // The unknown-function error has a different shape and must not match.
+    assert_eq!(
+      parse_unknown_shard("unknown built-in function or definition: fbl/x"),
+      None
+    );
+  }
+
+  #[test]
+  fn candidates_prefer_converters_and_drop_container_noise() {
+    // actual = String(52); expected = Int(4) and a Seq([Any], 56).
+    let index = vec![
+      st("ParseInt", &[52], &[4]),          // String -> Int : exact-input (tier 0)
+      st("ToInt", &[SHTYPE_ANY], &[4]),     // Any -> Int : tier 1
+      st("CSV.Read", &[52], &[SHTYPE_SEQ]), // String -> Seq : dropped (scalar actual)
+      st("Count", &[SHTYPE_ANY], &[4]),     // Any -> Int : tier 1
+      st("Math.Add", &[4], &[4]),           // offending : excluded
+    ];
+    let c = find_candidates(&index, 52, &[4, SHTYPE_SEQ], Some("Math.Add"), 10);
+    assert!(c.contains(&"ParseInt".to_string()), "got {:?}", c);
+    assert!(
+      !c.contains(&"CSV.Read".to_string()),
+      "seq-output must be dropped for a scalar mismatch: {:?}",
+      c
+    );
+    assert!(!c.contains(&"Math.Add".to_string()), "offending must be excluded");
+    // exact-input converter ranks before Any-input ones.
+    let pi = c.iter().position(|x| x == "ParseInt").unwrap();
+    if let Some(ti) = c.iter().position(|x| x == "ToInt") {
+      assert!(pi < ti, "exact-input should rank before Any-input: {:?}", c);
+    }
+  }
+
+  #[test]
+  fn candidates_empty_on_degenerate_input() {
+    let index = vec![st("ParseInt", &[52], &[4])];
+    assert!(find_candidates(&index, 52, &[], None, 10).is_empty()); // no expected
+    assert!(find_candidates(&index, SHTYPE_NONE, &[4], None, 10).is_empty()); // actual None
+    assert!(find_candidates(&index, 52, &[SHTYPE_ANY], None, 10).is_empty()); // only wildcard expected
+  }
+
+  #[test]
+  fn candidates_respect_max() {
+    let index: Vec<ShardTypes> = (0..20).map(|i| st(&format!("S{:02}", i), &[52], &[4])).collect();
+    assert_eq!(find_candidates(&index, 52, &[4], None, 5).len(), 5);
+  }
+}
+
 /// Emit the report (JSON or human) and compute the exit code.
 fn finish_report(file: String, diagnostics: Vec<JsonDiagnostic>, json: bool) -> i32 {
   let ok = !diagnostics.iter().any(|d| d.severity == "error");

--- a/shards/lang/src/check.rs
+++ b/shards/lang/src/check.rs
@@ -1,0 +1,502 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2026 Fragcolor Pte. Ltd. */
+
+//! `shards check` — compose-only verification with structured, machine-readable
+//! diagnostics for agent repair loops.
+//!
+//! The whole point of this command is to be the compiler-as-a-tool: it parses and
+//! composes a script but NEVER schedules, warms up, or runs it (no side effects),
+//! then reports every problem it can in a stable JSON schema. Three phases are
+//! surfaced distinctly:
+//!
+//!   - `parse`     — syntax errors from the reader
+//!   - `construct` — errors while building the wire graph (e.g. unknown shards)
+//!   - `compose`   — whole-program type validation (the structured oracle)
+//!
+//! On top of the raw diagnostics it adds two repair aids:
+//!   - did-you-mean suggestions for unknown shard names (edit distance over the
+//!     registry), and
+//!   - type-directed `candidates`: for an input/output type mismatch, the bridge
+//!     shards whose input accepts the actual type and whose output produces an
+//!     expected type.
+
+use crate::eval::eval;
+use crate::read::read;
+use crate::Program;
+use shards::core::{getShards, Core};
+use shards::types::{AutoShardRef, ComposeDiagnostic, Mesh};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+// Must mirror SHDiagnosticKind in include/shards/shards.h.
+const KIND_GENERIC: u8 = 0;
+const KIND_INPUT_TYPE_MISMATCH: u8 = 1;
+const KIND_COMPOSE_ERROR: u8 = 2;
+const KIND_UNKNOWN_SHARD: u8 = 3;
+
+// SHType values we special-case during candidate matching (see SHType in shards.h).
+const SHTYPE_NONE: i32 = 0;
+const SHTYPE_ANY: i32 = 1;
+const SHTYPE_SEQ: i32 = 56;
+const SHTYPE_TABLE: i32 = 57;
+
+/// A "scalar" for candidate purposes: anything that isn't a container or wildcard.
+/// A scalar/value mismatch is almost never repaired by producing a Seq/Table, so we
+/// use this to keep container targets from drowning out real value converters.
+fn is_scalar(b: i32) -> bool {
+  b != SHTYPE_ANY && b != SHTYPE_NONE && b != SHTYPE_SEQ && b != SHTYPE_TABLE
+}
+
+/// A single rendered type in the JSON output.
+#[derive(serde::Serialize, Clone)]
+struct JsonType {
+  /// Canonical type string (e.g. `String`, `[Int]`, `{none: Any}`).
+  name: String,
+  /// SHType value, -1 if unknown. Stable across releases; useful for tooling.
+  basic_type: i32,
+}
+
+/// One diagnostic in the JSON report.
+#[derive(serde::Serialize)]
+struct JsonDiagnostic {
+  /// `parse` | `construct` | `compose`.
+  phase: &'static str,
+  /// `error` | `warning`.
+  severity: &'static str,
+  /// Stable classification: `syntax` | `unknown-shard` | `input-type-mismatch` |
+  /// `compose-error` | `generic`.
+  kind: &'static str,
+  message: String,
+  file: String,
+  line: u32,
+  column: u32,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  shard: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  actual: Option<JsonType>,
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  expected: Vec<JsonType>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  param_index: Option<i32>,
+  /// Edit-distance suggestions for misspelled shard names.
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  did_you_mean: Vec<String>,
+  /// Type-directed bridge shards that could fix an input-type mismatch.
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  candidates: Vec<String>,
+}
+
+/// The top-level JSON document emitted by `shards check --json`.
+#[derive(serde::Serialize)]
+struct CheckReport {
+  ok: bool,
+  file: String,
+  diagnostics: Vec<JsonDiagnostic>,
+}
+
+/// Resolve a source-file id (as tracked through parse/compose) to a path string.
+fn source_file_name(file_id: u32) -> Option<String> {
+  unsafe {
+    let swl = (*Core).getSourceFileName.unwrap_unchecked()(file_id);
+    if swl.string.is_null() || swl.len == 0 {
+      None
+    } else {
+      Some(swl.str().to_string())
+    }
+  }
+}
+
+/// Case-insensitive Levenshtein distance (small inputs; allocates two rows).
+fn levenshtein(a: &str, b: &str) -> usize {
+  let a: Vec<char> = a.chars().flat_map(|c| c.to_lowercase()).collect();
+  let b: Vec<char> = b.chars().flat_map(|c| c.to_lowercase()).collect();
+  if a.is_empty() {
+    return b.len();
+  }
+  if b.is_empty() {
+    return a.len();
+  }
+  let mut prev: Vec<usize> = (0..=b.len()).collect();
+  let mut curr: Vec<usize> = vec![0; b.len() + 1];
+  for (i, &ca) in a.iter().enumerate() {
+    curr[0] = i + 1;
+    for (j, &cb) in b.iter().enumerate() {
+      let cost = if ca == cb { 0 } else { 1 };
+      curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+    }
+    std::mem::swap(&mut prev, &mut curr);
+  }
+  prev[b.len()]
+}
+
+/// Suggest up to `max` registered shard names close to `name`.
+fn did_you_mean(name: &str, all: &[String], max: usize) -> Vec<String> {
+  // Threshold scales with the typo'd name length; short names need exact-ish hits.
+  let threshold = (name.chars().count() / 3).max(2);
+  let mut scored: Vec<(usize, &String)> = all
+    .iter()
+    .map(|s| (levenshtein(name, s), s))
+    .filter(|(d, _)| *d <= threshold)
+    .collect();
+  scored.sort_by(|(da, sa), (db, sb)| da.cmp(db).then_with(|| sa.cmp(sb)));
+  scored.into_iter().take(max).map(|(_, s)| s.clone()).collect()
+}
+
+/// A compact view of a registered shard's input/output basic types, used to find
+/// bridge shards for the candidates engine.
+struct ShardTypes {
+  name: String,
+  inputs: Vec<i32>,
+  outputs: Vec<i32>,
+}
+
+/// Build the registry index of input/output basic types. This creates and destroys
+/// every registered shard once, so it is built lazily — only when at least one
+/// input-type-mismatch diagnostic actually needs candidates.
+fn build_shard_index() -> Vec<ShardTypes> {
+  let mut index = Vec::new();
+  for cname in getShards() {
+    let name = cname.to_string_lossy().to_string();
+    if let Some(shard) = AutoShardRef::create(&name, None) {
+      let inputs: Vec<i32> = shard.0.input_types().iter().map(|t| t.basicType as i32).collect();
+      let outputs: Vec<i32> = shard.0.output_types().iter().map(|t| t.basicType as i32).collect();
+      index.push(ShardTypes { name, inputs, outputs });
+    }
+  }
+  index
+}
+
+/// Find bridge shards that could repair an input-type mismatch: a shard whose input
+/// accepts `actual` and whose output produces one of `expected`.
+///
+/// Two refinements keep the list signal-dense:
+///   - Target outputs drop the `Any`/`None` wildcards; for a *scalar* actual we also
+///     drop container (`Seq`/`Table`) targets, which otherwise match every
+///     seq-producing shard (a scalar mismatch is not fixed by producing a container).
+///   - Results are ranked: converters whose input is *exactly* `actual` (e.g.
+///     `ParseInt: String -> Int`) come before ones that merely accept `Any`, so the
+///     genuinely useful bridges survive the truncation to `max`.
+fn find_candidates(
+  index: &[ShardTypes],
+  actual: i32,
+  expected: &[i32],
+  offending: Option<&str>,
+  max: usize,
+) -> Vec<String> {
+  if actual < 0 || actual == SHTYPE_NONE {
+    return Vec::new();
+  }
+  let non_generic: Vec<i32> = expected
+    .iter()
+    .copied()
+    .filter(|&b| b != SHTYPE_ANY && b != SHTYPE_NONE)
+    .collect();
+  if non_generic.is_empty() {
+    return Vec::new();
+  }
+  // Prefer scalar targets when the mismatch is a scalar; fall back to the full set
+  // only if there are no scalar targets (i.e. a genuine container is expected).
+  let targets: Vec<i32> = if is_scalar(actual) {
+    let scalars: Vec<i32> = non_generic.iter().copied().filter(|&b| is_scalar(b)).collect();
+    if scalars.is_empty() {
+      non_generic
+    } else {
+      scalars
+    }
+  } else {
+    non_generic
+  };
+
+  let mut scored: Vec<(u8, String)> = index
+    .iter()
+    .filter(|s| Some(s.name.as_str()) != offending)
+    .filter_map(|s| {
+      let in_exact = s.inputs.iter().any(|&b| b == actual);
+      let in_any = s.inputs.iter().any(|&b| b == SHTYPE_ANY);
+      let out_ok = s.outputs.iter().any(|&b| b != SHTYPE_ANY && targets.contains(&b));
+      if out_ok && (in_exact || in_any) {
+        Some((if in_exact { 0u8 } else { 1u8 }, s.name.clone()))
+      } else {
+        None
+      }
+    })
+    .collect();
+  scored.sort_by(|(ta, na), (tb, nb)| ta.cmp(tb).then_with(|| na.cmp(nb)));
+  scored.truncate(max);
+  scored.into_iter().map(|(_, n)| n).collect()
+}
+
+/// Map a structured compose diagnostic onto its JSON form, attaching candidates
+/// for input-type mismatches (building the registry index lazily on first need).
+fn compose_diag_to_json(
+  d: &ComposeDiagnostic,
+  fallback_file: &str,
+  index: &mut Option<Vec<ShardTypes>>,
+) -> JsonDiagnostic {
+  let kind = match d.kind {
+    KIND_INPUT_TYPE_MISMATCH => "input-type-mismatch",
+    KIND_COMPOSE_ERROR => "compose-error",
+    KIND_UNKNOWN_SHARD => "unknown-shard",
+    KIND_GENERIC => "generic",
+    _ => "generic",
+  };
+
+  let actual = d.actual.as_ref().map(|t| JsonType {
+    name: t.name.clone(),
+    basic_type: t.basic_type,
+  });
+  let expected: Vec<JsonType> = d
+    .expected
+    .iter()
+    .map(|t| JsonType {
+      name: t.name.clone(),
+      basic_type: t.basic_type,
+    })
+    .collect();
+
+  let mut candidates = Vec::new();
+  if d.kind == KIND_INPUT_TYPE_MISMATCH {
+    if let Some(actual_t) = d.actual.as_ref() {
+      let expected_basics: Vec<i32> = d.expected.iter().map(|t| t.basic_type).collect();
+      let idx = index.get_or_insert_with(build_shard_index);
+      let offending = if d.shard_name.is_empty() {
+        None
+      } else {
+        Some(d.shard_name.as_str())
+      };
+      candidates = find_candidates(idx, actual_t.basic_type, &expected_basics, offending, 10);
+    }
+  }
+
+  let file = if d.file.is_empty() {
+    fallback_file.to_string()
+  } else {
+    d.file.clone()
+  };
+
+  JsonDiagnostic {
+    phase: "compose",
+    severity: "error",
+    kind,
+    message: d.message.clone(),
+    file,
+    line: d.line,
+    column: d.column,
+    shard: if d.shard_name.is_empty() {
+      None
+    } else {
+      Some(d.shard_name.clone())
+    },
+    actual,
+    expected,
+    param_index: if d.param_index >= 0 {
+      Some(d.param_index)
+    } else {
+      None
+    },
+    did_you_mean: Vec::new(),
+    candidates,
+  }
+}
+
+/// Render the report in a concise, human-readable (clang-like) form to stdout.
+fn print_human(report: &CheckReport) {
+  if report.ok {
+    println!("{}: ok", report.file);
+    return;
+  }
+  for d in &report.diagnostics {
+    println!(
+      "{}:{}:{}: {} [{}/{}]: {}",
+      d.file, d.line, d.column, d.severity, d.phase, d.kind, d.message
+    );
+    if let Some(actual) = &d.actual {
+      if !d.expected.is_empty() {
+        let exp: Vec<&str> = d.expected.iter().map(|t| t.name.as_str()).collect();
+        println!("    found: {} | expected: {}", actual.name, exp.join(" | "));
+      }
+    }
+    if !d.candidates.is_empty() {
+      println!("    candidate bridges: {}", d.candidates.join(", "));
+    }
+    if !d.did_you_mean.is_empty() {
+      println!("    did you mean: {}", d.did_you_mean.join(", "));
+    }
+  }
+  let n = report.diagnostics.len();
+  println!("{} diagnostic{}", n, if n == 1 { "" } else { "s" });
+}
+
+/// Entry point for the `check` subcommand. Returns the process exit code:
+///   0 = ok, 1 = problems found, 2 = could not run the check (e.g. file missing).
+pub fn check_command(
+  file: &str,
+  include: Vec<String>,
+  json: bool,
+  cancellation_token: Arc<AtomicBool>,
+) -> i32 {
+  // Resolve the file and set the root path so includes resolve exactly as `run` would.
+  let file_path = match dunce::canonicalize(Path::new(file)) {
+    Ok(p) => p,
+    Err(_) => {
+      eprintln!("shards check: input file '{}' not found", file);
+      return 2;
+    }
+  };
+  let mut file_content = match std::fs::read_to_string(&file_path) {
+    Ok(c) => c,
+    Err(e) => {
+      eprintln!("shards check: failed to read '{}': {}", file, e);
+      return 2;
+    }
+  };
+  // The reader expects a trailing newline.
+  file_content.push('\n');
+
+  let parent_path = file_path.parent().and_then(|p| p.to_str()).unwrap_or(".").to_string();
+  if let Ok(c_parent) = std::ffi::CString::new(parent_path.clone()) {
+    unsafe { (*Core).setRootPath.unwrap_unchecked()(c_parent.as_ptr()) };
+  }
+
+  let mut include_paths = Vec::new();
+  for path in &include {
+    if let Ok(p) = dunce::canonicalize(std::path::PathBuf::from(path)) {
+      include_paths.push(p.to_string_lossy().to_string());
+    }
+  }
+
+  let display_file = file_path.to_string_lossy().to_string();
+  let mut diagnostics: Vec<JsonDiagnostic> = Vec::new();
+
+  // Phase 1: parse.
+  let ast: Program = match read(
+    &file_content,
+    file_path.to_str().unwrap(),
+    parent_path.clone(),
+    include_paths,
+  ) {
+    Ok(ast) => ast,
+    Err(e) => {
+      let file = source_file_name(e.loc.file).unwrap_or_else(|| display_file.clone());
+      diagnostics.push(JsonDiagnostic {
+        phase: "parse",
+        severity: "error",
+        kind: "syntax",
+        message: e.message,
+        file,
+        line: e.loc.line,
+        column: e.loc.column,
+        shard: None,
+        actual: None,
+        expected: Vec::new(),
+        param_index: None,
+        did_you_mean: Vec::new(),
+        candidates: Vec::new(),
+      });
+      return finish_report(display_file, diagnostics, json);
+    }
+  };
+
+  // Phase 2: construct (build the wire graph). Unknown shards surface here.
+  let wire = match eval(&ast, "root", HashMap::new(), cancellation_token) {
+    Ok(w) => w,
+    Err(e) => {
+      let file = source_file_name(e.loc.file).unwrap_or_else(|| display_file.clone());
+      // "Shard X does not exist" -> attach did-you-mean for X.
+      let (kind, shard, suggestions) = match parse_unknown_shard(&e.message) {
+        Some(name) => {
+          let names: Vec<String> = getShards()
+            .iter()
+            .map(|c| c.to_string_lossy().to_string())
+            .collect();
+          ("unknown-shard", Some(name.clone()), did_you_mean(&name, &names, 5))
+        }
+        None => ("generic", None, Vec::new()),
+      };
+      diagnostics.push(JsonDiagnostic {
+        phase: "construct",
+        severity: "error",
+        kind,
+        message: e.message,
+        file,
+        line: e.loc.line,
+        column: e.loc.column,
+        shard,
+        actual: None,
+        expected: Vec::new(),
+        param_index: None,
+        did_you_mean: suggestions,
+        candidates: Vec::new(),
+      });
+      return finish_report(display_file, diagnostics, json);
+    }
+  };
+
+  // Phase 3: compose (whole-program type validation). Never schedules or runs.
+  let mesh = Mesh::default();
+  let result = mesh.compose_check(wire.0);
+
+  let mut index: Option<Vec<ShardTypes>> = None;
+  for d in &result.diagnostics {
+    diagnostics.push(compose_diag_to_json(d, &display_file, &mut index));
+  }
+  // If compose failed but produced no structured diagnostics, surface the raw error.
+  if result.failed && result.diagnostics.is_empty() {
+    diagnostics.push(JsonDiagnostic {
+      phase: "compose",
+      severity: "error",
+      kind: "generic",
+      message: if result.error.is_empty() {
+        "Composition failed".to_string()
+      } else {
+        result.error.clone()
+      },
+      file: display_file.clone(),
+      line: 0,
+      column: 0,
+      shard: None,
+      actual: None,
+      expected: Vec::new(),
+      param_index: None,
+      did_you_mean: Vec::new(),
+      candidates: Vec::new(),
+    });
+  }
+
+  finish_report(display_file, diagnostics, json)
+}
+
+/// Extract the shard name out of the "Shard X does not exist" construct error.
+fn parse_unknown_shard(message: &str) -> Option<String> {
+  let rest = message.strip_prefix("Shard ")?;
+  let name = rest.strip_suffix(" does not exist")?;
+  if name.is_empty() {
+    None
+  } else {
+    Some(name.to_string())
+  }
+}
+
+/// Emit the report (JSON or human) and compute the exit code.
+fn finish_report(file: String, diagnostics: Vec<JsonDiagnostic>, json: bool) -> i32 {
+  let ok = !diagnostics.iter().any(|d| d.severity == "error");
+  let report = CheckReport { ok, file, diagnostics };
+  if json {
+    match serde_json::to_string_pretty(&report) {
+      Ok(s) => println!("{}", s),
+      Err(e) => {
+        eprintln!("shards check: failed to serialize report: {}", e);
+        return 2;
+      }
+    }
+  } else {
+    print_human(&report);
+  }
+  if ok {
+    0
+  } else {
+    1
+  }
+}

--- a/shards/lang/src/cli.rs
+++ b/shards/lang/src/cli.rs
@@ -74,6 +74,22 @@ enum Commands {
   New(RunArgs),
   /// Run a Shards script
   Run(RunArgs),
+  /// Type-check a Shards script: parse + compose only, never runs it.
+  ///
+  /// Emits structured, machine-readable diagnostics (with `--json`) suitable for
+  /// CI and agent repair loops. Exit code: 0 = ok, 1 = problems found, 2 = the
+  /// check could not run (e.g. missing file).
+  Check {
+    /// The script source file to check
+    #[arg(value_hint = clap::ValueHint::FilePath)]
+    file: String,
+    /// Emit machine-readable JSON diagnostics
+    #[arg(long, short = 'j', action)]
+    json: bool,
+    /// Additional include directories for imports
+    #[arg(long, short = 'I')]
+    include: Vec<String>,
+  },
   /// Evaluate Shards code from stdin
   Eval {
     /// Decompress help strings before evaluation
@@ -273,6 +289,15 @@ pub fn process_args(argc: i32, argv: *const *const c_char, _no_cancellation: boo
       } => load(file, args, *decompress_strings, cancellation_token),
       Commands::New(args) => execute(args, cancellation_token),
       Commands::Run(args) => execute(args, cancellation_token),
+      Commands::Check {
+        file,
+        json,
+        include,
+      } => {
+        // `check` controls its own exit code (and keeps stdout clean for `--json`),
+        // so it bypasses the generic error-logging `finish` path.
+        return crate::check::check_command(file, include.to_vec(), *json, cancellation_token);
+      }
       Commands::Eval {
         decompress_strings,
         args,

--- a/shards/lang/src/lib.rs
+++ b/shards/lang/src/lib.rs
@@ -6,6 +6,7 @@ extern crate clap;
 
 pub mod ast;
 pub mod ast_visitor;
+pub mod check;
 pub mod cli;
 pub mod custom_state;
 pub mod directory;

--- a/shards/lang/src/read.rs
+++ b/shards/lang/src/read.rs
@@ -1374,11 +1374,18 @@ pub fn read_with_env(code: &str, env: &mut ReadEnv) -> Result<Program, ShardsErr
 
   let successful_parse: pest::iterators::Pairs<'_, Rule> = {
     ShardsParser::parse(Rule::Program, code).map_err(|e| {
+      // pest carries the precise failure location; surface it as structured
+      // line/column so tooling (e.g. `shards check --json`) can localize the error
+      // instead of fishing it out of the message text.
+      let (line, column) = match e.line_col {
+        pest::error::LineColLocation::Pos((l, c)) => (l as u32, c as u32),
+        pest::error::LineColLocation::Span((l, c), _) => (l as u32, c as u32),
+      };
       (
         format!("Failed to parse file {:?}: {}", env.script_directory, e),
         LineInfo {
-          line: 0,
-          column: 0,
+          line,
+          column,
           file: env.resolve_file_id(),
         },
       )

--- a/shards/rust/src/types/mesh.rs
+++ b/shards/rust/src/types/mesh.rs
@@ -5,9 +5,86 @@
 
 use super::*;
 use crate::core::Core;
-use crate::shardsc::{SHMeshRef, SHWireRef};
+use crate::shardsc::{SHComposeResult, SHMeshRef, SHTypeDesc, SHWireRef};
 use crate::SHStringWithLen;
 use std::os::raw::c_char;
+
+/// A single type rendered for a compose diagnostic: a canonical string plus the
+/// top-level basic type id (SHType value, -1 when unknown).
+#[derive(Debug, Clone)]
+pub struct DiagType {
+  pub name: std::string::String,
+  pub basic_type: i32,
+}
+
+/// A structured, machine-readable compose-time diagnostic (see `shards check`).
+/// `kind` matches the C `SHDiagnosticKind` enum value.
+#[derive(Debug, Clone)]
+pub struct ComposeDiagnostic {
+  pub kind: u8,
+  pub line: u32,
+  pub column: u32,
+  pub file: std::string::String,
+  pub shard_name: std::string::String,
+  pub message: std::string::String,
+  pub actual: Option<DiagType>,
+  pub expected: Vec<DiagType>,
+  pub param_index: i32,
+}
+
+/// Result of a compose-only check: success flag, the human-readable error/stack
+/// trace, and the structured diagnostics.
+#[derive(Debug, Clone, Default)]
+pub struct CheckResult {
+  pub failed: bool,
+  pub error: std::string::String,
+  pub error_stack_trace: std::string::String,
+  pub diagnostics: Vec<ComposeDiagnostic>,
+}
+
+unsafe fn read_type_desc(d: &SHTypeDesc) -> Option<DiagType> {
+  if d.name.string.is_null() || d.name.len == 0 {
+    return None;
+  }
+  Some(DiagType {
+    name: d.name.str().to_string(),
+    basic_type: d.basicType,
+  })
+}
+
+unsafe fn read_check_result(r: &SHComposeResult) -> CheckResult {
+  let mut diagnostics = Vec::new();
+  if !r.diagnostics.is_null() && r.numDiagnostics > 0 {
+    let slice = std::slice::from_raw_parts(r.diagnostics, r.numDiagnostics as usize);
+    for d in slice {
+      let expected = if d.expected.is_null() || d.numExpected == 0 {
+        Vec::new()
+      } else {
+        std::slice::from_raw_parts(d.expected, d.numExpected as usize)
+          .iter()
+          .filter_map(|t| read_type_desc(t))
+          .collect()
+      };
+      diagnostics.push(ComposeDiagnostic {
+        kind: d.kind,
+        line: d.line,
+        column: d.column,
+        file: d.file.str().to_string(),
+        shard_name: d.shardName.str().to_string(),
+        message: d.message.str().to_string(),
+        actual: read_type_desc(&d.actual),
+        expected,
+        param_index: d.paramIndex,
+      });
+    }
+  }
+  CheckResult {
+    failed: r.failed,
+    error: r.error.str().to_string(),
+    error_stack_trace: r.errorStackTrace.str().to_string(),
+    diagnostics,
+  }
+}
 
 #[repr(transparent)] // force it same size of original
 #[derive(Clone)]
@@ -33,6 +110,18 @@ impl Mesh {
       Err(error.to_string())
     } else {
       Ok(())
+    }
+  }
+
+  /// Compose-only check: composes the wire against this mesh's environment exactly
+  /// like a real schedule would, but never schedules/warms/runs. Returns the
+  /// structured, machine-readable diagnostics used by `shards check`.
+  pub fn compose_check(&self, wire: WireRef) -> CheckResult {
+    unsafe {
+      let mut result = (*Core).composeForCheck.unwrap_unchecked()(self.0, wire.0);
+      let out = read_check_result(&result);
+      (*Core).freeComposeResult.unwrap_unchecked()(&mut result);
+      out
     }
   }
 

--- a/shards/rust/src/types/mod.rs
+++ b/shards/rust/src/types/mod.rs
@@ -31,7 +31,7 @@ pub mod shard_type;
 pub use common::*;
 
 // Re-export from submodules
-pub use mesh::{Mesh, MeshVar};
+pub use mesh::{CheckResult, ComposeDiagnostic, DiagType, Mesh, MeshVar};
 pub use wire::{
   Wire, WireRef, WireState, EnumInfoId, ObjectInfoId,
   get_enum_info, get_object_info, find_object_type_id, find_object_type_vendor_type_pair,

--- a/shards/tests/check/README.md
+++ b/shards/tests/check/README.md
@@ -1,0 +1,37 @@
+# `shards check` eval harness
+
+The measuring stick for diagnostic quality. For each script in `cases/`, the runner
+invokes `shards check --json` and asserts that the diagnostics carry what an agent
+repair loop needs: the right phase/kind, a precise location, structured
+`actual`/`expected` types, and the repair aids (`candidates`, `did_you_mean`).
+
+It also reports a **repairability** score — the fraction of broken cases whose
+diagnostic shipped an actionable repair aid. This is the signal roadmap items 3.3
+(canonical-form benchmark) and 3.4 (synthetic corpus) build on.
+
+## Run
+
+```sh
+shards/tests/check/run.sh           # auto-detects build/Release or build/Debug
+SHARDS=/path/to/shards shards/tests/check/run.sh
+```
+
+Requires `jq`. Exit code is non-zero if any assertion fails.
+
+## Cases
+
+| file | phase | kind | repair aid |
+|---|---|---|---|
+| `ok-basic.shs` | — | — | valid; composes cleanly (exit 0) |
+| `type-mismatch.shs` | compose | input-type-mismatch | type-directed `candidates` |
+| `unknown-shard.shs` | construct | unknown-shard | `did_you_mean` |
+| `syntax-error.shs` | parse | syntax | precise location |
+
+All three phases (parse, construct, compose) carry precise `line`/`column`.
+
+## Candidate quality
+
+The candidates engine matches on top-level `basicType` only, so an input-type
+mismatch may include type-valid-but-semantically-odd bridges alongside the obvious
+ones (e.g. `ParseInt`/`ParseFloat` for `String -> Int`). Inner seq/table element
+matching could sharpen this later.

--- a/shards/tests/check/cases/ok-basic.shs
+++ b/shards/tests/check/cases/ok-basic.shs
@@ -1,0 +1,2 @@
+// valid script — must compose cleanly (exit 0, ok:true)
+"Hello" | Log

--- a/shards/tests/check/cases/syntax-error.shs
+++ b/shards/tests/check/cases/syntax-error.shs
@@ -1,0 +1,3 @@
+// syntax error: unterminated shard call (missing closing paren).
+// Expected: parse-phase diagnostic, kind "syntax".
+"Hello" | Log(

--- a/shards/tests/check/cases/type-mismatch.shs
+++ b/shards/tests/check/cases/type-mismatch.shs
@@ -1,0 +1,5 @@
+// input-type mismatch: a String flows into Math.Add, which wants a number.
+// Expected: compose-phase diagnostic, kind "input-type-mismatch",
+// with structured actual/expected and non-empty type-directed candidates
+// (a String->number bridge such as ParseInt/ParseFloat/ToFloat).
+"42" | Math.Add(1)

--- a/shards/tests/check/cases/unknown-shard.shs
+++ b/shards/tests/check/cases/unknown-shard.shs
@@ -1,0 +1,4 @@
+// unknown shard: "Logg" is a typo for "Log".
+// Expected: construct-phase diagnostic, kind "unknown-shard",
+// with a non-empty did_you_mean that includes "Log".
+"Hello" | Logg

--- a/shards/tests/check/run.sh
+++ b/shards/tests/check/run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Eval harness for `shards check` — the measuring stick for diagnostic quality.
+#
+# For each script in cases/, runs `shards check --json` and asserts that the
+# diagnostics carry what an agent repair loop needs: the right phase/kind, a
+# precise location, structured actual/expected types, and the repair aids
+# (type-directed `candidates`, edit-distance `did_you_mean`).
+#
+# Reports a pass/fail summary and a "repairability" score: the fraction of broken
+# cases whose diagnostic included an actionable repair aid. This is exactly the
+# signal roadmap items 3.3 (canonical-form benchmark) and 3.4 (corpus) build on.
+#
+# Usage: shards/tests/check/run.sh   (set SHARDS=/path/to/shards to override)
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+CASES="$HERE/cases"
+
+# Locate the shards binary.
+if [[ -n "${SHARDS:-}" ]]; then
+  BIN="$SHARDS"
+elif [[ -x "$ROOT/build/Release/shards" ]]; then
+  BIN="$ROOT/build/Release/shards"
+elif [[ -x "$ROOT/build/Debug/shards" ]]; then
+  BIN="$ROOT/build/Debug/shards"
+else
+  echo "ERROR: could not find a shards binary (build it, or set SHARDS=...)" >&2
+  exit 2
+fi
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 2; }
+
+echo "Using binary: $BIN"
+echo
+
+PASS=0
+FAIL=0
+REPAIR_OK=0
+REPAIR_TOTAL=0
+
+# assert <description> <condition-exit-code>
+assert() {
+  local desc="$1" rc="$2"
+  if [[ "$rc" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# jq_true <json> <filter>  -> returns 0 if filter is truthy
+jq_true() { echo "$1" | jq -e "$2" >/dev/null 2>&1; }
+
+run_case() {
+  local name="$1"
+  local file="$CASES/$name.shs"
+  OUT="$("$BIN" check --json "$file" 2>/dev/null)"
+  CODE=$?
+  echo "case: $name (exit $CODE)"
+}
+
+# ---- ok-basic: valid script -------------------------------------------------
+run_case ok-basic
+assert "exit code 0" "$([[ $CODE -eq 0 ]]; echo $?)"
+assert "ok == true" "$(jq_true "$OUT" '.ok == true'; echo $?)"
+assert "no diagnostics" "$(jq_true "$OUT" '(.diagnostics | length) == 0'; echo $?)"
+echo
+
+# ---- type-mismatch: compose-phase input-type mismatch + candidates ----------
+run_case type-mismatch
+assert "exit code 1" "$([[ $CODE -eq 1 ]]; echo $?)"
+assert "has compose input-type-mismatch" \
+  "$(jq_true "$OUT" '[.diagnostics[] | select(.phase=="compose" and .kind=="input-type-mismatch")] | length > 0'; echo $?)"
+assert "diagnostic carries structured actual+expected" \
+  "$(jq_true "$OUT" '[.diagnostics[] | select(.kind=="input-type-mismatch") | select(.actual != null and (.expected|length)>0)] | length > 0'; echo $?)"
+REPAIR_TOTAL=$((REPAIR_TOTAL + 1))
+if jq_true "$OUT" '[.diagnostics[] | select(.kind=="input-type-mismatch") | select((.candidates|length)>0)] | length > 0'; then
+  assert "type-directed candidates present" 0
+  REPAIR_OK=$((REPAIR_OK + 1))
+else
+  assert "type-directed candidates present" 1
+fi
+echo
+
+# ---- unknown-shard: construct-phase + did_you_mean --------------------------
+run_case unknown-shard
+assert "exit code 1" "$([[ $CODE -eq 1 ]]; echo $?)"
+assert "has construct unknown-shard" \
+  "$(jq_true "$OUT" '[.diagnostics[] | select(.phase=="construct" and .kind=="unknown-shard")] | length > 0'; echo $?)"
+REPAIR_TOTAL=$((REPAIR_TOTAL + 1))
+if jq_true "$OUT" '[.diagnostics[] | select(.kind=="unknown-shard") | select(.did_you_mean | index("Log"))] | length > 0'; then
+  assert "did_you_mean includes Log" 0
+  REPAIR_OK=$((REPAIR_OK + 1))
+else
+  assert "did_you_mean includes Log" 1
+fi
+echo
+
+# ---- syntax-error: parse-phase ---------------------------------------------
+run_case syntax-error
+assert "exit code 1" "$([[ $CODE -eq 1 ]]; echo $?)"
+assert "has parse syntax diagnostic" \
+  "$(jq_true "$OUT" '[.diagnostics[] | select(.phase=="parse" and .kind=="syntax")] | length > 0'; echo $?)"
+assert "parse diagnostic has a location (line > 0)" \
+  "$(jq_true "$OUT" '[.diagnostics[] | select(.phase=="parse" and .line > 0)] | length > 0'; echo $?)"
+echo
+
+# ---- summary ---------------------------------------------------------------
+echo "================================================================"
+echo "assertions: $PASS passed, $FAIL failed"
+if [[ $REPAIR_TOTAL -gt 0 ]]; then
+  echo "repairability: $REPAIR_OK/$REPAIR_TOTAL broken cases shipped an actionable repair aid"
+fi
+echo "================================================================"
+
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## `shards check` — the compiler as the agent's tool

Implements roadmap item **3.1** (`docs/ai-first-roadmap.md`): a compose-only verification mode with structured, machine-readable diagnostics for agent repair loops and CI.

`shards check <file> [--json]` parses and composes a script — **never schedules, warms up, or runs it** — and reports diagnostics across three phases (`parse`, `construct`, `compose`).

Exit codes: `0` ok · `1` problems found · `2` could not run (e.g. missing file).

### JSON schema (per diagnostic)

`phase` · `severity` · `kind` (`syntax` | `unknown-shard` | `input-type-mismatch` | `compose-error` | `generic`) · `message` · `file` · `line` · `column` · `shard` · structured `actual`/`expected` (each `{name, basic_type}`) · `param_index` · plus two repair aids:

- **`candidates`** — type-directed bridge shards, computed by reverse-indexing the registry's input/output types. Scalar-aware, tiered ranking surfaces real converters (e.g. `ParseInt`/`ParseFloat` for `String → Int`) ahead of container/wildcard noise.
- **`did_you_mean`** — edit distance over the live shard registry for unknown shard names.

```jsonc
// "42" | Math.Add(1)
{ "phase": "compose", "kind": "input-type-mismatch", "line": 1, "column": 8, "shard": "Math.Add",
  "actual": { "name": "String", "basic_type": 52 },
  "expected": [ { "name": "Int", "basic_type": 4 }, ... ],
  "candidates": [ "ParseFloat", "ParseInt", "String.Find", ... ] }
```

### Architecture (hybrid)

A **minimal** C++ core change emits structured diagnostics — `SHDiagnostic[]` on `SHComposeResult`, carrying `SHTypeInfo`-derived type descriptors + source location + shard context — plus a non-throwing `composeForCheck` mesh entry that composes with semantics **identical** to a real schedule. All logic (JSON shaping, did-you-mean, candidates engine) lives in the Rust CLI (`shards/lang/src/check.rs`). Only owned strings + ints cross the ABI; no string re-parsing. The normal `run`/compose path is unchanged (it still uses the throwing path).

### Also in this PR

- **Parse-phase location** — syntax errors now carry precise `line`/`column` (extracted from the pest error; previously `0:0`). Improves all consumers, not just `check`.
- **Source-faithful identifier rendering** — namespaced identifiers render with `/` (e.g. `fbl/set-tracked`) in messages and the formatter source round-trip, instead of the `::` display convention (which also produced invalid source for namespaced `TakeTable` in the formatter).
- **Eval harness** (`shards/tests/check/`) — a broken-script corpus + `run.sh` that asserts diagnostic quality and reports a *repairability* score. This is the measuring stick that roadmap 3.3 (canonical-form benchmark) and 3.4 (synthetic corpus) build on.

### Verification

- Release build green.
- Eval harness: 13/13 assertions, repairability 2/2.
- Formatter round-trip tests pass (`shards test`).
- Regression: representative existing scripts run unchanged; the normal compose-error path is intact.

### Known follow-ups (tracked in the roadmap, not blocking)

- **Warnings** (type-widening `If`/`Maybe` → `Any`) — compose currently only throws on hard errors.
- **Parameter context** — `param_index` is reserved but not yet populated.
- **Candidate refinement** — coarse top-level `basic_type` matching; seq/table inner-type matching would sharpen it.
- **Isolated-fragment checking** — a library file relying on an externally-injected `@include` prelude reports those symbols as unknown when checked standalone (the live-environment angle of 3.5).

> Note: `just tests` (the full `.shs` suite) was not run end-to-end locally; a targeted regression subset + the formatter tests + the new harness pass. CI will cover the rest.
