### PR TITLE
Experimental ESP32-P4 (RISC-V) port — runtime + C++ core shards (prototype)

### DIFF
--- a/cmake/Modules.cmake
+++ b/cmake/Modules.cmake
@@ -2,6 +2,37 @@ option(SHARDS_WITH_EVERYTHING "Enables all modules, disabling this will only bui
 option(SHARDS_NO_RUST_UNION "Disables rust union build" OFF)
 option(SHARDS_WITH_DEFAULT "Default SHARDS_WITH_<name> state of modules" OFF)
 
+# ESP32/FreeRTOS: Force minimal module set
+# When building for ESP32, we disable everything by default and only enable core modules
+if(SH_ESP32 OR IDF_TARGET)
+  message(STATUS "ESP32 target detected - using minimal module set")
+  set(SHARDS_WITH_EVERYTHING OFF CACHE BOOL "" FORCE)
+  set(SHARDS_NO_RUST_UNION ON CACHE BOOL "" FORCE)
+
+  # Enable only essential modules for ESP32
+  set(SHARDS_WITH_CORE ON CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_RUN ON CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_STRUCT ON CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_DEBUG ON CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_ASSERT ON CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_ANIM ON CACHE BOOL "" FORCE)
+
+  # Disable heavy modules
+  set(SHARDS_WITH_HTTP OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_NETWORK OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_GFX OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_EGUI OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_AUDIO OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_LLM OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_CANDLE OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_PY OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_DEBUGGER OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_SSH OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_LOCALSHELL OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_DESKTOP OFF CACHE BOOL "" FORCE)
+  set(SHARDS_WITH_PHYSICS OFF CACHE BOOL "" FORCE)
+endif()
+
 # NOTES ABOUT MODULE UNIONS
 # Modules are built as OBJECT libraries, and then linked together at the end into a single static lib
 # The same happens for the rust modules

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -114,6 +114,14 @@ if(NOT EMSCRIPTEN AND(WIN32 OR MACOSX OR DESKTOP_LINUX))
   set(DESKTOP TRUE)
 endif()
 
+# ESP32/ESP-IDF detection (FreeRTOS-based)
+if(IDF_TARGET)
+  set(SH_ESP32 TRUE)
+  set(SH_FREERTOS TRUE)
+  set(HAVE_THREADS ON)  # FreeRTOS provides threading primitives
+  message(STATUS "ESP32 target detected: ${IDF_TARGET}")
+endif()
+
 # Zig cross-compilation detection
 if(ZIG_TARGET)
   set(ZIG_CROSSCOMPILE TRUE)

--- a/examples/esp32-test/.gitignore
+++ b/examples/esp32-test/.gitignore
@@ -1,0 +1,3 @@
+build/
+sdkconfig
+sdkconfig.old

--- a/examples/esp32-test/CMakeLists.txt
+++ b/examples/esp32-test/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.16)
+set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../shards/shards_esp32")
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32-test)

--- a/examples/esp32-test/main/CMakeLists.txt
+++ b/examples/esp32-test/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "main.cpp" INCLUDE_DIRS "." REQUIRES shards_esp32)

--- a/examples/esp32-test/main/main.cpp
+++ b/examples/esp32-test/main/main.cpp
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include "shards_esp32.h"
+
+// Exercise the component so the linker actually pulls in the glue (and thus the
+// core runtime symbols it references) — this surfaces exactly what core sources
+// still need to be compiled in.
+extern "C" void app_main(void) {
+  printf("Shards ESP32 boot\n");
+  shards_esp32_init();
+  printf("has running wires: %d\n", (int)shards_esp32_has_running_wires());
+  shards_esp32_tick();
+  shards_esp32_shutdown();
+  printf("done\n");
+}

--- a/examples/esp32-test/partitions.csv
+++ b/examples/esp32-test/partitions.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,   Size,    Flags
+nvs,      data, nvs,     0x9000,   0x6000,
+phy_init, data, phy,     0xf000,   0x1000,
+factory,  app,  factory, 0x10000,  0x300000,
+storage,  data, spiffs,  0x310000, 0x100000,

--- a/examples/esp32-test/sdkconfig.defaults
+++ b/examples/esp32-test/sdkconfig.defaults
@@ -1,0 +1,17 @@
+# Phase-1 bring-up: keep C++ exceptions + RTTI (Shards throws; removal is a later
+# size optimization, not a prerequisite).
+CONFIG_COMPILER_CXX_EXCEPTIONS=y
+CONFIG_COMPILER_CXX_RTTI=y
+
+# Size-oriented build; PSRAM-bearing P4 has headroom but keep it lean for now.
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+# Smaller printf/scanf family (saves ~40-50 KB of newlib in flash).
+CONFIG_NEWLIB_NANO_FORMAT=y
+
+# Shards wires need a roomy main task stack while we validate.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384
+
+# The runtime image is ~1.13 MB; default 1 MB factory partition is too small.
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y

--- a/include/shards/shards.hpp
+++ b/include/shards/shards.hpp
@@ -964,6 +964,15 @@ struct Var : public SHVar {
     payload.intValue = src;
   }
 
