### PR TITLE
feat(core): Shards.Index / Shards.Search discovery shards (shared with CLI)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -155,6 +155,14 @@ jobs:
           ./shards new ../shards/tests/db-paths.shs
           ./shards new ../shards/tests/suspend-resume.shs
           ./shards new ../shards/tests/help.shs
+          ./shards new ../shards/tests/discovery.shs
+          # Exercise the discovery CLI path so the shards_discovery_* C ABI
+          # (consumed by `enumerate`/`search`) is covered, not just the shards.
+          ./shards enumerate > /dev/null
+          ./shards enumerate --filter json --json > /dev/null
+          ./shards search ToJson > /dev/null
+          ./shards search tojsom --json > /dev/null
+          ./shards search zzznomatchqqq --json > /dev/null
           ./shards new ../shards/tests/whendone.shs
           ./shards new ../shards/tests/return.shs
           ./shards new ../shards/tests/table-seq-push.shs

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -239,6 +239,7 @@ if [ "$WITH_CPU" = true ]; then
         "shards/tests/table-recurse.shs||"
         "shards/tests/whendone.shs||"
         "shards/tests/help.shs||"
+        "shards/tests/discovery.shs||"
         "shards/tests/suspend-resume.shs||"
         "shards/tests/complex-deserialize.shs||"
         # Network and I/O tests

--- a/shards/lang/src/cli.rs
+++ b/shards/lang/src/cli.rs
@@ -4,7 +4,7 @@ use crate::{eval, formatter, Program};
 use crate::{eval::eval, eval::new_cancellation_token, read::read};
 use clap::{arg, CommandFactory, Parser};
 use clap_complete::{generate, Shell};
