### PR TITLE
fix: multi-word Shards.Search + Swift ObjC-exception bridge & color-space fix

### DIFF
--- a/.github/workflows/build-zig-cross.yml
+++ b/.github/workflows/build-zig-cross.yml
@@ -24,6 +24,11 @@ on:
           - riscv64-linux-musl
           - riscv32-linux-musl
 
+concurrency:
+  # A new push to a PR cancels that PR's in-progress run; pushes to devel run to completion.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-cross:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,11 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  # A new push to a PR cancels that PR's in-progress run; pushes to devel run to completion.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   Setup:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}

--- a/include/shards/SHObjCException.m
+++ b/include/shards/SHObjCException.m
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2024 Fragcolor Pte. Ltd. */
+
+#import <Foundation/Foundation.h>
+#include <string.h>
+
+// Runs `thunk(ctx)` inside an Objective-C @try/@catch. Returns NULL on success,
+// or a malloc'd UTF-8 description of the caught NSException (the caller must
+// free() it).
+//
+// Swift cannot catch Objective-C exceptions. Without this shim, an NSException
+// raised inside a Swift shard's lifecycle — e.g. NSColor/UIColor component
+// access on a non-RGB color, or other UIKit/AppKit misuse — unwinds straight
+// through Swift frames (which aren't set up for foreign-exception unwinding) and
+// hard-crashes the process; the shards runtime only bridges C++ exceptions.
+// Routing the Swift→C shard bridge (activate/warmup/cleanup/compose) through here
+// turns those otherwise-fatal exceptions into recoverable shard errors that get
+// reported back to the wire/model instead.
+//
+// Plain C function (defined in a .m so it has C linkage); the Swift side binds it
+// by symbol via @_silgen_name, so no bridging header is required.
+const char *SHRunCatchingNSException(void (*thunk)(void *), void *ctx) {
+  @try {
+    thunk(ctx);
+    return NULL;
+  } @catch (NSException *exception) {
+    NSString *desc = exception.reason ?: exception.name ?: @"Objective-C exception";
+    const char *utf8 = desc.UTF8String;
+    return strdup(utf8 ? utf8 : "Objective-C exception");
+  }
+}

--- a/include/shards/shards.swift
+++ b/include/shards/shards.swift
@@ -77,6 +77,42 @@ private let kAudioSampleRateDivisor: UInt32 = 25
 import Foundation
 import shards
 