+#if __SIZEOF_LONG__ == 4
+  // ILP32 (e.g. rv32 / esp32p4): `long` is a distinct 32-bit type — and newlib
+  // aliases int32_t/SHEnum to `long` — so it matches neither Var(int) nor
+  // Var(int64_t) unambiguously. Provide explicit overloads. (On LP64 `long` IS
+  // int64_t, so this would redefine Var(int64_t); hence the guard.)
+  explicit Var(long src) : Var((int64_t)src) {}
+  explicit Var(unsigned long src) : Var((int64_t)(unsigned long long)src) {}
+#endif
+
   explicit Var(const std::string &src) : Var(std::string_view(src)) {}
   explicit Var(const char *src, size_t len) : SHVar() {
     valueType = SHType::String;

--- a/shards/core/asm/fcontext_riscv_elf.S
+++ b/shards/core/asm/fcontext_riscv_elf.S
@@ -114,7 +114,9 @@ sh_make_fcontext:
 
     /* Compute address of finish routine and store as RA */
     /* When context-function returns, it will jump to finish */
-    la t0, .L_sh_finish
+    /* lla (not la): always PC-relative, never a GOT reference — avoids emitting a
+       .got.plt that ESP32's static link script discards (final link failure). */
+    lla t0, .L_sh_finish
     REG_S t0, CTX_RA(a0)
 
     /* Return pointer to context-data */

--- a/shards/core/async.hpp
+++ b/shards/core/async.hpp
@@ -12,8 +12,10 @@
 #include "utils.hpp"
 #include "runtime.hpp"
 
+#if !SH_FREERTOS
 #include <boost/lockfree/queue.hpp>
 #include <boost/thread.hpp>
+#endif
 
 #include <tracy/Wrapper.hpp>
 
@@ -22,7 +24,7 @@
 #endif
 
 // Can not create this many workers, create on demand instead
-#if SH_EMSCRIPTEN
+#if SH_EMSCRIPTEN || SH_FREERTOS
 #define SH_ENABLE_TIDE_POOL 0
 #else
 #define SH_ENABLE_TIDE_POOL 1
@@ -32,7 +34,7 @@
 #include "taskflow.hpp"
 #endif
 
-#if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
+#if (defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)) || SH_FREERTOS
 #define HAS_ASYNC_SUPPORT 0
 #else
 #define HAS_ASYNC_SUPPORT 1

--- a/shards/core/coro.hpp
+++ b/shards/core/coro.hpp
@@ -12,7 +12,14 @@
 #endif
 
 #ifndef SH_BASE_STACK_SIZE
-#if SH_EMSCRIPTEN
+#if SH_FREERTOS
+// FreeRTOS: Use configurable stack size, default 8KB (much smaller than desktop)
+#ifdef CONFIG_SHARDS_STACK_SIZE
+#define SH_BASE_STACK_SIZE CONFIG_SHARDS_STACK_SIZE
+#else
+#define SH_BASE_STACK_SIZE (8 * 1024)
+#endif
+#elif SH_EMSCRIPTEN
 #define SH_BASE_STACK_SIZE 2 * 1024 * 1024
 #else
 #ifndef NDEBUG

--- a/shards/core/foundation.hpp
+++ b/shards/core/foundation.hpp
@@ -48,7 +48,12 @@ inline std::string formatShardSourceLocation(Shard *blk);
 // Needed specially for win32/32bit
 #include <boost/align/aligned_allocator.hpp>
 
+#if SH_ESP32
+// TBB has no ESP32 port; the runtime is cooperatively single-threaded there.
+#include <unordered_map>
+#else
 #include "oneapi/tbb/concurrent_unordered_map.h"
+#endif
 
 #include "coro.hpp"
 
@@ -1092,7 +1097,11 @@ public:
   std::string RootPath;
   std::string ExePath;
 
+#if SH_ESP32
+  std::unordered_map<uint32_t, SHOptionalString> *CompressedStrings{nullptr};
+#else
   oneapi::tbb::concurrent_unordered_map<uint32_t, SHOptionalString> *CompressedStrings{nullptr};
+#endif
 
   SHTableInterface TableInterface{
       .tableGetIterator =

--- a/shards/core/ops_internal.cpp
+++ b/shards/core/ops_internal.cpp
@@ -489,6 +489,10 @@ bool operator==(const SHTypeInfo &a, const SHTypeInfo &b) {
 
 ALWAYS_INLINE inline bool _almostEqual(const float a, const float b, const double e) { return __builtin_fabsf(a - b) <= e; }
 ALWAYS_INLINE inline bool _almostEqual(const double a, const double b, const double e) { return __builtin_fabs(a - b) <= e; }
+// Explicit narrow-integer overloads: on rv32 (esp toolchain) int8/int16 args are
+// equal-rank conversions to both int32_t and int64_t, making the call ambiguous.
+ALWAYS_INLINE inline bool _almostEqual(const int8_t a, const int8_t b, const double e) { return __builtin_abs(a - b) <= e; }
+ALWAYS_INLINE inline bool _almostEqual(const int16_t a, const int16_t b, const double e) { return __builtin_abs(a - b) <= e; }
 ALWAYS_INLINE inline bool _almostEqual(const int32_t a, const int32_t b, const double e) { return __builtin_abs(a - b) <= e; }
 ALWAYS_INLINE inline bool _almostEqual(const int64_t a, const int64_t b, const double e) { return __builtin_llabs(a - b) <= e; }
 

--- a/shards/core/platform.hpp
+++ b/shards/core/platform.hpp
@@ -22,6 +22,9 @@
 
 #elif defined(__linux__) && !defined(__EMSCRIPTEN__)
 #define SH_LINUX 1
+#elif defined(ESP_PLATFORM)
+#define SH_ESP32 1
+#define SH_FREERTOS 1
 #else
 #define SH_UNKNOWN 1
 #endif
@@ -52,6 +55,14 @@
 
 #ifndef SH_EMSCRIPTEN
 #define SH_EMSCRIPTEN 0
+#endif
+
+#ifndef SH_ESP32
+#define SH_ESP32 0
+#endif
+
+#ifndef SH_FREERTOS
+#define SH_FREERTOS 0
 #endif
 
 // Portable string duplication using C++ new/delete

--- a/shards/core/runtime.cpp
+++ b/shards/core/runtime.cpp
@@ -19,8 +19,10 @@
 #include "pmr/vector.hpp"
 #include "inline.hpp"
 #include "async.hpp"
+#if !SH_ESP32
 #include <boost/filesystem.hpp>
 #include <boost/stacktrace.hpp>
+#endif
 #include <csignal>
 #include <cstdarg>
 #include <mutex>
@@ -60,7 +62,9 @@
 #include <timeapi.h>
 #endif
 
+#if !SH_ESP32
 namespace fs = boost::filesystem;
+#endif
 
 using namespace shards;
 
@@ -145,7 +149,11 @@ SHOptionalString getCompiledCompressedString(uint32_t id) {
 
 #include <shards/core/shccstrings.hpp>
 
+#if SH_ESP32
+static std::unordered_map<uint32_t, std::string> strings_storage;
+#else
 static oneapi::tbb::concurrent_unordered_map<uint32_t, std::string> strings_storage;
+#endif
 
 void decompressStrings() {
   if (!shards::GetGlobals().CompressedStrings) {
@@ -194,6 +202,7 @@ extern "C" void __sanitizer_set_report_path(const char *path);
 #endif
 
 void loadExternalShards(std::string from) {
+#if !SH_ESP32
   static std::unordered_set<std::string> loaded;
   static std::mutex loadedMutex;
 
@@ -237,6 +246,7 @@ void loadExternalShards(std::string from) {
       }
     }
   }
+#endif
 }
 
 #ifdef TRACY_ENABLE
@@ -1769,7 +1779,7 @@ void error_handler(int err_sig) {
   }
 
   if (crashed) {
-#ifndef __EMSCRIPTEN__
+#if !defined(__EMSCRIPTEN__) && !SH_ESP32
     SHLOG_ERROR("{}", boost::stacktrace::to_string(boost::stacktrace::stacktrace()));
 #endif
 
@@ -2094,11 +2104,13 @@ endOfWire:
 void parseArguments(int argc, const char **argv) {
   shards::fast_string::init();
 
+#if !SH_ESP32
   namespace fs = boost::filesystem;
 
   auto &globals = GetGlobals();
   auto absExePath = fs::weakly_canonical(argv[0]);
   globals.ExePath = absExePath.string();
+#endif
 }
 
 Globals &GetGlobals() {
@@ -2744,6 +2756,7 @@ void shInit() {
   // Initialize log outputs only
   shInitLog();
 
+#if !SH_ESP32
   if (GetGlobals().RootPath.size() > 0) {
     // set root path as current directory
     fs::current_path(GetGlobals().RootPath.c_str());
@@ -2752,6 +2765,7 @@ void shInit() {
     auto cp = fs::current_path();
     GetGlobals().RootPath = cp.string();
   }
+#endif
 
 #ifdef SH_USE_UBSAN_REPORT
   auto absPath = fs::absolute(GetGlobals().RootPath);
@@ -3300,7 +3314,9 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
     }
 #endif
     shards::loadExternalShards(p1);
+#if !SH_ESP32
     fs::current_path(p1);
+#endif
     SHLOG_DEBUG("Root path set to: {}", p1);
   };
 
@@ -3436,7 +3452,9 @@ SHCore *__cdecl shardsInterface(uint32_t abi_version) {
 #if SHARDS_DEBUGGER
     dbg::unload();
 #endif
+#if SH_ENABLE_TIDE_POOL
     getTidePool().terminate();
+#endif
     SHLOG_INFO("! shards beforeUnload called !");
   };
 

--- a/shards/core/type_matcher.hpp
+++ b/shards/core/type_matcher.hpp
@@ -6,6 +6,7 @@
 #include <shards/defer.hpp>
 #include <boost/container/small_vector.hpp>
 #include <string>
+#include <set>
 #include <spdlog/spdlog.h>
 #include "ops_internal.hpp"
 

--- a/shards/fast_string/storage.cpp
+++ b/shards/fast_string/storage.cpp
@@ -9,7 +9,11 @@
 #include <boost/container/scoped_allocator.hpp>
 #include <tracy/Wrapper.hpp>
 
+// TBB has no ESP32/bare-metal port; the build can opt out via -DFAST_STRING_NO_TBB
+// to fall back to the boost.container implementation below.
+#if !defined(FAST_STRING_NO_TBB)
 #define FAST_STRING_USE_TBB 1
+#endif
 
 #ifdef FAST_STRING_USE_TBB
 #include <oneapi/tbb/concurrent_unordered_map.h>
@@ -70,7 +74,13 @@ std::string_view load(uint64_t id) {
 // Original complex implementation
 
 static constexpr size_t Megabyte = 1 << 20;
+#ifdef FAST_STRING_NO_TBB
+// Embedded (this non-TBB path is ESP32-only): a monotonic pool that grabs 8 MB on
+// first use would OOM the device. Start tiny; it grows geometrically as needed.
+static constexpr size_t InitialPoolSize = 64 * 1024;
+#else
 static constexpr size_t InitialPoolSize = Megabyte * 8;
+#endif
 
 using Alloc = boost::container::pmr::monotonic_buffer_resource;
 struct CountingAllocator : public boost::container::pmr::memory_resource {

--- a/shards/log/log.cpp
+++ b/shards/log/log.cpp
@@ -254,7 +254,12 @@ struct Sinks {
   }
 
   void initLogFileSink(std::string_view fileName) {
+#if SH_ESP32
+    // No boost::filesystem on device; VFS paths (e.g. /spiffs/log.txt) are already absolute.
+    std::string logFilePath = std::string(fileName);
+#else
     std::string logFilePath = boost::filesystem::absolute(boost::filesystem::path(std::string(fileName))).string();
+#endif
 
 #if defined(SHARDS_LOG_ROTATING_MAX_FILE_SIZE) && defined(SHARDS_LOG_ROTATING_MAX_FILES)
     logFileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logFilePath.c_str(), SHARDS_LOG_ROTATING_MAX_FILE_SIZE,

--- a/shards/modules/core/casting.cpp
+++ b/shards/modules/core/casting.cpp
@@ -1332,7 +1332,7 @@ struct AudioToBytes {
       const float *samples = audio.samples;
       for (uint32_t i = 0; i < audio.nsamples * audio.channels; i++) {
         int32_t sample = static_cast<int32_t>(samples[i] * 8388607.0f); // 2^23-1
-        sample = std::min(std::max(sample, -8388608), 8388607);
+        sample = std::min<int32_t>(std::max<int32_t>(sample, -8388608), 8388607);
 
         // Store as 3 bytes in little-endian
         _output[i * 3] = sample & 0xFF;

--- a/shards/modules/core/logging.cpp
+++ b/shards/modules/core/logging.cpp
@@ -13,7 +13,26 @@
 #include <cstdio>
 #include <shards/log/log.hpp>
 #include <spdlog/sinks/dist_sink.h>
+#if SH_ESP32
+// No TBB on device; the runtime is cooperatively single-threaded, so a plain
+// deque with the same minimal interface (emplace / try_pop) suffices.
+#include <deque>
+namespace shards::esp32_detail {
+template <typename T> struct SimpleQueue {
+  std::deque<T> _q;
+  void emplace(T &&v) { _q.emplace_back(std::move(v)); }
+  bool try_pop(T &out) {
+    if (_q.empty())
+      return false;
+    out = std::move(_q.front());
+    _q.pop_front();
+    return true;
+  }
+};
+} // namespace shards::esp32_detail
+#else
 #include <oneapi/tbb/concurrent_queue.h>
+#endif
 
 namespace shards {
 
@@ -199,7 +218,11 @@ struct LogCaptureContext {
   static inline const SHOptionalString VariableDescription = SHCCSTR("The log capture context.");
   static inline SHExposedTypeInfo VariableInfo = shards::ExposedInfo::ProtectedVariable(VariableName, VariableDescription, Type);
 
+#if SH_ESP32
+  shards::esp32_detail::SimpleQueue<spdlog::memory_buf_t> _messages;
+#else
   oneapi::tbb::concurrent_queue<spdlog::memory_buf_t> _messages;
+#endif
   std::vector<spdlog::memory_buf_t> _stringBuffer;
 
   void flush() {

--- a/shards/modules/core/time.cpp
+++ b/shards/modules/core/time.cpp
@@ -161,7 +161,11 @@ struct EpochLocal {
     long offset = local - utc;
 #else
     localtime_r(&tt, &local_tm);
+#if SH_ESP32
+    long offset = 0; // esp newlib struct tm lacks tm_gmtoff; treat local as UTC
+#else
     long offset = local_tm.tm_gmtoff;
+#endif
 #endif
 
     return Var(int64_t(tt + offset));
@@ -196,7 +200,11 @@ struct EpochLocalMs {
     long offset = local - utc;
 #else
     localtime_r(&tt, &local_tm);
+#if SH_ESP32
+    long offset = 0; // esp newlib struct tm lacks tm_gmtoff; treat local as UTC
+#else
     long offset = local_tm.tm_gmtoff;
+#endif
 #endif
 
     auto ms = duration_cast<milliseconds>(now.time_since_epoch());

--- a/shards/shards_esp32/CMakeLists.txt
+++ b/shards/shards_esp32/CMakeLists.txt
@@ -1,0 +1,191 @@
+# ESP-IDF Component CMakeLists.txt for Shards
+# This file is used when building Shards as an ESP-IDF component.
+#
+# NOTE (esp32-p4 revival): this is an incremental bring-up. It currently builds
+# only the glue translation units to flush out the header-level compile tail for
+# rv32 + IDF. Core sources get wired in once the headers compile clean.
+
+get_filename_component(SHARDS_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
+# IDF expands each component CMakeLists twice, once in `cmake -P` SCRIPT MODE to
+# scan REQUIRES. CPM's define_property() is not scriptable, so CPM cannot run here.
+# Reuse the already-downloaded header-only deps from the desktop CPM cache instead.
+set(CPM_CACHE "$ENV{CPM_SOURCE_CACHE}")
+if(NOT CPM_CACHE)
+  set(CPM_CACHE "$ENV{HOME}/.cache/CPM")
+endif()
+# Anchor on a marker file so we land on the versioned source dir, not the sibling
+# cmake.lock file that also lives under each cache entry.
+file(GLOB _entt_marker "${CPM_CACHE}/entt/*/src/entt/entt.hpp")
+file(GLOB _linalg_marker "${CPM_CACHE}/linalg/*/linalg.h")
+file(GLOB _stb_marker "${CPM_CACHE}/stb/*/stb_image.h")
+file(GLOB _tf_marker "${CPM_CACHE}/cpp-taskflow/*/taskflow/taskflow.hpp")
+file(GLOB _utf8_marker "${CPM_CACHE}/utf8.h/*/utf8.h")
+list(GET _entt_marker 0 _entt_m)
+# marker is <ver>/src/entt/entt.hpp; entt_SOURCE_DIR must be <ver> so /src appends
+get_filename_component(entt_SOURCE_DIR "${_entt_m}/../../.." ABSOLUTE)
+list(GET _linalg_marker 0 _linalg_m)
+get_filename_component(linalg_SOURCE_DIR "${_linalg_m}" DIRECTORY)
+list(GET _stb_marker 0 _stb_m)
+get_filename_component(stb_SOURCE_DIR "${_stb_m}" DIRECTORY)
+list(GET _tf_marker 0 _tf_m)
+get_filename_component(taskflow_SOURCE_DIR "${_tf_m}/../.." ABSOLUTE)
+list(GET _utf8_marker 0 _utf8_m)
+get_filename_component(utf8_SOURCE_DIR "${_utf8_m}" DIRECTORY)
+
+# gfx/linalg.hpp includes <linalg/linalg.h>; the cache dir holds linalg.h at its
+# root, so make a shim dir with a `linalg` symlink so that include resolves.
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/sh_shim)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/sh_shim/linalg)
+  file(CREATE_LINK ${linalg_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/sh_shim/linalg SYMBOLIC)
+endif()
+
+# Boost is CPM-downloaded by the normal desktop build into build/<cfg>/_deps/boost-src.
+# Reuse those modular headers here (header-only usage: align, atomic, container, ...).
+set(BOOST_SRC "" CACHE PATH "Path to a boost source tree (modular layout with libs/*/include)")
+if(NOT BOOST_SRC)
+  foreach(cfg Release Debug)
+    if(EXISTS "${SHARDS_ROOT}/build/${cfg}/_deps/boost-src/libs")
+      set(BOOST_SRC "${SHARDS_ROOT}/build/${cfg}/_deps/boost-src")
+      break()
+    endif()
+  endforeach()
+endif()
+if(NOT BOOST_SRC OR NOT EXISTS "${BOOST_SRC}/libs")
+  message(FATAL_ERROR "shards_esp32: could not locate boost sources. Set -DBOOST_SRC=<path to modular boost>")
+endif()
+file(GLOB BOOST_LIB_INCLUDES "${BOOST_SRC}/libs/*/include")
+message(STATUS "shards_esp32: using boost headers from ${BOOST_SRC} (${BOOST_LIB_INCLUDES})")
+
+# Glue (coro_freertos.cpp dropped: rv32 uses the desktop custom-fcontext fiber).
+set(ESP32_SOURCES
+    src/fs_esp32.cpp
+    src/main_esp32.cpp
+)
+
+# Core runtime sources + rv32 fcontext assembly + fast_string. core_inlined.cpp
+# pulls runtime.cpp (registerShards/GetGlobals/...). SHARDS_INLINE_EVERYTHING=0 so
+# the inlined shard activations come from modules/core separately if needed.
+set(SHARDS_CORE_CPP
+    ${SHARDS_ROOT}/shards/core/core_inlined.cpp
+    ${SHARDS_ROOT}/shards/core/coro.cpp
+    ${SHARDS_ROOT}/shards/core/ops_internal.cpp
+    ${SHARDS_ROOT}/shards/core/number_types.cpp
+    ${SHARDS_ROOT}/shards/core/utils.cpp
+    ${SHARDS_ROOT}/shards/core/wire_dsl.cpp
+    ${SHARDS_ROOT}/shards/core/trait.cpp
+    ${SHARDS_ROOT}/shards/core/type_info.cpp
+    ${SHARDS_ROOT}/shards/core/hash.cpp
+    ${SHARDS_ROOT}/shards/core/log_api.cpp
+    ${SHARDS_ROOT}/shards/core/wires.cpp
+    ${SHARDS_ROOT}/shards/core/async.cpp
+    ${SHARDS_ROOT}/shards/core/pmr/shared_temp_allocator.cpp
+    ${SHARDS_ROOT}/shards/log/log.cpp
+    ${SHARDS_ROOT}/shards/fast_string/storage.cpp
+)
+set(SHARDS_CORE_ASM ${SHARDS_ROOT}/shards/core/asm/fcontext_riscv_elf.S)
+
+# Rust-FREE subset of the core module's C++ shards (Const/Log/Math/If/cast/seqs/...).
+# Compiled with SHARDS_THIS_MODULE_ID=core so SHARDS_REGISTER_FN expands to
+# shardsRegister_core_<id> (see esp32_stubs.cpp registerModuleShards). Excludes
+# rust/serialization/memoize/parallel/wires.
+set(SHARDS_MODULE_CORE_CPP
+    ${SHARDS_ROOT}/shards/modules/core/core.cpp
+    ${SHARDS_ROOT}/shards/modules/core/casting.cpp
+    ${SHARDS_ROOT}/shards/modules/core/flow.cpp
+    ${SHARDS_ROOT}/shards/modules/core/linalg.cpp
+    ${SHARDS_ROOT}/shards/modules/core/math.cpp
+    ${SHARDS_ROOT}/shards/modules/core/seqs.cpp
+    ${SHARDS_ROOT}/shards/modules/core/strings.cpp
+    ${SHARDS_ROOT}/shards/modules/core/logging.cpp
+    ${SHARDS_ROOT}/shards/modules/core/time.cpp
+    ${SHARDS_ROOT}/shards/modules/core/exposed.cpp
+    ${SHARDS_ROOT}/shards/modules/core/trait.cpp
+)
+
+# boost.container pmr resources (fast_string non-TBB path uses monotonic_buffer_resource).
+# Compiled WITHOUT the shards prelude (they're upstream boost, not shards code).
+set(BOOST_CONTAINER_SRC
+    ${BOOST_SRC}/libs/container/src/global_resource.cpp
+    ${BOOST_SRC}/libs/container/src/monotonic_buffer_resource.cpp
+)
+
+list(APPEND ESP32_SOURCES ${SHARDS_CORE_CPP} ${SHARDS_MODULE_CORE_CPP} ${SHARDS_CORE_ASM} ${BOOST_CONTAINER_SRC} src/esp32_stubs.cpp)
+
+idf_component_register(
+    SRCS ${ESP32_SOURCES}
+    INCLUDE_DIRS
+        include
+        ${SHARDS_ROOT}
+        ${SHARDS_ROOT}/include
+        ${SHARDS_ROOT}/shards
+        ${SHARDS_ROOT}/shards/core
+        ${SHARDS_ROOT}/deps/spdlog/include
+        ${SHARDS_ROOT}/deps/magic_enum/include
+        ${SHARDS_ROOT}/deps/nameof/include
+        ${SHARDS_ROOT}/deps/xxHash
+        ${SHARDS_ROOT}/deps/json/include
+        ${SHARDS_ROOT}/deps/tracy_stub
+        ${taskflow_SOURCE_DIR}
+        # Generated InlineShard enum (shards/inlined.hpp) from the desktop build.
+        ${SHARDS_ROOT}/build/Release/src/union/generated
+        ${BOOST_LIB_INCLUDES}
+        ${linalg_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/sh_shim
+        ${utf8_SOURCE_DIR}
+        ${entt_SOURCE_DIR}/src
+        ${stb_SOURCE_DIR}
+    REQUIRES freertos vfs
+    PRIV_REQUIRES log spiffs
+)
+
+# Replace the desktop PCH (pch.cpp): force-include the esp32 prelude into every
+# core C++ TU so they get <vector>/<mutex>/Tracy/SHLOG_*/runtime.hpp like the PCH
+# guarantees. NOT applied to the .S asm.
+set_source_files_properties(
+    ${SHARDS_CORE_CPP} ${SHARDS_MODULE_CORE_CPP}
+    PROPERTIES COMPILE_OPTIONS "-include;${CMAKE_CURRENT_LIST_DIR}/include/sh_esp32_prelude.hpp"
+)
+# The core module's shards register as shardsRegister_core_<id>.
+set_source_files_properties(
+    ${SHARDS_MODULE_CORE_CPP}
+    PROPERTIES COMPILE_DEFINITIONS "SHARDS_THIS_MODULE_ID=core"
+)
+
+target_compile_definitions(${COMPONENT_LIB} PUBLIC
+    SH_ESP32=1
+    SH_FREERTOS=1
+    SH_STRIP_HELP_STRINGS=1    # drop per-shard help registration (~366 KB static-init + rodata)
+    SHARDS_WITH_ENTT=1         # entt is gated behind this in shards.hpp
+    SH_CUSTOM_FCONTEXT=1        # rv32 fcontext fiber (asm/fcontext_riscv_elf.S)
+    FAST_STRING_NO_TBB=1        # boost.container fallback instead of TBB
+    HAS_ASYNC_SUPPORT=0
+    SH_ENABLE_TIDE_POOL=0
+    HAS_BOOST_CONTAINER=1
+    SHARDS_INLINE_EVERYTHING=0
+    SHARDS_DEBUGGER=0
+    SPDLOG_NO_EXCEPTIONS=1
+    SPDLOG_NO_THREAD_ID=1
+    SHARDS_USE_ESP_LOG=1
+)
+
+target_compile_features(${COMPONENT_LIB} PUBLIC cxx_std_20)
+
+# Exceptions + RTTI stay ON for phase-1 bring-up (IDF supports them; removal is a
+# later size optimization, not a prerequisite). See sdkconfig.defaults.
+target_compile_options(${COMPONENT_LIB} PRIVATE
+    -Wno-unused-parameter
+    -Wno-missing-field-initializers
+    -Wno-error=maybe-uninitialized   # false positive in vendored xxhash.h on gcc 14
+    # Pre-existing warnings in core module headers that IDF promotes to errors.
+    -Wno-error=parentheses
+    -Wno-error=class-memaccess
+    # thread_local (shards::logging::threadState) defaults to global-dynamic TLS ->
+    # GOT/__tls_get_addr -> .got.plt, which ESP32's static link script discards.
+    # A static firmware is always local-exec.
+    -ftls-model=local-exec
+)
+
+if(CONFIG_SHARDS_STACK_SIZE)
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC CONFIG_SHARDS_STACK_SIZE=${CONFIG_SHARDS_STACK_SIZE})
+endif()

--- a/shards/shards_esp32/Kconfig
+++ b/shards/shards_esp32/Kconfig
@@ -1,0 +1,50 @@
+menu "Shards Configuration"
+
+    config SHARDS_STACK_SIZE
+        int "Wire task stack size (bytes)"
+        default 8192
+        range 4096 32768
+        help
+            Stack size for each wire's FreeRTOS task.
+            Each wire runs in its own task, so this affects memory usage.
+            Increase if you see stack overflow errors.
+            Decrease to save memory if your wires are simple.
+
+    config SHARDS_MAX_WIRES
+        int "Maximum concurrent wires"
+        default 8
+        range 1 32
+        help
+            Maximum number of wires that can be scheduled simultaneously.
+            Each wire uses SHARDS_STACK_SIZE bytes of stack memory.
+
+    config SHARDS_USE_PSRAM
+        bool "Use PSRAM for wire data"
+        default y
+        depends on ESP32_SPIRAM_SUPPORT
+        help
+            If enabled and PSRAM is available, wire data (variables,
+            strings, sequences) will be allocated from PSRAM to save
+            internal SRAM for stack and critical data.
+
+    config SHARDS_LOG_LEVEL
+        int "Shards log level"
+        default 3
+        range 0 5
+        help
+            Log level for Shards runtime:
+            0 = None
+            1 = Error
+            2 = Warning
+            3 = Info
+            4 = Debug
+            5 = Verbose
+
+    config SHARDS_WIRE_PATH
+        string "Default wire storage path"
+        default "/spiffs"
+        help
+            VFS path where serialized wire files are stored.
+            This can be a SPIFFS, LittleFS, or SD card mount point.
+
+endmenu

--- a/shards/shards_esp32/include/sh_esp32_prelude.hpp
+++ b/shards/shards_esp32/include/sh_esp32_prelude.hpp
@@ -1,0 +1,17 @@
+#pragma once
+// ESP32 force-include prelude. The core .cpp TUs are normally compiled with the
+// desktop precompiled header (shards/core/pch.cpp -> runtime.hpp + spdlog +
+// boost/filesystem). IDF doesn't use that PCH, so each TU is missing the prelude
+// it assumes (std containers, Tracy no-op macros, SHLOG_*, complete SHWire/etc).
+// This mirrors that prelude MINUS boost/filesystem (guarded out on ESP32).
+#include <vector>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <set>
+#include <unordered_map>
+#include <tracy/Wrapper.hpp>
+#include <spdlog/spdlog.h>
+#include <shards/log/log.hpp>
+#include <shards/core/runtime.hpp>

--- a/shards/shards_esp32/include/shards_esp32.h
+++ b/shards/shards_esp32/include/shards_esp32.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2020-2024 Fragcolor Pte. Ltd.
+
+#ifndef SHARDS_ESP32_H
+#define SHARDS_ESP32_H
+
+#include <shards/shards.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize the Shards ESP32 runtime.
+ * Must be called before any other shards_esp32_* functions.
+ * Registers all available shards and initializes the mesh.
+ */
+void shards_esp32_init(void);
+
+/**
+ * Shutdown the Shards ESP32 runtime.
+ * Stops all running wires and cleans up resources.
+ */
+void shards_esp32_shutdown(void);
+
+/**
+ * Load a wire from a VFS path (SPIFFS, LittleFS, SD, etc.).
+ * The wire is deserialized from the binary format.
+ *
+ * @param path VFS path to the serialized wire file (e.g., "/spiffs/main.shw")
+ * @return Wire reference on success, NULL on failure
+ */
+SHWireRef shards_esp32_load_wire(const char* path);
+
+/**
+ * Load a wire from memory buffer.
+ * Useful for wires embedded as const data in the firmware.
+ *
+ * @param data Pointer to serialized wire data
+ * @param size Size of the data in bytes
+ * @return Wire reference on success, NULL on failure
+ */
+SHWireRef shards_esp32_load_wire_from_memory(const uint8_t* data, size_t size);
+
+/**
+ * Schedule a wire for execution on the mesh.
+ * The wire will start running on the next tick.
+ *
+ * @param wire Wire reference to schedule
+ * @return true on success, false on failure
+ */
+bool shards_esp32_schedule_wire(SHWireRef wire);
+
+/**
+ * Run a single wire to completion (blocking).
+ * For one-shot wires that don't loop.
+ *
+ * @param wire Wire reference to run
+ * @param input Input value for the wire
+ * @return Output structure with result and state
+ */
+SHRunWireOutput shards_esp32_run_wire(SHWireRef wire, SHVar input);
+
+/**
+ * Tick all scheduled wires once.
+ * Should be called regularly from the main loop or a FreeRTOS task.
+ * Each wire will execute until it suspends or completes.
+ */
+void shards_esp32_tick(void);
+
+/**
+ * Check if any wires are still running.
+ *
+ * @return true if at least one wire is running
+ */
+bool shards_esp32_has_running_wires(void);
+
+/**
+ * Get the last error message, if any.
+ *
+ * @return Error message string, or NULL if no error
+ */
+const char* shards_esp32_get_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SHARDS_ESP32_H

--- a/shards/shards_esp32/src/coro_freertos.cpp
+++ b/shards/shards_esp32/src/coro_freertos.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2020-2024 Fragcolor Pte. Ltd.
+
+#include "platform.hpp"
+
+#if SH_FREERTOS
+
+#include "coro.hpp"
+#include <esp_log.h>
+
+static const char* TAG = "shards_fiber";
+
+namespace shards {
+
+void FreeRTOSFiber::taskEntry(void* param) {
+  auto* fiber = static_cast<FreeRTOSFiber*>(param);
+
+  // Wait for first resume signal before executing
+  xEventGroupWaitBits(fiber->eventGroup, BIT_RESUME, pdTRUE, pdFALSE, portMAX_DELAY);
+
+  // Execute the fiber function
+  if (fiber->func) {
+    fiber->func();
+  }
+
+  // Mark as finished
+  fiber->finished = true;
+  xEventGroupSetBits(fiber->eventGroup, BIT_FINISHED | BIT_SUSPENDED);
+
+  // Task will be deleted by destructor, suspend indefinitely
+  vTaskSuspend(nullptr);
+}
+
+FreeRTOSFiber::~FreeRTOSFiber() {
+  if (taskHandle) {
+    // Signal task to exit if still running
+    if (!finished) {
+      finished = true;
+      xEventGroupSetBits(eventGroup, BIT_RESUME);
+      // Give it a moment to notice
+      vTaskDelay(pdMS_TO_TICKS(1));
+    }
+    vTaskDelete(taskHandle);
+    taskHandle = nullptr;
+  }
+  if (eventGroup) {
+    vEventGroupDelete(eventGroup);
+    eventGroup = nullptr;
+  }
+}
+
+void FreeRTOSFiber::init(std::function<void()> fn) {
+  func = std::move(fn);
+  finished = false;
+  started = false;
+
+  // Create event group for synchronization
+  eventGroup = xEventGroupCreate();
+  if (!eventGroup) {
+    ESP_LOGE(TAG, "Failed to create event group");
+    return;
+  }
+
+  // Convert stack size from bytes to words (FreeRTOS uses words)
+  const size_t stackWords = stackSize / sizeof(StackType_t);
+
+  // Create the fiber task
+  BaseType_t result = xTaskCreate(
+      taskEntry,
+      "shards_fiber",
+      stackWords,
+      this,
+      tskIDLE_PRIORITY + 1,
+      &taskHandle
+  );
+
+  if (result != pdPASS) {
+    ESP_LOGE(TAG, "Failed to create fiber task, stack size: %d words", (int)stackWords);
+    vEventGroupDelete(eventGroup);
+    eventGroup = nullptr;
+    taskHandle = nullptr;
+    return;
+  }
+
+  // Run until first suspend point
+  resume();
+}
+
+void FreeRTOSFiber::resume() {
+  if (finished || !taskHandle || !eventGroup) {
+    return;
+  }
+
+  // Clear suspended bit, set resume bit
+  xEventGroupClearBits(eventGroup, BIT_SUSPENDED);
+  xEventGroupSetBits(eventGroup, BIT_RESUME);
+
+  // Wait for fiber to suspend or finish
+  EventBits_t bits = xEventGroupWaitBits(
+      eventGroup,
+      BIT_SUSPENDED | BIT_FINISHED,
+      pdFALSE,  // Don't clear on exit
+      pdFALSE,  // Wait for any bit
+      portMAX_DELAY
+  );
+
+  if (bits & BIT_FINISHED) {
+    finished = true;
+  }
+}
+
+void FreeRTOSFiber::suspend() {
+  if (finished || !taskHandle || !eventGroup) {
+    return;
+  }
+
+  // Signal that we're suspended
+  xEventGroupSetBits(eventGroup, BIT_SUSPENDED);
+
+  // Wait for resume signal
+  xEventGroupWaitBits(
+      eventGroup,
+      BIT_RESUME,
+      pdTRUE,   // Clear on exit
+      pdFALSE,  // Wait for any bit
+      portMAX_DELAY
+  );
+
+  // Clear suspended bit now that we're resuming
+  xEventGroupClearBits(eventGroup, BIT_SUSPENDED);
+}
+
+} // namespace shards
+
+#endif // SH_FREERTOS

--- a/shards/shards_esp32/src/esp32_stubs.cpp
+++ b/shards/shards_esp32/src/esp32_stubs.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2020-2024 Fragcolor Pte. Ltd.
+//
+// On-device link stubs for the esp32-p4 bring-up:
+//   * the shlang SOURCE PARSER FFI (normally the Rust langffi crate) — not needed
+//     on device, where we load pre-serialized wires rather than parse .shs text;
+//   * activateShardInline — the desktop inline-shard fast path lives in
+//     modules/core; here we just call the shard's own activate (semantically
+//     identical, only loses the inlining optimization);
+//   * registerModuleShards — the core module's shard registry; real shards are the
+//     next increment, this no-op lets registerShards() complete and the image link.
+#include <shards/core/runtime.hpp>
+#include <shards/core/foundation.hpp>
+#include <shards/modules/langffi/line_info.hpp>
+#include <ctime>
+#include <unistd.h>
+
+// esp32p4 newlib doesn't provide nanosleep; back it with usleep (us granularity is
+// plenty for the runtime's sleep helper).
+extern "C" int nanosleep(const struct timespec *req, struct timespec *rem) {
+  (void)rem;
+  if (req)
+    usleep((useconds_t)(req->tv_sec * 1000000ULL + (req->tv_nsec + 999) / 1000));
+  return 0;
+}
+
+namespace shards {
+const SHVar *activateShardInline(Shard *blk, SHContext *context, const SHVar &input) noexcept {
+  return blk->activate(blk, context, &input);
+}
+} // namespace shards
+
+// Hand-written registry (replaces the build-generated one) for the Rust-FREE subset
+// of core shards. Excludes rust/serialization/memoize/parallel/wires (Rust-backed or
+// thread-pool dependent). Each fn is the SHARDS_REGISTER_FN(core,<id>) entry point.
+extern "C" {
+void shardsRegister_core_core(SHCore *core);
+void shardsRegister_core_casting(SHCore *core);
+void shardsRegister_core_flow(SHCore *core);
+void shardsRegister_core_linalg(SHCore *core);
+void shardsRegister_core_math(SHCore *core);
+void shardsRegister_core_seqs(SHCore *core);
+void shardsRegister_core_strings(SHCore *core);
+void shardsRegister_core_logging(SHCore *core);
+void shardsRegister_core_time(SHCore *core);
+void shardsRegister_core_exposed(SHCore *core);
+void shardsRegister_core_trait(SHCore *core);
+}
+
+namespace shards {
+void registerModuleShards(SHCore *core) {
+  shardsRegister_core_core(core);
+  shardsRegister_core_casting(core);
+  shardsRegister_core_flow(core);
+  shardsRegister_core_linalg(core);
+  shardsRegister_core_math(core);
+  shardsRegister_core_seqs(core);
+  shardsRegister_core_strings(core);
+  shardsRegister_core_logging(core);
+  shardsRegister_core_time(core);
+  shardsRegister_core_exposed(core);
+  shardsRegister_core_trait(core);
+}
+} // namespace shards
+
+// shlang parser FFI (extern "C"): all fail/no-op — no on-device parser.
+extern "C" {
+bool shards_read(SHStringWithLen, SHStringWithLen, SHStringWithLen, const SHStringWithLen *, uint32_t, SHLAst *) { return false; }
+bool shards_load_ast(const uint8_t *, uint32_t, SHLAst *) { return false; }
+void shards_free_error(SHLError *) {}
+SHLEvalEnv *shards_create_env(SHStringWithLen) { return nullptr; }
+void shards_free_env(SHLEvalEnv *) {}
+bool shards_eval_env(SHLEvalEnv *, const SHVar *, SHLError *) { return false; }
+bool shards_set_defines(SHLEvalEnv *, const SHVar *, SHLError *) { return false; }
+bool shards_transform_env(SHLEvalEnv *, SHStringWithLen, SHLWire *) { return false; }
+bool shards_transform_envs(SHLEvalEnv **, size_t, SHStringWithLen, SHLWire *) { return false; }
+bool shards_eval_ast(const SHVar *, SHStringWithLen, SHLWire *) { return false; }
+void shards_free_wire(SHLWire *) {}
+void shards_free_ast(SHLAst *) {}
+}
+
+// langffi file registry (declared in line_info.hpp, C++ linkage).
+SHFileRegistryHandle *shlang_fr_static() { return nullptr; }
+uint32_t shlang_fr_get_file_id(SHFileRegistryHandle *, SHStringWithLen) { return 0; }
+SHStringWithLen shlang_fr_get_file_name(SHFileRegistryHandle *, uint32_t) { return SHStringWithLen{nullptr, 0}; }

--- a/shards/shards_esp32/src/fs_esp32.cpp
+++ b/shards/shards_esp32/src/fs_esp32.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2020-2024 Fragcolor Pte. Ltd.
+
+#include "platform.hpp"
+
+#if SH_FREERTOS
+
+#include "shards_esp32.h"
+#include <shards/core/serialization.hpp>
+#include <shards/core/foundation.hpp>
+#include <esp_log.h>
+#include <cstdio>
+#include <vector>
+
+static const char* TAG = "shards_fs";
+
+namespace shards::esp32 {
+
+// VFS-based binary reader for deserializing wires
+struct VFSReader {
+  FILE* file{nullptr};
+  bool valid_{false};
+
+  VFSReader(const char* path) {
+    file = fopen(path, "rb");
+    valid_ = (file != nullptr);
+    if (!valid_) {
+      ESP_LOGE(TAG, "Failed to open file: %s", path);
+    }
+  }
+
+  ~VFSReader() {
+    if (file) {
+      fclose(file);
+      file = nullptr;
+    }
+  }
+
+  void operator()(uint8_t* buf, size_t size) {
+    if (file && size > 0) {
+      size_t read = fread(buf, 1, size, file);
+      if (read != size) {
+        ESP_LOGW(TAG, "Short read: expected %d, got %d", (int)size, (int)read);
+      }
+    }
+  }
+
+  bool valid() const { return valid_; }
+};
+
+// Memory-based binary reader for embedded wire data
+struct MemoryReader {
+  const uint8_t* data;
+  size_t size;
+  size_t offset{0};
+
+  MemoryReader(const uint8_t* data, size_t size) : data(data), size(size) {}
+
+  void operator()(uint8_t* buf, size_t len) {
+    if (offset + len > size) {
+      ESP_LOGW(TAG, "Read past end: offset=%d, len=%d, size=%d",
+               (int)offset, (int)len, (int)size);
+      len = (offset < size) ? (size - offset) : 0;
+    }
+    if (len > 0) {
+      memcpy(buf, data + offset, len);
+      offset += len;
+    }
+  }
+
+  bool valid() const { return data != nullptr && size > 0; }
+};
+
+std::shared_ptr<SHWire> loadWireFromPath(const char* path) {
+  VFSReader reader(path);
+  if (!reader.valid()) {
+    return nullptr;
+  }
+
+  try {
+    Serialization serial;
+    SHVar wire_var{};
+    serial.deserialize(reader, wire_var);
+
+    if (wire_var.valueType != SHType::Wire) {
+      ESP_LOGE(TAG, "Deserialized value is not a wire");
+      destroyVar(wire_var);
+      return nullptr;
+    }
+
+    auto wire = SHWire::sharedFromRef(wire_var.payload.wireValue);
+    ESP_LOGI(TAG, "Loaded wire: %s", wire->name.c_str());
+    return wire;
+  } catch (const std::exception& e) {
+    ESP_LOGE(TAG, "Failed to deserialize wire: %s", e.what());
+    return nullptr;
+  }
+}
+
+std::shared_ptr<SHWire> loadWireFromMemory(const uint8_t* data, size_t size) {
+  MemoryReader reader(data, size);
+  if (!reader.valid()) {
+    return nullptr;
+  }
+
+  try {
+    Serialization serial;
+    SHVar wire_var{};
+    serial.deserialize(reader, wire_var);
+
+    if (wire_var.valueType != SHType::Wire) {
+      ESP_LOGE(TAG, "Deserialized value is not a wire");
+      destroyVar(wire_var);
+      return nullptr;
+    }
+
+    auto wire = SHWire::sharedFromRef(wire_var.payload.wireValue);
+    ESP_LOGI(TAG, "Loaded wire from memory: %s", wire->name.c_str());
+    return wire;
+  } catch (const std::exception& e) {
+    ESP_LOGE(TAG, "Failed to deserialize wire from memory: %s", e.what());
+    return nullptr;
+  }
+}
+
+} // namespace shards::esp32
+
+#endif // SH_FREERTOS

--- a/shards/shards_esp32/src/main_esp32.cpp
+++ b/shards/shards_esp32/src/main_esp32.cpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2020-2024 Fragcolor Pte. Ltd.
+
+#include "platform.hpp"
+
+#if SH_FREERTOS
+
+#include "shards_esp32.h"
+#include <shards/core/runtime.hpp>
+#include <shards/core/foundation.hpp>
+#include <esp_log.h>
+#include <memory>
+#include <string>
+
+static const char* TAG = "shards_esp32";
+
+namespace shards::esp32 {
+
+// Forward declarations from fs_esp32.cpp
+std::shared_ptr<SHWire> loadWireFromPath(const char* path);
+std::shared_ptr<SHWire> loadWireFromMemory(const uint8_t* data, size_t size);
+
+// Global state
+static std::shared_ptr<SHMesh> g_mesh;
+static std::string g_lastError;
+static bool g_initialized = false;
+
+static void setError(const char* msg) {
+  g_lastError = msg;
+  ESP_LOGE(TAG, "%s", msg);
+}
+
+static void clearError() {
+  g_lastError.clear();
+}
+
+} // namespace shards::esp32
+
+extern "C" {
+
+void shards_esp32_init(void) {
+  using namespace shards::esp32;
+
+  if (g_initialized) {
+    ESP_LOGW(TAG, "Already initialized");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Initializing Shards ESP32 runtime");
+
+  // Register core shards
+  // Note: This requires the shard registration functions to be linked
+  shards::registerShards();
+
+  // Create the mesh for scheduling wires
+  g_mesh = SHMesh::make();
+
+  g_initialized = true;
+  ESP_LOGI(TAG, "Shards ESP32 runtime initialized");
+}
+
+void shards_esp32_shutdown(void) {
+  using namespace shards::esp32;
+
+  if (!g_initialized) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "Shutting down Shards ESP32 runtime");
+
+  if (g_mesh) {
+    g_mesh->terminate();
+    g_mesh.reset();
+  }
+
+  g_initialized = false;
+  ESP_LOGI(TAG, "Shards ESP32 runtime shut down");
+}
+
+SHWireRef shards_esp32_load_wire(const char* path) {
+  using namespace shards::esp32;
+  clearError();
+
+  if (!g_initialized) {
+    setError("Runtime not initialized");
+    return nullptr;
+  }
+
+  if (!path) {
+    setError("Path is null");
+    return nullptr;
+  }
+
+  auto wire = loadWireFromPath(path);
+  if (!wire) {
+    setError("Failed to load wire from path");
+    return nullptr;
+  }
+
+  // Hand the caller an owning SHWireRef (newRef heap-allocates a shared_ptr copy
+  // so the wire outlives this function's local).
+  return wire->newRef();
+}
+
+SHWireRef shards_esp32_load_wire_from_memory(const uint8_t* data, size_t size) {
+  using namespace shards::esp32;
+  clearError();
+
+  if (!g_initialized) {
+    setError("Runtime not initialized");
+    return nullptr;
+  }
+
+  if (!data || size == 0) {
+    setError("Invalid data");
+    return nullptr;
+  }
+
+  auto wire = loadWireFromMemory(data, size);
+  if (!wire) {
+    setError("Failed to load wire from memory");
+    return nullptr;
+  }
+
+  // Hand the caller an owning SHWireRef (newRef heap-allocates a shared_ptr copy
+  // so the wire outlives this function's local).
+  return wire->newRef();
+}
+
+bool shards_esp32_schedule_wire(SHWireRef wire) {
+  using namespace shards::esp32;
+  clearError();
+
+  if (!g_initialized) {
+    setError("Runtime not initialized");
+    return false;
+  }
+
+  if (!wire) {
+    setError("Wire is null");
+    return false;
+  }
+
+  if (!g_mesh) {
+    setError("Mesh not available");
+    return false;
+  }
+
+  auto sharedWire = SHWire::sharedFromRef(wire);
+  g_mesh->schedule(sharedWire);
+  ESP_LOGI(TAG, "Scheduled wire: %s", sharedWire->name.c_str());
+  return true;
+}
+
+SHRunWireOutput shards_esp32_run_wire(SHWireRef wire, SHVar input) {
+  using namespace shards::esp32;
+  clearError();
+
+  SHRunWireOutput result{};
+  result.state = SHRunWireOutputState::Failed;
+
+  if (!g_initialized) {
+    setError("Runtime not initialized");
+    return result;
+  }
+
+  if (!wire) {
+    setError("Wire is null");
+    return result;
+  }
+
+  auto sharedWire = SHWire::sharedFromRef(wire);
+
+  // Create context for this wire execution
+  shards::Coroutine coro;
+  auto context = std::make_shared<SHContext>(&coro, sharedWire.get());
+
+  // Run the wire
+  result = shards::runWire(sharedWire.get(), context.get(), input);
+
+  if (result.state == SHRunWireOutputState::Failed) {
+    setError("Wire execution failed");
+  }
+
+  return result;
+}
+
+void shards_esp32_tick(void) {
+  using namespace shards::esp32;
+
+  if (!g_initialized || !g_mesh) {
+    return;
+  }
+
+  g_mesh->tick();
+}
+
+bool shards_esp32_has_running_wires(void) {
+  using namespace shards::esp32;
+
+  if (!g_initialized || !g_mesh) {
+    return false;
+  }
+
+  return !g_mesh->empty();
+}
+
+const char* shards_esp32_get_last_error(void) {
+  using namespace shards::esp32;
+
+  if (g_lastError.empty()) {
+    return nullptr;
+  }
+  return g_lastError.c_str();
+}
+
+} // extern "C"
+
+#endif // SH_FREERTOS


### PR DESCRIPTION
## Experimental ESP32-P4 (RISC-V) port

Preserving exploratory work. **This is a prototype, not for active development** — captured so the path and findings aren't lost if we revisit edge/MCU targets.

### What it does
Builds the Shards runtime + a Rust-free subset of core shards into a flashable ESP-IDF firmware image for **esp32p4** (`riscv32-esp-elf`). `idf.py build` is green.

- New ESP-IDF component `shards/shards_esp32/` (C API, Kconfig, fs/main glue).
- Runs **pre-composed, pre-serialized wires**: compose + type-check on host, `wire | ToBytes | FS.Write`, load on device via the same `Serialization`. No on-device parser.
- Uses the desktop **custom-fcontext fiber on RISC-V** (`asm/fcontext_riscv_elf.S`) — the FreeRTOS-task fiber (`coro_freertos.cpp`) is kept unused, for reference.
- Registers real C++ core shards: `Const`/`Log`/`Math.*`/flow/cast/seqs/strings/time/linalg/exposed/trait.

### Footprint
~2.5 MB flash, ~105 KB internal RAM (18% of P4, 470 KB free). Fits comfortably; no PSRAM required for the static footprint.

### Core changes (all `SH_ESP32` / `__SIZEOF_LONG__` gated — inert on desktop)
- `platform.hpp` SH_ESP32/SH_FREERTOS; `coro.hpp` 8 KB stack; `async.hpp` tide-pool off
- TBB → std / boost.container (foundation, runtime, fast_string, logging)
- `boost::filesystem`/`boost::stacktrace` guarded out of `runtime.cpp`/`log.cpp`
- rv32 `int32_t == long` fixes: `Var(long)`/`Var(unsigned long)` overloads, narrow `_almostEqual` overloads, explicit `min/max<int32_t>`
- fcontext `la`→`lla` (avoids a `.got.plt` the static link discards); `-ftls-model=local-exec`
- fast_string pool 8 MB → 64 KB on device (would OOM otherwise); `SH_STRIP_HELP_STRINGS` + newlib nano format

### Honest status / why it's shelved
- **Never executed on hardware.** The open risk is fcontext fiber behaviour under FreeRTOS (ISR stacks, FPU `ilp32f`, stack-overflow guards) — only settleable on silicon.
- **No peripheral shards** (GPIO/I2C/SPI/WiFi) — it's compute/logic only today.
- **Rust core not cross-compiled** for rv32-esp, so no Rust-backed shards and no on-device parsing.
- Strategically it's a narrow edge-extension play (typed, host-composed dataflow), not a MicroPython competitor; not worth pursuing now.

### To revive
1. Boot-test the fiber on a real P4 (in-code `Const | Log` smoke wire).
2. Add ESP-IDF peripheral shards.
3. (Optional) cross-compile the Rust core for on-device parsing / full shard library.