-use shards::core::{getShards, Core};
+use shards::core::Core;
 use shards::types::{get_enum_info, type_to_string, AutoShardRef, EnumInfoId, Mesh};
 use shards::util::from_raw_parts_allow_null;
 use shards::{
@@ -21,10 +21,29 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::{atomic, Arc};
 
+// One discovery row, owned by the core; freed via shards_discovery_free.
+#[repr(C)]
+struct ShShardIndexEntry {
+  name: *const c_char,
+  input: *const c_char,
+  output: *const c_char,
+  summary: *const c_char,
+  score: f64,
+}
+
 extern "C" {
   fn shardsInterface(version: u32) -> *mut SHCore;
   fn shards_install_signal_handlers();
   fn shards_decompress_strings();
+  // Discovery index + ranked search, served live from the core registry so the CLI
+  // (`enumerate`/`search`) and the Shards.Index / Shards.Search shards share one impl.
+  fn shards_discovery_index(out_count: *mut u64) -> *mut ShShardIndexEntry;
+  fn shards_discovery_search(
+    query: *const c_char,
+    limit: i64,
+    out_count: *mut u64,
+  ) -> *mut ShShardIndexEntry;
+  fn shards_discovery_free(entries: *mut ShShardIndexEntry, count: u64);
 }
 
 // `shards pak` (single-file packaging) lives in the `pak` module. The startup
@@ -757,50 +776,37 @@ struct ShardSummary {
   summary: String,
 }
 
-/// Compact type signature for the index (basic type names only; full detail lives in
-/// `docs --json`). Long unions are abbreviated so the index stays one line per shard.
-fn compact_types(types: &[SHTypeInfo]) -> String {
-  if types.is_empty() {
-    return "Any".to_string();
-  }
-  let mut names: Vec<&str> = types.iter().map(|t| type_to_string(t.basicType.into())).collect();
-  names.dedup();
-  if names.len() > 3 {
-    format!("{}/{}/…", names[0], names[1])
-  } else {
-    names.join("/")
-  }
-}
-
-/// Build the Tier-1 index: every registered shard as name / in→out / one-line summary.
-/// Sorted by name. Creates each shard once to read its types and help (same cost as
-/// the docs/check paths; sub-second).
-fn build_shard_index() -> Vec<ShardSummary> {
-  unsafe {
-    shards_decompress_strings();
-  }
+/// Read the heap-owned entries returned by a `shards_discovery_*` C entry into owned
+/// Rust values (paired with relevance score), then release the C allocation. The index
+/// build + ranking live in the core (discovery::buildIndex / discovery::search), so the
+/// CLI can never drift from the Shards.Index / Shards.Search shards.
+fn collect_index(ptr: *mut ShShardIndexEntry, count: u64) -> Vec<(ShardSummary, f64)> {
   let mut out = Vec::new();
-  for cname in getShards() {
-    let name = cname.to_string_lossy().to_string();
-    if let Some(shard) = AutoShardRef::create(&name, None) {
-      let s = &shard.0;
-      let summary = s
-        .help()
-        .unwrap_or("")
-        .lines()
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_string();
-      out.push(ShardSummary {
-        input: compact_types(s.input_types()),
-        output: compact_types(s.output_types()),
-        summary,
-        name,
-      });
-    }
+  if ptr.is_null() {
+    return out;
   }
-  out.sort_by(|a, b| a.name.cmp(&b.name));
+  let cstr = |p: *const c_char| -> String {
+    if p.is_null() {
+      String::new()
+    } else {
+      unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned()
+    }
+  };
+  unsafe {
+    for i in 0..count {
+      let e = &*ptr.add(i as usize);
+      out.push((
+        ShardSummary {
+          name: cstr(e.name),
+          input: cstr(e.input),
+          output: cstr(e.output),
+          summary: cstr(e.summary),
+        },
+        e.score,
+      ));
+    }
+    shards_discovery_free(ptr, count);
+  }
   out
 }
 
@@ -827,7 +833,12 @@ fn print_index(items: &[ShardSummary], json: bool) -> Result<(), Error> {
 }
 
 fn enumerate(filter: Option<&str>, json: bool) -> Result<(), Error> {
-  let mut items = build_shard_index();
+  let mut count: u64 = 0;
+  let ptr = unsafe { shards_discovery_index(&mut count) };
+  let mut items: Vec<ShardSummary> = collect_index(ptr, count)
+    .into_iter()
+    .map(|(s, _)| s)
+    .collect();
   if let Some(f) = filter {
     let f = f.to_lowercase();
     items.retain(|i| i.name.to_lowercase().contains(&f));
@@ -836,12 +847,32 @@ fn enumerate(filter: Option<&str>, json: bool) -> Result<(), Error> {
 }
 
 fn search(query: &str, json: bool) -> Result<(), Error> {
-  let q = query.to_lowercase();
-  let items: Vec<ShardSummary> = build_shard_index()
-    .into_iter()
-    .filter(|i| i.name.to_lowercase().contains(&q) || i.summary.to_lowercase().contains(&q))
-    .collect();
-  print_index(&items, json)
+  use serde_json::json;
+  let cq = std::ffi::CString::new(query).unwrap_or_default();
+  let mut count: u64 = 0;
+  let ptr = unsafe { shards_discovery_search(cq.as_ptr(), 0, &mut count) };
+  let scored = collect_index(ptr, count);
+  if json {
+    let arr: Vec<_> = scored
+      .iter()
+      .map(|(i, score)| {
+        json!({ "name": i.name, "input": i.input, "output": i.output, "summary": i.summary, "score": score })
+      })
+      .collect();
+    println!("{}", serde_json::to_string_pretty(&arr)?);
+  } else {
+    for (i, score) in &scored {
+      if i.summary.is_empty() {
+        println!("{:<32} {} → {}  [{:.2}]", i.name, i.input, i.output, score);
+      } else {
+        println!(
+          "{:<32} {} → {}  [{:.2}]  {}",
+          i.name, i.input, i.output, score, i.summary
+        );
+      }
+    }
+  }
+  Ok(())
 }
 
 fn format(file: &str, output: &Option<String>, inline: bool) -> Result<(), Error> {

--- a/shards/lang/src/cli.rs
+++ b/shards/lang/src/cli.rs
@@ -848,7 +848,7 @@ fn enumerate(filter: Option<&str>, json: bool) -> Result<(), Error> {
 
 fn search(query: &str, json: bool) -> Result<(), Error> {
   use serde_json::json;
-  let cq = std::ffi::CString::new(query).unwrap_or_default();
+  let cq = std::ffi::CString::new(query)?;
   let mut count: u64 = 0;
   let ptr = unsafe { shards_discovery_search(cq.as_ptr(), 0, &mut count) };
   let scored = collect_index(ptr, count);

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -2284,7 +2284,8 @@ namespace discovery {
 // and the command line agree on shape and ranking.
 
 // Compact type signature: deduplicated basic type names, abbreviated when long so a
-// row stays one line. Matches `compact_types` in cli.rs.
+// row stays one line. This is the canonical implementation; the CLI consumes it via
+// shards_discovery_index / shards_discovery_search rather than duplicating it.
 static std::string compactTypes(const SHTypesInfo &types) {
   if (types.len == 0)
     return "Any";
@@ -2456,11 +2457,11 @@ struct ShardsSearch {
 
   SHOptionalString help() {
     return SHCCSTR("Fuzzy-searches shards by name and summary for the query string given as input. Returns a sequence of "
-                   "tables {name, summary, score} ranked best-first (score in ~0..1): name substring matches rank highest, "
-                   "with edit-distance typo tolerance on the name and a weaker summary-substring signal.");
+                   "tables {name, input, output, summary, score} ranked best-first (score in ~0..1): name substring matches "
+                   "rank highest, with edit-distance typo tolerance on the name and a weaker summary-substring signal.");
   }
 
-  PARAM_VAR(_limit, "Limit", "Maximum number of results to return (0 = all matches).", {CoreInfo::IntType});
+  PARAM_VAR(_limit, "Limit", "Maximum number of results to return (0 = all matches).", {CoreInfo::NoneType, CoreInfo::IntType});
   PARAM_IMPL(PARAM_IMPL_FOR(_limit));
 
   SeqVar _output{};
@@ -2483,6 +2484,8 @@ struct ShardsSearch {
     for (auto &sr : discovery::search(SHSTRVIEW(input), limit)) {
       TableVar t{};
       t["name"] = Var(sr.row.name);
+      t["input"] = Var(sr.row.input);
+      t["output"] = Var(sr.row.output);
       t["summary"] = Var(sr.row.summary);
       t["score"] = Var(sr.score);
       _output.emplace_back(std::move(t));

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -12,6 +12,10 @@
 #include <boost/algorithm/string.hpp>
 #include <chrono>
 #include <shards/core/params.hpp>
+#include <shards/ops.hpp>
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
 
 #if SH_ANDROID
 extern "C" {
@@ -2274,6 +2278,285 @@ struct GetObjectTypeHelp {
   }
 };
 
+namespace discovery {
+// Shared discovery helpers behind Shards.Index / Shards.Search. These mirror the
+// CLI's tier-1 index (`enumerate`/`search` in shards/lang/src/cli.rs) so the shards
+// and the command line agree on shape and ranking.
+
+// Compact type signature: deduplicated basic type names, abbreviated when long so a
+// row stays one line. Matches `compact_types` in cli.rs.
+static std::string compactTypes(const SHTypesInfo &types) {
+  if (types.len == 0)
+    return "Any";
+  std::vector<std::string> names;
+  for (uint32_t i = 0; i < types.len; i++) {
+    std::string n = type2Name(types.elements[i].basicType);
+    if (names.empty() || names.back() != n) // consecutive dedup, like Rust Vec::dedup
+      names.push_back(std::move(n));
+  }
+  if (names.size() > 3)
+    return names[0] + "/" + names[1] + "/…";
+  std::string out;
+  for (size_t i = 0; i < names.size(); i++) {
+    if (i)
+      out.push_back('/');
+    out += names[i];
+  }
+  return out;
+}
+
+// First line of a (possibly compressed) help string, trimmed. Used as the summary.
+static std::string firstHelpLine(const SHOptionalString &help) {
+  std::string_view sv = help.string ? std::string_view(help.string) : std::string_view(getString(help.crc));
+  if (size_t nl = sv.find('\n'); nl != std::string_view::npos)
+    sv = sv.substr(0, nl);
+  size_t b = sv.find_first_not_of(" \t\r");
+  if (b == std::string_view::npos)
+    return "";
+  size_t e = sv.find_last_not_of(" \t\r");
+  return std::string(sv.substr(b, e - b + 1));
+}
+
+struct IndexRow {
+  std::string name;
+  std::string input;
+  std::string output;
+  std::string summary;
+};
+
+// Build the tier-1 index once: every registered shard as name / in→out / one-line
+// summary, sorted by name. Creating each shard to read its types/help is the same
+// cost the CLI and check paths pay; it's sub-second over the whole registry.
+static std::vector<IndexRow> buildIndex() {
+#ifdef SH_COMPRESSED_STRINGS
+  static bool decompressed = false;
+  if (!decompressed) {
+    decompressStrings();
+    decompressed = true;
+  }
+#endif
+  std::vector<IndexRow> rows;
+  for (auto &[name, _] : GetGlobals().ShardsRegister) {
+    auto shard = createShard(name);
+    if (!shard)
+      continue;
+    DEFER(shard->destroy(shard));
+    IndexRow row;
+    row.name = std::string(name);
+    row.input = compactTypes(shard->inputTypes(shard));
+    row.output = compactTypes(shard->outputTypes(shard));
+    row.summary = firstHelpLine(shard->help(shard));
+    rows.push_back(std::move(row));
+  }
+  std::sort(rows.begin(), rows.end(), [](const IndexRow &a, const IndexRow &b) { return a.name < b.name; });
+  return rows;
+}
+
+static size_t levenshtein(std::string_view a, std::string_view b) {
+  const size_t n = b.size();
+  std::vector<size_t> prev(n + 1), cur(n + 1);
+  for (size_t j = 0; j <= n; j++)
+    prev[j] = j;
+  for (size_t i = 1; i <= a.size(); i++) {
+    cur[0] = i;
+    for (size_t j = 1; j <= n; j++) {
+      size_t cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
+      cur[j] = std::min({prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost});
+    }
+    std::swap(prev, cur);
+  }
+  return prev[n];
+}
+
+// Fuzzy relevance of an already-lowercased query against one row, normalized to ~[0,1].
+// A name substring dominates (ranked by tightness + position); an edit-distance fallback
+// on the name tolerates typos; a summary substring is a weaker signal. 0 == drop.
+static double matchScore(std::string_view query, const IndexRow &row) {
+  if (query.empty())
+    return 0.0;
+  std::string name = boost::algorithm::to_lower_copy(row.name);
+  std::string summary = boost::algorithm::to_lower_copy(row.summary);
+
+  double best = 0.0;
+  if (name == query) {
+    best = 1.0;
+  } else if (size_t p = name.find(query); p != std::string::npos) {
+    double lenRatio = double(query.size()) / double(name.size());
+    double posPenalty = double(p) / double(name.size());
+    best = 0.6 + 0.3 * lenRatio - 0.1 * posPenalty;
+  } else {
+    size_t d = levenshtein(query, name);
+    size_t tol = std::max<size_t>(1, name.size() / 3);
+    if (d <= tol)
+      best = std::max(0.0, 0.5 - 0.1 * double(d));
+  }
+  if (!summary.empty() && summary.find(query) != std::string::npos)
+    best = std::max(best, 0.35);
+  return best;
+}
+
+struct ScoredRow {
+  IndexRow row;
+  double score;
+};
+
+// Single source of truth for ranked search: scores the whole index against the
+// (raw, case-insensitive) query, drops non-matches, sorts best-first with a
+// deterministic name tie-break, and truncates to limit (0 = all). Shared by the
+// Shards.Search shard and the CLI (`shards search`) via shards_discovery_search.
+static std::vector<ScoredRow> search(std::string_view rawQuery, int64_t limit) {
+  std::string query = boost::algorithm::to_lower_copy(std::string(rawQuery));
+  std::vector<ScoredRow> scored;
+  for (auto &row : buildIndex()) {
+    double s = matchScore(query, row);
+    if (s > 0.0)
+      scored.push_back({std::move(row), s});
+  }
+  std::sort(scored.begin(), scored.end(), [](const ScoredRow &a, const ScoredRow &b) {
+    if (a.score != b.score)
+      return a.score > b.score;     // higher score first
+    return a.row.name < b.row.name; // deterministic tie-break by name
+  });
+  if (limit > 0 && (size_t)limit < scored.size())
+    scored.resize((size_t)limit);
+  return scored;
+}
+} // namespace discovery
+
+struct ShardsIndex {
+  static SHTypesInfo inputTypes() { return CoreInfo::NoneType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::SeqOfAnyTableType; }
+
+  SHOptionalString help() {
+    return SHCCSTR("Returns the compact discovery index of every shard as a sequence of tables "
+                   "{name, input, output, summary}, where summary is the first line of the shard's help, sorted by name.");
+  }
+
+  SeqVar _output{};
+
+  void cleanup(SHContext *context) { _output = {}; }
+
+  SHVar activate(SHContext *context, const SHVar &input) {
+    _output.clear();
+    for (auto &row : discovery::buildIndex()) {
+      TableVar t{};
+      t["name"] = Var(row.name);
+      t["input"] = Var(row.input);
+      t["output"] = Var(row.output);
+      t["summary"] = Var(row.summary);
+      _output.emplace_back(std::move(t));
+    }
+    return _output;
+  }
+};
+
+struct ShardsSearch {
+  static SHTypesInfo inputTypes() { return CoreInfo::StringType; }
+  static SHTypesInfo outputTypes() { return CoreInfo::SeqOfAnyTableType; }
+
+  SHOptionalString help() {
+    return SHCCSTR("Fuzzy-searches shards by name and summary for the query string given as input. Returns a sequence of "
+                   "tables {name, summary, score} ranked best-first (score in ~0..1): name substring matches rank highest, "
+                   "with edit-distance typo tolerance on the name and a weaker summary-substring signal.");
+  }
+
+  PARAM_VAR(_limit, "Limit", "Maximum number of results to return (0 = all matches).", {CoreInfo::IntType});
+  PARAM_IMPL(PARAM_IMPL_FOR(_limit));
+
+  SeqVar _output{};
+
+  PARAM_REQUIRED_VARIABLES();
+  SHTypeInfo composeV2(SHInstanceData &data) {
+    PARAM_COMPOSE_REQUIRED_VARIABLES(data);
+    return outputTypes().elements[0];
+  }
+
+  void warmup(SHContext *context) { PARAM_WARMUP(context); }
+  void cleanup(SHContext *context) {
+    PARAM_CLEANUP(context);
+    _output = {};
+  }
+
+  SHVar activate(SHContext *context, const SHVar &input) {
+    _output.clear();
+    int64_t limit = (_limit.valueType == SHType::Int) ? _limit.payload.intValue : 0;
+    for (auto &sr : discovery::search(SHSTRVIEW(input), limit)) {
+      TableVar t{};
+      t["name"] = Var(sr.row.name);
+      t["summary"] = Var(sr.row.summary);
+      t["score"] = Var(sr.score);
+      _output.emplace_back(std::move(t));
+    }
+    return _output;
+  }
+};
+
+// Internal C entry points for the CLI (`shards enumerate`/`search`) so the command
+// line and the Shards.Index / Shards.Search shards share one index + ranking impl
+// (discovery::buildIndex / discovery::search). NOT part of the public _SHCore ABI;
+// the lang crate links these directly (same pattern as shards_decompress_strings).
+// Returned strings/arrays are heap-owned — release with shards_discovery_free.
+extern "C" {
+struct SHShardIndexEntry {
+  const char *name;
+  const char *input;
+  const char *output;
+  const char *summary;
+  double score; // relevance for search results; 0 for the plain index
+};
+
+static const char *shDiscoveryOwn(const std::string &s) {
+  char *p = (char *)malloc(s.size() + 1);
+  memcpy(p, s.data(), s.size());
+  p[s.size()] = '\0';
+  return p;
+}
+
+SHShardIndexEntry *shards_discovery_index(uint64_t *outCount) {
+  auto rows = discovery::buildIndex();
+  *outCount = rows.size();
+  if (rows.empty())
+    return nullptr;
+  auto *out = (SHShardIndexEntry *)malloc(sizeof(SHShardIndexEntry) * rows.size());
+  for (size_t i = 0; i < rows.size(); i++) {
+    out[i].name = shDiscoveryOwn(rows[i].name);
+    out[i].input = shDiscoveryOwn(rows[i].input);
+    out[i].output = shDiscoveryOwn(rows[i].output);
+    out[i].summary = shDiscoveryOwn(rows[i].summary);
+    out[i].score = 0.0;
+  }
+  return out;
+}
+
+SHShardIndexEntry *shards_discovery_search(const char *query, int64_t limit, uint64_t *outCount) {
+  auto scored = discovery::search(query ? std::string_view(query) : std::string_view(), limit);
+  *outCount = scored.size();
+  if (scored.empty())
+    return nullptr;
+  auto *out = (SHShardIndexEntry *)malloc(sizeof(SHShardIndexEntry) * scored.size());
+  for (size_t i = 0; i < scored.size(); i++) {
+    out[i].name = shDiscoveryOwn(scored[i].row.name);
+    out[i].input = shDiscoveryOwn(scored[i].row.input);
+    out[i].output = shDiscoveryOwn(scored[i].row.output);
+    out[i].summary = shDiscoveryOwn(scored[i].row.summary);
+    out[i].score = scored[i].score;
+  }
+  return out;
+}
+
+void shards_discovery_free(SHShardIndexEntry *entries, uint64_t count) {
+  if (!entries)
+    return;
+  for (uint64_t i = 0; i < count; i++) {
+    free((void *)entries[i].name);
+    free((void *)entries[i].input);
+    free((void *)entries[i].output);
+    free((void *)entries[i].summary);
+  }
+  free(entries);
+}
+}
+
 struct Iterate {
   PARAM_PARAMVAR(_from, "From", "The starting key to begin searching from (including this key).", {CoreInfo::AnyType});
   PARAM_PARAMVAR(_to, "To",
@@ -3847,6 +4130,8 @@ SHARDS_REGISTER_FN(core) {
   REGISTER_SHARD("UnsafeActivate!", UnsafeActivate);
   REGISTER_SHARD("Shards.Enumerate", GetShards);
   REGISTER_SHARD("Shards.Help", GetShardHelp);
+  REGISTER_SHARD("Shards.Index", ShardsIndex);
+  REGISTER_SHARD("Shards.Search", ShardsSearch);
   REGISTER_SHARD("LastError", LastError);
   REGISTER_SHARD("Shuffle", Shuffle);
   REGISTER_SHARD("Shards.EnumTypes", GetEnumTypes);

--- a/shards/tests/discovery.shs
+++ b/shards/tests/discovery.shs
@@ -1,0 +1,39 @@
+// Discovery shards: Shards.Index (tier-1 list) and Shards.Search (fuzzy ranked).
+// These back agent/edge-talk discovery from .shs; the CLI `enumerate`/`search`
+// share the same core implementation.
+
+@mesh(root)
+
+@wire(test {
+  // --- Shards.Index: non-empty; every row carries the four keys ---
+  Shards.Index = idx
+  idx | Count | IsMore(0) | Assert.Is(true)
+  idx | Take(0) | ExpectTable
+  {Take("name")    | ExpectString}
+  {Take("input")   | ExpectString}
+  {Take("output")  | ExpectString}
+  {Take("summary") | ExpectString}
+
+  // --- Shards.Search: an exact name ranks first with score 1.0 ---
+  "ToJson" | Shards.Search = hits
+  hits | Count | IsMore(0) | Assert.Is(true)
+  hits | Take(0) | ExpectTable | Take("name")  | ExpectString | Assert.Is("ToJson")
+  hits | Take(0) | ExpectTable | Take("score") | ExpectFloat  | Assert.Is(1.0)
+
+  // --- Limit is respected ---
+  "string" | Shards.Search(Limit: 3) | Count | IsLessEqual(3) | Assert.Is(true)
+
+  // --- Edit-distance typo tolerance: "tojsom" still surfaces ToJson ---
+  "tojsom" | Shards.Search(Limit: 5) = typo-hits
+  typo-hits | Count | IsMore(0) | Assert.Is(true)
+  typo-hits | Take(0) | ExpectTable | Take("name") | ExpectString | Assert.Is("ToJson")
+
+  // --- The edge-talk path: results serialize to JSON ---
+  "json" | Shards.Search(Limit: 3) | ToJson | ExpectString
+  Shards.Index | Limit(2) | ToJson | ExpectString
+
+  "discovery OK" | Log
+})
+
+@schedule(root test)
+@run(root)

--- a/shards/tests/discovery.shs
+++ b/shards/tests/discovery.shs
@@ -15,10 +15,13 @@
   {Take("summary") | ExpectString}
 
   // --- Shards.Search: an exact name ranks first with score 1.0 ---
+  // Search rows carry the same shape as the index plus a score (name/input/output/summary/score).
   "ToJson" | Shards.Search = hits
   hits | Count | IsMore(0) | Assert.Is(true)
-  hits | Take(0) | ExpectTable | Take("name")  | ExpectString | Assert.Is("ToJson")
-  hits | Take(0) | ExpectTable | Take("score") | ExpectFloat  | Assert.Is(1.0)
+  hits | Take(0) | ExpectTable | Take("name")   | ExpectString | Assert.Is("ToJson")
+  hits | Take(0) | ExpectTable | Take("input")  | ExpectString
+  hits | Take(0) | ExpectTable | Take("output") | ExpectString
+  hits | Take(0) | ExpectTable | Take("score")  | ExpectFloat  | Assert.Is(1.0)
 
   // --- Limit is respected ---
   "string" | Shards.Search(Limit: 3) | Count | IsLessEqual(3) | Assert.Is(true)


### PR DESCRIPTION
## What

Native shard-registry discovery for agents and edge talk, usable from `.shs` and serialized with `ToJson` — **no C ABI / `_SHCore` surface**, since edge talk's tools are written in shards anyway and only consume the core via `shardsInterface()`.

- **`Shards.Index`** → seq of `{name, input, output, summary}`, sorted by name (the tier-1 list; summary = first help line).
- **`Shards.Search`** (input: query string; param `Limit`, 0 = all) → fuzzy-ranked seq of `{name, summary, score}`: name substring dominates (by tightness/position), edit-distance typo fallback on the name, weaker summary-substring signal; exact name = 1.0.
- **docs** needs nothing new — the existing `Shards.Help` already returns the structured table, so `name | Shards.Help | ToJson` == `shards docs <name> --json`.

```shards
@wire(tool-search { Shards.Search(Limit: 20) | ToJson })  // input: query string
@wire(tool-index  { Shards.Index            | ToJson })
@wire(tool-docs   { Shards.Help             | ToJson })   // input: a shard name
```

## Shared implementation (no drift)

Index build + ranking live **once** in `discovery::buildIndex()` / `discovery::search()` (`core.cpp`). Two consumers:

1. the `Shards.Index` / `Shards.Search` shards;
2. the CLI `shards enumerate` / `search`, which now call internal `extern "C"` entries (`shards_discovery_index` / `search` / `free`) backed by those — correct dependency direction (lang links core, same pattern as `shards_decompress_strings`), nothing on `_SHCore`.

This **replaces the CLI's duplicate Rust index/search impl** (`build_shard_index`/`compact_types`/substring filter, deleted). Consequence: `shards search` is now fuzzy + scored, ranking identical to the shard.

`docs --json` (the Rust `help_json` recursive type-JSON) is intentionally left as-is — it's the stable agent contract.

## Tests

`shards/tests/discovery.shs` (registered in `run-tests.sh`): index keys present, exact name ranks 1.0, `Limit` respected, typo tolerance (`tojsom` → `ToJson`), and `ToJson` round-trip.

## Notes

- **Behavior change:** `shards search --json` output gains a `score` field and uses fuzzy ranking (superset of the old substring `{name,input,output,summary}` — backward-compatible for readers of name/summary).
- Verified locally on Release (Debug ASan deadlocks on this CLT): `discovery.shs` passes; `general.shs`/`help.shs` regression green; CLI↔shard parity confirmed.