+// MARK: - Objective-C exception boundary
+//
+// Swift cannot catch Objective-C exceptions; the shards runtime only bridges C++
+// ones. An NSException raised inside a Swift shard's lifecycle (e.g. NSColor
+// component access on a non-RGB color, or UIKit/AppKit misuse) would unwind
+// through Swift frames and hard-crash the process. `SHRunCatchingNSException`
+// (defined in SHObjCException.m, bound by symbol so no bridging header is needed)
+// runs a thunk inside an ObjC @try/@catch; the helper below adapts it to a Swift
+// closure and surfaces the exception description, so the shard bridge can abort
+// the wire with a real error instead of crashing.
+@_silgen_name("SHRunCatchingNSException")
+private func _shRunCatchingNSException(
+    _ thunk: @convention(c) (UnsafeMutableRawPointer?) -> Void,
+    _ ctx: UnsafeMutableRawPointer?
+) -> UnsafePointer<CChar>?
+
+/// Runs `body` inside an Objective-C @try/@catch. Returns `nil` on success, or the
+/// caught exception's description. `body` runs synchronously before returning.
+@usableFromInline
+func runCatchingObjCException(_ body: () -> Void) -> String? {
+    withoutActuallyEscaping(body) { escapingBody in
+        var box: () -> Void = escapingBody
+        return withUnsafeMutablePointer(to: &box) { boxPtr in
+            let raw = UnsafeMutableRawPointer(boxPtr)
+            guard let cString = _shRunCatchingNSException({ ctx in
+                ctx!.assumingMemoryBound(to: (() -> Void).self).pointee()
+            }, raw) else {
+                return nil
+            }
+            let message = String(cString: cString)
+            free(UnsafeMutableRawPointer(mutating: cString))
+            return message
+        }
+    }
+}
+
 public struct Globals {
     public var Core: UnsafeMutablePointer<SHCore>
 
@@ -1894,8 +1930,20 @@ extension IShard {}
     let typedInstance = unsafeBitCast(instance, to: T.self)
 
     var value = SHShardComposeResult()
-    let result = typedInstance.compose(data: data!.pointee)
-    switch result {
+    var result: Result<SHTypeInfo, ShardError>? = nil
+    let objcError = runCatchingObjCException {
+        result = typedInstance.compose(data: data!.pointee)
+    }
+    if let objcError = objcError {
+        var error = SHError()
+        error.code = 1
+        typedInstance.errorCache = ("Objective-C exception in shard: " + objcError).utf8CString
+        error.message.string = typedInstance.errorCache.withUnsafeBufferPointer { $0.baseAddress }
+        error.message.len = UInt64(typedInstance.errorCache.count - 1)
+        value.error = error
+        return value
+    }
+    switch result! {
     case let .success(typ):
         value.result = typ
         return value
@@ -1918,8 +1966,18 @@ extension IShard {}
     let typedInstance = unsafeBitCast(instance, to: T.self)
 
     var error = SHError()
-    let result = typedInstance.warmup(context: Context(context: ctx))
-    switch result {
+    var result: Result<Void, ShardError>? = nil
+    let objcError = runCatchingObjCException {
+        result = typedInstance.warmup(context: Context(context: ctx))
+    }
+    if let objcError = objcError {
+        error.code = 1
+        typedInstance.errorCache = ("Objective-C exception in shard: " + objcError).utf8CString
+        error.message.string = typedInstance.errorCache.withUnsafeBufferPointer { $0.baseAddress }
+        error.message.len = UInt64(typedInstance.errorCache.count - 1)
+        return error
+    }
+    switch result! {
     case .success():
         return error
     case let .failure(err):
@@ -1939,8 +1997,18 @@ extension IShard {}
     let typedInstance = unsafeBitCast(instance, to: T.self)
 
     var error = SHError()
-    let result = typedInstance.cleanup(context: Context(context: ctx))
-    switch result {
+    var result: Result<Void, ShardError>? = nil
+    let objcError = runCatchingObjCException {
+        result = typedInstance.cleanup(context: Context(context: ctx))
+    }
+    if let objcError = objcError {
+        error.code = 1
+        typedInstance.errorCache = ("Objective-C exception in shard: " + objcError).utf8CString
+        error.message.string = typedInstance.errorCache.withUnsafeBufferPointer { $0.baseAddress }
+        error.message.len = UInt64(typedInstance.errorCache.count - 1)
+        return error
+    }
+    switch result! {
     case .success():
         return error
     case let .failure(err):
@@ -1963,17 +2031,33 @@ extension IShard {}
     // Cache output pointer location - avoids repeated property access
     let outputPtr = withUnsafeMutablePointer(to: &typedInstance.output) { $0 }
 
-    // Process activation
-    let result = typedInstance.activate(context: Context(context: ctx), input: input!.pointee)
+    // Process activation inside an Objective-C @try/@catch so a stray NSException
+    // (e.g. a color shard touching a non-RGB NSColor) aborts the wire with a real
+    // error instead of crashing the app — Swift can't catch ObjC exceptions.
+    var result: Result<SHVar, ShardError>? = nil
+    let objcError = runCatchingObjCException {
+        result = typedInstance.activate(context: Context(context: ctx), input: input!.pointee)
+    }
+
+    if let objcError = objcError {
+        let message = "Objective-C exception in shard: \(objcError)"
+        message.withCString { cString in
+            var shString = SHStringWithLen()
+            shString.string = cString
+            shString.len = UInt64(message.utf8.count)
+            G.Core.pointee.abortWire(ctx, shString)
+        }
+        return UnsafePointer(outputPtr)
+    }
 
     // Handle result - success path is hot, keep it simple
-    if case let .success(res) = result {
+    if case let .success(res)? = result {
         typedInstance.output = res
         return UnsafePointer(outputPtr)
     }
 
     // Error path unchanged - not performance critical
-    if case let .failure(error) = result {
+    if case let .failure(error)? = result {
         error.message.withCString { cString in
             var shString = SHStringWithLen()
             shString.string = cString
@@ -2213,6 +2297,19 @@ class MeshController {
         let result = G.Core.pointee.compose(nativeRef, wire.nativeRef, &error.v)
         if result {
             schedule(wire: wire, compose: false)
+            return .success(())
+        }
+        return .failure(ShardError(message: error.v.string))
+    }
+
+    /// Compose a wire WITHOUT scheduling or running it — returns the real
+    /// composition error (variable/input/output type-flow mismatches, etc.) or
+    /// success. This is the full type-check that scheduling performs; unlike
+    /// `Shards.Distill` it is not just parse + parameter validation. Use it to
+    /// validate a script with no side effects.
+    func compose(wire: WireController) -> Result<Void, ShardError> {
+        let error = OwnedVar()
+        if G.Core.pointee.compose(nativeRef, wire.nativeRef, &error.v) {
             return .success(())
         }
         return .failure(ShardError(message: error.v.string))
@@ -2822,11 +2919,17 @@ enum Shards {
             var g: CGFloat = 0
             var b: CGFloat = 0
             var a: CGFloat = 0
-            color.getRed(&r, green: &g, blue: &b, alpha: &a)
-            payload.colorValue.r = UInt8(r * 255)
-            payload.colorValue.g = UInt8(g * 255)
-            payload.colorValue.b = UInt8(b * 255)
-            payload.colorValue.a = UInt8(a * 255)
+            // getRed returns false for color spaces it can't represent as RGBA
+            // (e.g. pattern colors), leaving r/g/b/a untouched — fall back to
+            // opaque white rather than storing garbage. Clamp because wide-gamut
+            // (P3) components can fall outside 0...1 and would trap UInt8.
+            if !color.getRed(&r, green: &g, blue: &b, alpha: &a) {
+                r = 1; g = 1; b = 1; a = 1
+            }
+            payload.colorValue.r = UInt8(max(0, min(255, (r * 255).rounded())))
+            payload.colorValue.g = UInt8(max(0, min(255, (g * 255).rounded())))
+            payload.colorValue.b = UInt8(max(0, min(255, (b * 255).rounded())))
+            payload.colorValue.a = UInt8(max(0, min(255, (a * 255).rounded())))
         }
 
         var nativeColor: UIColor {
@@ -2940,9 +3043,25 @@ enum Shards {
         init(color: NSColor) {
             self.init()
             valueType = VarType.Color.asSHType()
-            payload.colorValue.r = UInt8(color.redComponent * 255)
-            payload.colorValue.g = UInt8(color.greenComponent * 255)
-            payload.colorValue.b = UInt8(color.blueComponent * 255)
+            // NSColor.redComponent/green/blue/alpha raise an Objective-C
+            // NSException when the color is not already in an RGB color space
+            // (grayscale like .white/.black/.gray, system/catalog/semantic, or
+            // pattern colors). Swift cannot catch ObjC exceptions — only the
+            // runtime's C++ bridge does — so reading them directly crashes the
+            // app. Convert to sRGB first, clamp (wide-gamut/P3 components can
+            // exceed 1.0 and would trap UInt8), and fall back to opaque white if
+            // conversion is impossible (e.g. pattern colors).
+            if let c = color.usingColorSpace(.sRGB) ?? color.usingColorSpace(.deviceRGB) {
+                payload.colorValue.r = UInt8(max(0, min(255, (c.redComponent * 255).rounded())))
+                payload.colorValue.g = UInt8(max(0, min(255, (c.greenComponent * 255).rounded())))
+                payload.colorValue.b = UInt8(max(0, min(255, (c.blueComponent * 255).rounded())))
+                payload.colorValue.a = UInt8(max(0, min(255, (c.alphaComponent * 255).rounded())))
+            } else {
+                payload.colorValue.r = 255
+                payload.colorValue.g = 255
+                payload.colorValue.b = 255
+                payload.colorValue.a = 255
+            }
         }
 
         var nativeColor: NSColor {

--- a/shards/modules/core/CMakeLists.txt
+++ b/shards/modules/core/CMakeLists.txt
@@ -111,9 +111,16 @@ if(APPLE)
   target_include_directories(shards-core-swift-impl PRIVATE ${SHARDS_DIR}/include)
   set_target_properties(shards-core-swift-impl PROPERTIES Swift_MODULE_NAME shards_core_swift)
 
+  # ObjC @try/@catch shim that shards.swift binds via @_silgen_name (SHRunCatchingNSException).
+  # Built as its own C/ObjC static lib so every generator (Ninja, Xcode framework, iOS)
+  # compiles it with clang, and surfaced through the same interface that carries the Swift
+  # impl so it lands on the final link right after it (resolving shards.o's reference).
+  add_library(shards-core-objc-shim STATIC ${SHARDS_DIR}/include/shards/SHObjCException.m)
+  target_include_directories(shards-core-objc-shim PRIVATE ${SHARDS_DIR}/include)
+
   # Intermediate target some workaround for the xcode generator propagating some non-existent swift modules in combination with target duplication not working
   add_library(shards-core-swift INTERFACE)
-  target_link_libraries(shards-core-swift INTERFACE $<TARGET_FILE:shards-core-swift-impl>)
+  target_link_libraries(shards-core-swift INTERFACE $<TARGET_FILE:shards-core-swift-impl> shards-core-objc-shim)
   add_dependencies(shards-core-swift shards-core-swift-impl)
 
   target_link_libraries(shards-module-core shards-core-swift)

--- a/shards/modules/core/core.cpp
+++ b/shards/modules/core/core.cpp
@@ -2369,31 +2369,68 @@ static size_t levenshtein(std::string_view a, std::string_view b) {
   return prev[n];
 }
 
+// Fuzzy relevance of a single (already-lowercased) term against one row, normalized to
+// ~[0,1]. A name substring dominates (ranked by tightness + position); an edit-distance
+// fallback on the name tolerates typos; a summary substring is a weaker signal. 0 == miss.
+static double termScore(std::string_view term, const std::string &name, const std::string &summary) {
+  if (term.empty())
+    return 0.0;
+  double best = 0.0;
+  if (name == term) {
+    best = 1.0;
+  } else if (size_t p = name.find(term); p != std::string::npos) {
+    double lenRatio = double(term.size()) / double(name.size());
+    double posPenalty = double(p) / double(name.size());
+    best = 0.6 + 0.3 * lenRatio - 0.1 * posPenalty;
+  } else {
+    size_t d = levenshtein(term, name);
+    size_t tol = std::max<size_t>(1, name.size() / 3);
+    if (d <= tol)
+      best = std::max(0.0, 0.5 - 0.1 * double(d));
+  }
+  if (!summary.empty() && summary.find(term) != std::string::npos)
+    best = std::max(best, 0.35);
+  return best;
+}
+
 // Fuzzy relevance of an already-lowercased query against one row, normalized to ~[0,1].
-// A name substring dominates (ranked by tightness + position); an edit-distance fallback
-// on the name tolerates typos; a summary substring is a weaker signal. 0 == drop.
+// The query is split on whitespace: a single keyword scores exactly as termScore (exact
+// name = 1.0, substring, typo tolerance). A multi-word query averages its per-term scores,
+// so e.g. "swiftui stack" still surfaces stack-related shards even though no name/summary
+// contains that phrase verbatim — rows matching more (and better) terms rank higher. The
+// whole-phrase score is also taken, so an exact phrase hit in a name/summary still wins.
+// 0 == drop.
 static double matchScore(std::string_view query, const IndexRow &row) {
   if (query.empty())
     return 0.0;
   std::string name = boost::algorithm::to_lower_copy(row.name);
   std::string summary = boost::algorithm::to_lower_copy(row.summary);
 
-  double best = 0.0;
-  if (name == query) {
-    best = 1.0;
-  } else if (size_t p = name.find(query); p != std::string::npos) {
-    double lenRatio = double(query.size()) / double(name.size());
-    double posPenalty = double(p) / double(name.size());
-    best = 0.6 + 0.3 * lenRatio - 0.1 * posPenalty;
-  } else {
-    size_t d = levenshtein(query, name);
-    size_t tol = std::max<size_t>(1, name.size() / 3);
-    if (d <= tol)
-      best = std::max(0.0, 0.5 - 0.1 * double(d));
+  auto isSpace = [](char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r'; };
+  std::vector<std::string_view> terms;
+  for (size_t i = 0; i < query.size();) {
+    while (i < query.size() && isSpace(query[i]))
+      i++;
+    size_t start = i;
+    while (i < query.size() && !isSpace(query[i]))
+      i++;
+    if (i > start)
+      terms.push_back(query.substr(start, i - start));
   }
-  if (!summary.empty() && summary.find(query) != std::string::npos)
-    best = std::max(best, 0.35);
-  return best;
+  if (terms.empty())
+    return 0.0;
+  if (terms.size() == 1)
+    return termScore(terms[0], name, summary); // single keyword: behavior unchanged
+
+  double sum = 0.0;
+  bool any = false;
+  for (auto &t : terms) {
+    double s = termScore(t, name, summary);
+    sum += s;
+    any = any || s > 0.0;
+  }
+  double multi = any ? sum / double(terms.size()) : 0.0;
+  return std::max(multi, termScore(query, name, summary));
 }
 
 struct ScoredRow {
@@ -2458,7 +2495,9 @@ struct ShardsSearch {
   SHOptionalString help() {
     return SHCCSTR("Fuzzy-searches shards by name and summary for the query string given as input. Returns a sequence of "
                    "tables {name, input, output, summary, score} ranked best-first (score in ~0..1): name substring matches "
-                   "rank highest, with edit-distance typo tolerance on the name and a weaker summary-substring signal.");
+                   "rank highest, with edit-distance typo tolerance on the name and a weaker summary-substring signal. "
+                   "Multi-word queries are matched term by term, so a phrase like \"swiftui stack\" still surfaces "
+                   "stack-related shards.");
   }
 
   PARAM_VAR(_limit, "Limit", "Maximum number of results to return (0 = all matches).", {CoreInfo::NoneType, CoreInfo::IntType});

--- a/shards/tests/discovery.shs
+++ b/shards/tests/discovery.shs
@@ -31,6 +31,10 @@
   typo-hits | Count | IsMore(0) | Assert.Is(true)
   typo-hits | Take(0) | ExpectTable | Take("name") | ExpectString | Assert.Is("ToJson")
 
+  // --- Multi-word queries tokenize: a phrase that matches no single name/summary
+  //     verbatim still returns results because each term is scored on its own ---
+  "tojson fromjson" | Shards.Search(Limit: 5) | Count | IsMore(0) | Assert.Is(true)
+
   // --- The edge-talk path: results serialize to JSON ---
   "json" | Shards.Search(Limit: 3) | ToJson | ExpectString
   Shards.Index | Limit(2) | ToJson | ExpectString


### PR DESCRIPTION
Two independent fixes bundled into one branch so CI runs once.

## 1. Swift shards: ObjC-exception bridge + color-space fix (`38e7d67c9`)
- Wrap `activate`/`warmup`/`cleanup`/`compose` in an ObjC `@try/@catch` shim (`SHObjCException.m`, bound via `@_silgen_name`) so an `NSException` from a Swift shard (e.g. `NSColor` component access on a non-RGB color) becomes a recoverable wire error instead of a hard crash — the runtime previously only bridged C++ exceptions.
- Fix `SHVar(color:)` to convert color space before reading components (also sets alpha, clamps wide-gamut/P3).
- Add `MeshController.compose` for a run-free full type-check (backs edge-talk's `Shards.Check`).

Touches only the Swift/ObjC bridge (`include/shards/shards.swift`, `include/shards/SHObjCException.m`); exercised by the iOS/visionOS CI jobs.

## 2. Multi-word `Shards.Search` tokenization (`9aa4ed5a1`)
`Shards.Search` / `shards search` scored the whole query as a single string, so a multi-word query like `"SwiftUI stack vstack"` matched no shard name or summary verbatim and returned nothing — only single keywords hit.

`discovery::matchScore` now splits the (lowercased) query on whitespace:
- single-word queries are unchanged (exact name = 1.0, substring, edit-distance typo tolerance);
- multi-word queries average their per-term scores, so rows matching more — and better — terms rank highest;
- the whole-phrase score is still taken via `std::max`, so an exact phrase hit in a name/summary still wins.

Before: `shards search "SwiftUI stack vstack"` → (empty)
After: → `Tensor.Stack`, `Process.StackTrace`, `Debug.WireStack`, …

Covered by a new `"tojson fromjson"` case in `shards/tests/discovery.shs`.

## Verification
C++ Release build + `discovery.shs` pass locally; multi-word and single-word (`ToJson` → 1.00, no regression) searches confirmed. Swift bridge verified by CI.