### PR TITLE
SSH over pure-Rust russh; plaintext Http.Server (drop OpenSSL/LibreSSL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,8 +50,18 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
- "generic-array",
+ "crypto-common 0.1.7",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -61,8 +71,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -236,9 +273,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
- "blake2",
+ "blake2 0.10.6",
  "cpufeatures 0.2.17",
- "password-hash",
+ "password-hash 0.5.0",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2 0.11.0-rc.6",
+ "cpufeatures 0.3.0",
+ "password-hash 0.6.1",
 ]
 
 [[package]]
@@ -536,6 +585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +613,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.13.0",
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "bincode"
@@ -682,6 +748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,7 +779,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -713,7 +788,26 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -745,6 +839,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+dependencies = [
+ "byteorder",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1024,6 +1128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "cbindgen"
 version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -1129,8 +1242,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1139,10 +1254,10 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
- "poly1305",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -1166,8 +1281,20 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
  "zeroize",
 ]
 
@@ -1279,6 +1406,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codepage"
@@ -1398,6 +1531,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1631,12 @@ checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1621,8 +1766,25 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.0",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1633,9 +1795,20 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1644,8 +1817,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "subtle",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1703,6 +1886,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
 name = "cudaforge"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,7 +1954,23 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1927,15 +2145,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -2049,6 +2289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +2309,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2070,9 +2319,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2247,12 +2508,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.0",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2271,8 +2547,18 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -2281,10 +2567,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+dependencies = [
+ "curve25519-dalek 5.0.0-rc.1",
+ "ed25519 3.0.0",
+ "rand_core 0.10.0",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -2402,17 +2704,39 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "hkdf 0.12.4",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.0",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -2490,6 +2814,18 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -2768,10 +3104,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.0",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -3407,6 +3759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "geo"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,11 +3880,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3539,6 +3904,15 @@ name = "gfx-build"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -3683,8 +4057,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.0",
  "subtle",
 ]
 
@@ -3851,6 +4236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,6 +4275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,13 +4303,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array",
+ "generic-array 0.14.7",
  "hmac 0.8.1",
 ]
 
@@ -4006,6 +4415,18 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -4408,7 +4829,29 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -4563,19 +5006,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.15",
  "hmac 0.12.1",
  "js-sys",
- "p256",
- "p384",
+ "p256 0.13.2",
+ "p384 0.13.1",
  "pem",
  "rand 0.8.5",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
 ]
 
@@ -4586,6 +5029,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -4658,9 +5121,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libffi"
@@ -4775,32 +5238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -5037,6 +5474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5092,7 +5535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -5432,6 +5875,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.0",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "monostate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5559,6 +6027,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -6005,7 +6485,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
@@ -6090,10 +6570,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -6102,10 +6595,38 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "fiat-crypto 0.3.0",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+dependencies = [
+ "base16ct 1.0.0",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -6115,6 +6636,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+dependencies = [
+ "base16ct 1.0.0",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.10.0",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6170,6 +6711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6189,6 +6739,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -6222,6 +6782,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -6297,6 +6866,16 @@ dependencies = [
  "clap 3.2.25",
  "itertools 0.10.5",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -6431,9 +7010,36 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes 0.9.1",
+ "aes-gcm",
+ "cbc",
+ "der 0.8.0",
+ "pbkdf2 0.13.0",
+ "rand_core 0.10.0",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -6442,8 +7048,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "pkcs5",
+ "rand_core 0.10.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -6525,7 +7143,18 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -6535,6 +7164,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6632,12 +7272,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -7403,6 +8070,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "rfd"
 version = "0.14.1"
 source = "git+https://github.com/shards-lang/rfd.git?branch=shards-objc2#0ea4038d428cfdd66773dd64dc54bc36e2c708a6"
@@ -7502,17 +8179,36 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -7548,6 +8244,102 @@ dependencies = [
  "num-integer",
  "num-traits",
  "realfft",
+]
+
+[[package]]
+name = "russh"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d2039c3e50abb1ec3bdadea27098679da12a33befa9ab4e62adad9a13ebcb2"
+dependencies = [
+ "aes 0.9.1",
+ "bitflags 2.11.0",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "cipher 0.5.2",
+ "crypto-bigint 0.7.5",
+ "ctr",
+ "curve25519-dalek 5.0.0-rc.1",
+ "data-encoding",
+ "delegate",
+ "der 0.8.0",
+ "digest 0.11.3",
+ "ecdsa 0.17.0",
+ "ed25519-dalek 3.0.0-rc.1",
+ "elliptic-curve 0.14.1",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.3",
+ "getrandom 0.4.2",
+ "ghash",
+ "hex-literal",
+ "hmac 0.13.0",
+ "inout 0.2.2",
+ "internal-russh-num-bigint",
+ "keccak 0.2.0",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256 0.14.0-rc.15",
+ "p384 0.14.0-rc.15",
+ "p521",
+ "pageant",
+ "pbkdf2 0.13.0",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs5",
+ "pkcs8 0.11.0",
+ "polyval",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
+ "ring",
+ "rsa 0.10.0-rc.18",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20",
+ "scrypt",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sha3",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash 0.6.1",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
+dependencies = [
+ "log",
+ "nix 0.31.3",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -7754,6 +8546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7825,10 +8627,10 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "arrayref",
  "arrayvec",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "getrandom_or_panic",
  "merlin",
  "rand_core 0.6.4",
@@ -7866,15 +8668,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -8128,6 +8956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "serial"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8190,6 +9028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8211,6 +9060,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -8266,20 +9136,20 @@ dependencies = [
 name = "shards-crypto"
 version = "0.1.0"
 dependencies = [
- "argon2",
+ "argon2 0.5.3",
  "base64 0.22.1",
  "blake2b_simd",
  "byteorder",
  "chacha20poly1305",
  "compile-time-crc32",
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
  "jsonwebtoken",
  "lazy_static",
  "libsecp256k1",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "rand_core 0.6.4",
  "ring",
  "rustls-pki-types",
@@ -8566,10 +9436,11 @@ version = "0.1.0"
 dependencies = [
  "compile-time-crc32",
  "lazy_static",
+ "russh",
  "shards",
  "shards-shell-common",
  "shellexpand",
- "ssh2",
+ "tokio",
 ]
 
 [[package]]
@@ -8660,6 +9531,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -8823,7 +9704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -8839,15 +9730,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssh2"
-version = "0.9.5"
+name = "ssh-cipher"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
 dependencies = [
- "bitflags 2.11.0",
- "libc",
- "libssh2-sys",
- "parking_lot",
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "aes-gcm",
+ "chacha20 0.10.0",
+ "cipher 0.5.2",
+ "ctutils",
+ "des",
+ "poly1305 0.9.0",
+ "ssh-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "crypto-bigint 0.7.5",
+ "ctutils",
+ "digest 0.11.3",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.7.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
+dependencies = [
+ "argon2 0.6.0-rc.8",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek 3.0.0-rc.1",
+ "hex",
+ "hmac 0.13.0",
+ "p256 0.14.0-rc.15",
+ "p384 0.14.0-rc.15",
+ "p521",
+ "rand_core 0.10.0",
+ "rsa 0.10.0-rc.18",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -9214,7 +10152,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9426,7 +10364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "rand 0.8.5",
  "rustc-hash 1.1.0",
  "sha2 0.10.9",
@@ -10022,7 +10960,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -10062,9 +11000,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -10251,8 +11189,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -10923,11 +11871,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -10937,6 +11897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10973,7 +11942,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -11018,6 +11998,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -11191,6 +12181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -11504,6 +12503,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11515,9 +12525,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
- "der",
- "spki",
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "spki 0.7.3",
  "tls_codec",
 ]
 
@@ -11636,7 +12646,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "static_assertions",
  "tracing",
  "uds_windows",
@@ -11714,18 +12724,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -11771,7 +12781,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "arbitrary",
  "bzip2",
  "constant_time_eq 0.3.1",
@@ -11783,9 +12793,9 @@ dependencies = [
  "indexmap 2.13.0",
  "lzma-rust2",
  "memchr",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "ppmd-rust",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "zeroize",
  "zopfli",

--- a/shards/modules/http/CMakeLists.txt
+++ b/shards/modules/http/CMakeLists.txt
@@ -41,8 +41,10 @@ if(HTTP_SUPPORTED)
     target_include_directories(shards-module-http PRIVATE ../core)
 
     if(NOT EMSCRIPTEN)
-      target_link_libraries(shards-module-http Boost::beast Boost::asio Boost::context OpenSSL)
-      target_include_directories(shards-module-http PRIVATE $<TARGET_PROPERTY:OpenSSL,INTERFACE_INCLUDE_DIRECTORIES>)
+      # Plaintext-only Boost.Beast server/client — no OpenSSL/LibreSSL. TLS for
+      # Http.Server is expected to be terminated by a reverse proxy; the Rust
+      # client (Http.Get/Post) handles https:// via its own TLS stack.
+      target_link_libraries(shards-module-http Boost::beast Boost::asio Boost::context)
     else()
       target_include_directories(shards-module-http PUBLIC $<TARGET_PROPERTY:Boost::asio,INTERFACE_INCLUDE_DIRECTORIES>)
       target_include_directories(shards-module-http PUBLIC $<TARGET_PROPERTY:Boost::beast,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/shards/modules/http/http.cpp
+++ b/shards/modules/http/http.cpp
@@ -10,10 +10,8 @@
 #define BOOST_ERROR_CODE_HEADER_ONLY
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
-#include <boost/beast/ssl.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/filesystem.hpp>
 
@@ -21,7 +19,6 @@ namespace fs = boost::filesystem;
 namespace beast = boost::beast; // from <boost/beast.hpp>
 namespace http = beast::http;   // from <boost/beast/http.hpp>
 namespace net = boost::asio;    // from <boost/asio.hpp>
-namespace ssl = net::ssl;       // from <boost/asio/ssl.hpp>
 using tcp = net::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
 
 #include <cctype>
@@ -40,58 +37,6 @@ using tcp = net::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
 using namespace std;
 
 static auto logger = shards::logging::getOrCreate("http");
-
-// Embedded self-signed certificate for localhost (development use only)
-static const char *embedded_cert_pem = R"(-----BEGIN CERTIFICATE-----
-MIIDgTCCAmmgAwIBAgIUf3JVEFY5h4g5NQ6zfiEgjgtFcd8wDQYJKoZIhvcNAQEL
-BQAwUDELMAkGA1UEBhMCVVMxDDAKBgNVBAgMA0RldjEOMAwGA1UEBwwFTG9jYWwx
-DzANBgNVBAoMBlNoYXJkczESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDkxODAx
-NTcxMloXDTI2MDkxODAxNTcxMlowUDELMAkGA1UEBhMCVVMxDDAKBgNVBAgMA0Rl
-djEOMAwGA1UEBwwFTG9jYWwxDzANBgNVBAoMBlNoYXJkczESMBAGA1UEAwwJbG9j
-YWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn6wbqFfbUcUu
-3rxgmfQ4ZojaVG0DG5dytXpi04IOuKYf12noFgB6JTU6zwuCQzDirI80uZ8NZLWk
-gQ59pEEWY5lCFj1zaFQKK7eaT5KNr8C+TZSqCsl4NUKZODblfvNse+04LTEu2HJM
-V4xtWxcy9csQrViIeJue21/rkl7+XSKbrlFDqIyVUAbXFbN27CSu2bwAt4FiCqC0
-4798JG5h6Ud9ddceNJDAzza1dAYum/96H8uoji9W+Ds4znf0LYqqCTKFhSLZ/AYl
-cfB0r8JY44I2j2h8Bgkk349vE9a9J+XYQ+UcoemliK61Zqf1MsCScH8QDITJREjx
-0V5h6dXXBQIDAQABo1MwUTAdBgNVHQ4EFgQUuwJJIHn5x0YbJak/QM4NviR/dV4w
-HwYDVR0jBBgwFoAUuwJJIHn5x0YbJak/QM4NviR/dV4wDwYDVR0TAQH/BAUwAwEB
-/zANBgkqhkiG9w0BAQsFAAOCAQEAMijv3vegSULHtdoYqm+KKPIKkmtregviA2ZR
-bkS4KmrFbV/bXDPe15JQq0zE2L5Uka2nfPPs2V/2JfVu1RUQX/WAdniiX82ZeHGA
-O7/kBKnn4ZyuZftOgKuPvoz2rTT50AutkiF10rMNGH+Wumvk9TuSws1UaI0qt65p
-EsDaNvVfoWQ5SWMhIakYlOJq59vzUvwIkF8UrBRjrCqc9MOY9GFpr/fGJ9Q2hwpb
-1H7I9OOHimZPP9Ty4hr6JRLMz5hxlUi0yxx4AFecNAyeYTUJsjMAgVKam4cv8S2s
-0v37eXs3GF1JHPlGNuHg/J3NSwZeOy7+sUUN9xMQMdeKav5PwQ==
------END CERTIFICATE-----)";
-
-static const char *embedded_key_pem = R"(-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCfrBuoV9tRxS7e
-vGCZ9DhmiNpUbQMbl3K1emLTgg64ph/XaegWAHolNTrPC4JDMOKsjzS5nw1ktaSB
-Dn2kQRZjmUIWPXNoVAort5pPko2vwL5NlKoKyXg1Qpk4NuV+82x77TgtMS7YckxX
-jG1bFzL1yxCtWIh4m57bX+uSXv5dIpuuUUOojJVQBtcVs3bsJK7ZvAC3gWIKoLTj
-v3wkbmHpR3111x40kMDPNrV0Bi6b/3ofy6iOL1b4OzjOd/QtiqoJMoWFItn8BiVx
-8HSvwljjgjaPaHwGCSTfj28T1r0n5dhD5Ryh6aWIrrVmp/UywJJwfxAMhMlESPHR
-XmHp1dcFAgMBAAECggEABrcWbLAuUCt58NUlygDZcXp/IZu/4/AJ23nwDuTfghQP
-9NmdtnVaOV0DDadH2PbtreyjW+QLUhxJuoeUQiSYnzqGyCKTNAHSQyMOTnhSFOBk
-QII0IdR17loKXSVHWjprmM1jXDW/LtfTwATXqiy+01OZ7nQI93cDqXUOfwCjHG2n
-kC+wY8kaWLPX+yTPpkQM4jMxmSXoWXYgQQ9RLf7o94EgytId0uhk4r76jsXqB3Al
-MUmNUXtJDLiV4ipcK7I4yovXuqpkb6dNVaVAr0NgbUWqBdQ2zvNG3kTkh5si+HuJ
-X1P+DQmCZg+DmvQT0FiWebIfm7AcSQZKglDKvB6aiwKBgQDUWJHXdoJ/wrKhDonU
-PyMqz4DOMYzfm0+0VsMdReb2+VMcH+KOB9vS+SPM5VXSICWKLXFZuoTVNvcdOyml
-vuxfXUCnzZNlT3lwamFtNlr5ALHGGlqYraKdIACYNpydlQ+7qLPHgeUSWp6jGFxE
-g7yEHd0KYr7z8JfVS+i12ZnSXwKBgQDAf2gWMufR8dMw+cCTwLy2DukJszZ2oUrs
-fPc7QRefXi/FWg8Z1ppkkAZiMM9z0ak3vb85vE9C7dg4r+LiU5iIxW2WRR2xY2nh
-25NsS20rnk+AiN/6yV+V1iZwaawgi9PTBgn/BI6/y0rZeXFdzaRMy/A8wkXgO2i9
-3KRw9iq5GwKBgDdO8n26gncgkUJd9QxxfYlzDsumIFlFrNb+GkgPov8FJd6Xd30j
-EuC6v9ZojZfzg5OgDnweluaqMGdOt6RSPGMCeQq8Av5KWwkqzEGT/NIKmkNNLffC
-ki523XDIGLb60mRApsL6VF4ZeGRmvfGiloGa/a3s1mvXaNTHts9W5DflAoGAB+y2
-0kMiPAhik1+UyABlRHF0souIMHYPaZDzdKMHX+42tT8x4/RrwrwTJzOvNqto9fx/
-xNa1xKGaBytmgb7DRs4p5sfNoyHemAe8F/c69VK9HyODZQWpQ7ffOT2Aco6PF97l
-xnPflJG/8RgIzL3Mh8TVjQrKaaLIexh8RJI9zAUCgYEAgaOFr90vD3Dlf+NZZjm6
-Zkrow8cTkv+Y++k7i/7rgk6M7GM4Q2Wfv7HXdbRdvT3zSlvcmvfJhqQCMhGW/v7/
-E5fABcBgSDx4tNXzLCwtAARYB+UgcyfbgvwEWBI0DgFoadpgMIuykD681BhLOVQK
-IV5WFlI6Cf4er5LowEvwx/Q=
------END PRIVATE KEY-----)";
 
 inline std::string url_encode(const std::string_view &value) {
   std::ostringstream escaped;
@@ -600,62 +545,38 @@ struct Peer : public std::enable_shared_from_this<Peer> {
 
   std::shared_ptr<SHWire> wire;
   std::shared_ptr<tcp::socket> socket;
-  std::shared_ptr<ssl::stream<tcp::socket>> ssl_socket;
   std::deque<SHVar *> injectedVariables;
   entt::scoped_connection _onCleanupConnection;
-  bool use_ssl{false};
 
   ~Peer() { cleanup(); }
 
   void cleanup() {
-    ssl_socket.reset();
     socket.reset();
 
     // injectedVariables are cleaned up separately in wireOnStop
     // to avoid double-free issues
   }
 
-  // Helper template to get the correct stream type
   template <typename Handler>
   void async_read_header(beast::flat_buffer &buffer, http::request_parser<http::string_body> &parser, Handler &&handler) {
-    if (use_ssl) {
-      http::async_read_header(*ssl_socket, buffer, parser, std::forward<Handler>(handler));
-    } else {
-      http::async_read_header(*socket, buffer, parser, std::forward<Handler>(handler));
-    }
+    http::async_read_header(*socket, buffer, parser, std::forward<Handler>(handler));
   }
 
   template <typename Handler>
   void async_read(beast::flat_buffer &buffer, http::request_parser<http::string_body> &parser, Handler &&handler) {
-    if (use_ssl) {
-      http::async_read(*ssl_socket, buffer, parser, std::forward<Handler>(handler));
-    } else {
-      http::async_read(*socket, buffer, parser, std::forward<Handler>(handler));
-    }
+    http::async_read(*socket, buffer, parser, std::forward<Handler>(handler));
   }
 
   template <typename Response, typename Handler> void async_write(Response &response, Handler &&handler) {
-    if (use_ssl) {
-      http::async_write(*ssl_socket, response, std::forward<Handler>(handler));
-    } else {
-      http::async_write(*socket, response, std::forward<Handler>(handler));
-    }
+    http::async_write(*socket, response, std::forward<Handler>(handler));
   }
 
   template <typename Buffer, typename Handler> void async_write_raw(const Buffer &buffer, Handler &&handler) {
-    if (use_ssl) {
-      net::async_write(*ssl_socket, buffer, std::forward<Handler>(handler));
-    } else {
-      net::async_write(*socket, buffer, std::forward<Handler>(handler));
-    }
+    net::async_write(*socket, buffer, std::forward<Handler>(handler));
   }
 
   template <typename Serializer, typename Handler> void async_write_header(Serializer &serializer, Handler &&handler) {
-    if (use_ssl) {
-      http::async_write_header(*ssl_socket, serializer, std::forward<Handler>(handler));
-    } else {
-      http::async_write_header(*socket, serializer, std::forward<Handler>(handler));
-    }
+    http::async_write_header(*socket, serializer, std::forward<Handler>(handler));
   }
 };
 
@@ -666,21 +587,12 @@ struct PeerError {
 };
 
 struct Server {
-  Server() : _port(Var(7070)), _ssl_enabled(Var(false)) {}
+  Server() : _port(Var(7070)) {}
 
   static inline Parameters params{
       {"Handler", SHCCSTR("The wire that will be spawned and handle a remote request."), {CoreInfo::WireOrNone}},
       {"Endpoint", SHCCSTR("The URL from where your service can be accessed by a client."), {CoreInfo::StringType}},
-      {"Port", SHCCSTR("The port this service will use."), {CoreInfo::IntType, CoreInfo::IntVarType}},
-      {"SSL",
-       SHCCSTR("Enable HTTPS with SSL/TLS. Uses embedded self-signed certificate if no cert files specified."),
-       {CoreInfo::BoolType, CoreInfo::BoolVarType}},
-      {"CertFile",
-       SHCCSTR("Path to SSL certificate file (PEM format). Optional - uses embedded cert if not provided."),
-       {CoreInfo::StringType, CoreInfo::NoneType}},
-      {"KeyFile",
-       SHCCSTR("Path to SSL private key file (PEM format). Optional - uses embedded key if not provided."),
-       {CoreInfo::StringType, CoreInfo::NoneType}}};
+      {"Port", SHCCSTR("The port this service will use."), {CoreInfo::IntType, CoreInfo::IntVarType}}};
 
   static SHParametersInfo parameters() { return params; }
 
@@ -702,9 +614,6 @@ struct Server {
   std::deque<ParamVar> _vars;
   SeqVar _cache;
   SHExposedTypesInfo _mergedReqs;
-  ParamVar _ssl_enabled;
-  std::string _cert_file;
-  std::string _key_file;
 
   void destroy() { arrayFree(_mergedReqs); }
 
@@ -719,23 +628,6 @@ struct Server {
     case 2:
       _port = val;
       break;
-    case 3:
-      _ssl_enabled = val;
-      break;
-    case 4:
-      if (val.valueType != SHType::None) {
-        _cert_file = SHSTRVIEW(val);
-      } else {
-        _cert_file.clear();
-      }
-      break;
-    case 5:
-      if (val.valueType != SHType::None) {
-        _key_file = SHSTRVIEW(val);
-      } else {
-        _key_file.clear();
-      }
-      break;
     default:
       break;
     }
@@ -749,12 +641,6 @@ struct Server {
       return Var(_endpoint);
     case 2:
       return _port;
-    case 3:
-      return _ssl_enabled;
-    case 4:
-      return _cert_file.empty() ? Var::Empty : Var(_cert_file);
-    case 5:
-      return _key_file.empty() ? Var::Empty : Var(_key_file);
     default:
       return Var::Empty;
     }
@@ -855,61 +741,25 @@ struct Server {
       peer->_onCleanupConnection = peer->wire->dispatcher.sink<SHWire::OnCleanupEvent>().connect<&Server::wireOnCleanup>(this);
     }
 
-    peer->use_ssl = _ssl_enabled.get().payload.boolValue;
-
-    if (_ssl_enabled.get().payload.boolValue) {
-      peer->ssl_socket.reset(new ssl::stream<tcp::socket>(*_ioc, *_ssl_context));
-    } else {
-      peer->socket.reset(new tcp::socket(*_ioc));
-    }
+    peer->socket.reset(new tcp::socket(*_ioc));
 
     _pendingAcceptPeers.insert(peer); // add to pending set
 
-    auto &socket_to_accept = _ssl_enabled.get().payload.boolValue ? peer->ssl_socket->next_layer() : *peer->socket;
-    _acceptor->async_accept(socket_to_accept, [context, peer, this](beast::error_code ec) {
+    _acceptor->async_accept(*peer->socket, [context, peer, this](beast::error_code ec) {
       _pendingAcceptPeers.erase(peer); // remove from pending set
       if (!ec) {
-        if (_ssl_enabled.get().payload.boolValue) {
-          // Perform SSL handshake
-          peer->ssl_socket->async_handshake(ssl::stream_base::server, [context, peer, this](beast::error_code ssl_ec) {
-            if (!ssl_ec) {
-              // SSL handshake successful, schedule the wire
-              auto mesh = context->main->mesh.lock();
-              if (mesh) {
-                peer->wire->getVariable("Http.Server.Socket"_swl) = Var::Object(peer, CoreCC, Peer::PeerCC);
-                mesh->schedule(peer->wire, Var::Empty, false);
-              } else {
-                // Clean up injected variables
-                for (auto var : peer->injectedVariables) {
-                  releaseVariable(var);
-                }
-                peer->injectedVariables.clear();
-                _pool->release(peer);
-              }
-            } else {
-              SHLOG_DEBUG("SSL handshake failed: {}", ssl_ec.message());
-              // Clean up injected variables
-              for (auto var : peer->injectedVariables) {
-                releaseVariable(var);
-              }
-              peer->injectedVariables.clear();
-              _pool->release(peer);
-            }
-          });
+        // schedule the wire directly
+        auto mesh = context->main->mesh.lock();
+        if (mesh) {
+          peer->wire->getVariable("Http.Server.Socket"_swl) = Var::Object(peer, CoreCC, Peer::PeerCC);
+          mesh->schedule(peer->wire, Var::Empty, false);
         } else {
-          // No SSL, schedule directly
-          auto mesh = context->main->mesh.lock();
-          if (mesh) {
-            peer->wire->getVariable("Http.Server.Socket"_swl) = Var::Object(peer, CoreCC, Peer::PeerCC);
-            mesh->schedule(peer->wire, Var::Empty, false);
-          } else {
-            // Clean up injected variables
-            for (auto var : peer->injectedVariables) {
-              releaseVariable(var);
-            }
-            peer->injectedVariables.clear();
-            _pool->release(peer);
+          // Clean up injected variables
+          for (auto var : peer->injectedVariables) {
+            releaseVariable(var);
           }
+          peer->injectedVariables.clear();
+          _pool->release(peer);
         }
       } else {
         SHLOG_DEBUG("Accept failed: {}", ec.message());
@@ -939,7 +789,6 @@ struct Server {
     }
 
     _port.warmup(context);
-    _ssl_enabled.warmup(context);
   }
 
   void cleanup(SHContext *context) {
@@ -974,15 +823,13 @@ struct Server {
 
     _cache = {}; // ensure it's really all freed, not just cleared
 
-    // Stop and reset io_context and SSL context
+    // Stop and reset io_context
     if (_ioc) {
       _ioc->stop();
       _ioc.reset();
     }
-    _ssl_context.reset();
 
     _port.cleanup(context);
-    _ssl_enabled.cleanup(context);
     _is_running = false;
   }
 
@@ -997,34 +844,6 @@ struct Server {
 
     if (!_is_running) {
       _ioc.reset(new net::io_context());
-
-      // Initialize SSL context if SSL is enabled
-      if (_ssl_enabled.get().payload.boolValue) {
-        _ssl_context.reset(new ssl::context(ssl::context::tlsv12_server));
-
-        try {
-          // Configure SSL context
-          _ssl_context->set_options(ssl::context::default_workarounds | ssl::context::no_sslv2 | ssl::context::single_dh_use);
-
-          // Load certificate and key
-          if (!_cert_file.empty() || !_key_file.empty()) {
-            if (_cert_file.empty() || _key_file.empty()) {
-              throw ActivationError("SSL requires both CertFile and KeyFile parameters, or neither (to use embedded cert)");
-            }
-            // Use provided certificate files
-            _ssl_context->use_certificate_chain_file(_cert_file);
-            _ssl_context->use_private_key_file(_key_file, ssl::context::pem);
-            SHLOG_DEBUG("Using provided SSL certificate: {} and key: {}", _cert_file, _key_file);
-          } else {
-            // Use embedded certificate
-            _ssl_context->use_certificate_chain(net::buffer(embedded_cert_pem, strlen(embedded_cert_pem)));
-            _ssl_context->use_private_key(net::buffer(embedded_key_pem, strlen(embedded_key_pem)), ssl::context::pem);
-            SHLOG_DEBUG("Using embedded SSL certificate for localhost");
-          }
-        } catch (const std::exception &e) {
-          throw ActivationError(fmt::format("Failed to configure SSL context: {}", e.what()));
-        }
-      }
 
       auto port = _port.get().payload.intValue;
       // ensure port is in range of 1-65535
@@ -1092,7 +911,6 @@ struct Server {
 
   // The io_context is required for all I/O
   std::unique_ptr<net::io_context> _ioc;
-  std::unique_ptr<ssl::context> _ssl_context;
   std::deque<Peer> _peers;
   std::unique_ptr<tcp::acceptor> _acceptor;
 };

--- a/shards/modules/shell-common/src/lib.rs
+++ b/shards/modules/shell-common/src/lib.rs
@@ -378,6 +378,24 @@ pub fn clean_output_with_marker(output: &str, marker: Option<&str>) -> String {
   result.trim().to_string()
 }
 
+/// Strip the leading echoed command line. In an interactive PTY the shell echoes
+/// back whatever we type, so after the buffer is cleared and a command is sent,
+/// the first line of captured output is the echo of `cmd`. Remove it so results
+/// contain only real command output. Only strips when the first line actually
+/// matches (echo-off servers, or commands wrapped across the terminal width, are
+/// left untouched — no worse than before).
+pub fn strip_leading_command_echo(output: &str, cmd: &str) -> String {
+  let cmd_trimmed = cmd.trim();
+  if cmd_trimmed.is_empty() {
+    return output.to_string();
+  }
+  let mut lines = output.lines();
+  match lines.next() {
+    Some(first) if first.trim() == cmd_trimmed => lines.collect::<Vec<_>>().join("\n"),
+    _ => output.to_string(),
+  }
+}
+
 /// Truncate an output buffer to keep the tail, prepending a truncation notice.
 pub fn truncate_to_tail(buffer: &mut Vec<u8>, max_bytes: usize) -> bool {
   if buffer.len() <= max_bytes {
@@ -862,7 +880,7 @@ pub fn execute(
     let exit_code = capture_exit_code(s, marker);
 
     let final_output = if should_clean {
-      clean_output_with_marker(&output_str, marker)
+      strip_leading_command_echo(&clean_output_with_marker(&output_str, marker), cmd)
     } else {
       output_str
     };
@@ -894,7 +912,7 @@ pub fn execute(
     }
 
     let partial_output = if should_clean {
-      clean_output_with_marker(&output_str, marker)
+      strip_leading_command_echo(&clean_output_with_marker(&output_str, marker), cmd)
     } else {
       output_str
     };

--- a/shards/modules/ssh/Cargo.toml
+++ b/shards/modules/ssh/Cargo.toml
@@ -14,5 +14,8 @@ lazy_static = "1.5.0"
 shards = { path = "../../rust" }
 shards-shell-common = { path = "../shell-common" }
 compile-time-crc32 = "0.1.2"
-ssh2 = "0.9"
+# Pure-Rust SSH (no OpenSSL/libssh2). `ring` backend reuses the ring crypto
+# already present on every target instead of pulling aws-lc (cc+cmake).
+russh = { version = "0.62", default-features = false, features = ["ring", "flate2", "rsa"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "io-util", "net"] }
 shellexpand = "3.1"

--- a/shards/modules/ssh/src/lib.rs
+++ b/shards/modules/ssh/src/lib.rs
@@ -36,132 +36,158 @@ use shards::types::STRING_TYPES;
 
 use shards_shell_common as sc;
 
-use ssh2::Session;
-use std::io::prelude::*;
-use std::net::{TcpStream, ToSocketAddrs};
-use std::path::Path;
+use russh::client::{self, Handle, Handler};
+use russh::keys::{load_secret_key, PrivateKeyWithHashAlg};
+use russh::{ChannelMsg, Disconnect};
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-// Helper: check if an IO error indicates connection loss.
-fn is_connection_error(err: &std::io::Error) -> bool {
-  use std::io::ErrorKind;
-  matches!(
-    err.kind(),
-    ErrorKind::ConnectionReset
-      | ErrorKind::ConnectionAborted
-      | ErrorKind::BrokenPipe
-      | ErrorKind::UnexpectedEof
-  )
-}
+use tokio::sync::mpsc;
 
 // ============================================================================
-// SSH transport
+// SSH transport (russh — pure Rust, no OpenSSL/libssh2)
+//
+// russh is async; shell-common's `ShellTransport` is synchronous and driven
+// from a std reader thread + `run_blocking` shard threads. We bridge the two:
+// a single async task owns the russh `Handle` + `Channel` and is the only thing
+// that touches them. The sync side talks to it through an unbounded mpsc for
+// writes/resize/close (`send` is callable from any thread with no `block_on`)
+// and a shared byte queue that `read_into` drains. Only the initial connect
+// uses `block_on`, which is legal here because Connect runs on a `run_blocking`
+// thread, never on the wire coroutine.
 // ============================================================================
 
-struct SshTransport {
-  session: Arc<Mutex<Session>>,
-  channel: Arc<Mutex<ssh2::Channel>>,
+lazy_static! {
+  static ref SSH_RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
+    .worker_threads(2)
+    .enable_all()
+    .build()
+    .expect("Failed to build SSH tokio runtime");
 }
 
-impl sc::ShellTransport for SshTransport {
-  fn read_into(&self, buf: &mut [u8]) -> sc::ReadOutcome {
-    // Ensure non-blocking mode, then RELEASE the session lock before touching
-    // the channel. `write_all` holds the channel lock while acquiring the
-    // session lock, so the reader must never hold session while waiting on
-    // channel — otherwise the two could deadlock.
-    if let Ok(sess) = self.session.lock() {
-      sess.set_blocking(false);
+/// Accept-all host-key handler. Matches the previous ssh2 behavior, which did
+/// no `known_hosts` verification.
+struct Client;
+
+impl Handler for Client {
+  type Error = russh::Error;
+
+  async fn check_server_key(
+    &mut self,
+    _server_public_key: &russh::keys::PublicKey,
+  ) -> Result<bool, Self::Error> {
+    Ok(true)
+  }
+}
+
+/// Commands sent from the synchronous transport to the async channel task.
+enum Outbound {
+  Data(Vec<u8>),
+  Resize { cols: u16, rows: u16 },
+  Close,
+}
+
+struct RusshTransport {
+  write_tx: mpsc::UnboundedSender<Outbound>,
+  inbound: Arc<Mutex<VecDeque<u8>>>,
+  ended: Arc<AtomicBool>,
+}
+
+/// The single async owner of the russh channel + session handle. Forwards
+/// inbound channel data into `inbound` and applies outbound commands. Exits
+/// (setting `ended`) when the peer closes the channel or a `Close` is issued.
+async fn run_channel(
+  handle: Handle<Client>,
+  mut channel: russh::Channel<client::Msg>,
+  mut rx: mpsc::UnboundedReceiver<Outbound>,
+  inbound: Arc<Mutex<VecDeque<u8>>>,
+  ended: Arc<AtomicBool>,
+) {
+  loop {
+    tokio::select! {
+      msg = channel.wait() => {
+        match msg {
+          // With a PTY the server merges stdout/stderr onto the tty, so treat
+          // extended (stderr) data the same as normal data.
+          Some(ChannelMsg::Data { ref data })
+          | Some(ChannelMsg::ExtendedData { ref data, .. }) => {
+            if let Ok(mut q) = inbound.lock() {
+              q.extend(data.iter().copied());
+            }
+          }
+          Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
+          _ => {}
+        }
+      }
+      cmd = rx.recv() => {
+        match cmd {
+          Some(Outbound::Data(bytes)) => {
+            if channel.data(&bytes[..]).await.is_err() {
+              break;
+            }
+          }
+          Some(Outbound::Resize { cols, rows }) => {
+            let _ = channel.window_change(cols as u32, rows as u32, 0, 0).await;
+          }
+          // Explicit close, or all senders dropped (transport gone).
+          Some(Outbound::Close) | None => {
+            let _ = channel.eof().await;
+            let _ = channel.close().await;
+            let _ = handle
+              .disconnect(Disconnect::ByApplication, "Session closed", "")
+              .await;
+            break;
+          }
+        }
+      }
     }
+  }
+  ended.store(true, Ordering::Release);
+}
 
-    let read_result = match self.channel.lock() {
-      Ok(mut ch) => ch.read(buf),
+impl sc::ShellTransport for RusshTransport {
+  fn read_into(&self, buf: &mut [u8]) -> sc::ReadOutcome {
+    let mut q = match self.inbound.lock() {
+      Ok(q) => q,
       Err(_) => return sc::ReadOutcome::Ended,
     };
 
-    match read_result {
-      Ok(n) if n > 0 => sc::ReadOutcome::Data(n),
-      Ok(_) => sc::ReadOutcome::Ended,
-      Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => sc::ReadOutcome::Retry,
-      Err(e) if is_connection_error(&e) => sc::ReadOutcome::Ended,
-      Err(e) => {
-        shlog_trace!("SSH reader thread: read error (non-fatal): {}", e);
-        sc::ReadOutcome::Retry
+    if q.is_empty() {
+      // No buffered data: distinguish "closed" from "nothing yet".
+      if self.ended.load(Ordering::Acquire) {
+        return sc::ReadOutcome::Ended;
       }
+      return sc::ReadOutcome::Retry;
     }
+
+    let n = q.len().min(buf.len());
+    for (slot, byte) in buf.iter_mut().zip(q.drain(..n)) {
+      *slot = byte;
+    }
+    sc::ReadOutcome::Data(n)
   }
 
   fn write_all(&self, data: &[u8]) -> Result<(), sc::TransportError> {
-    let mut channel = self
-      .channel
-      .lock()
-      .map_err(|_| sc::TransportError::Other("Channel lock poisoned"))?;
-
-    // Hold the session lock across the write + flush. Setting blocking mode and
-    // releasing the session lock *before* writing leaves a window where the
-    // reader thread (which flips the session to non-blocking before every read)
-    // can make our write run non-blocking and fail with a spurious WouldBlock.
-    // Holding session here is deadlock-safe: write_all is the only path that
-    // ever holds both locks, and read_into never holds the session lock while
-    // waiting on the channel, so no lock cycle can form. A poisoned session
-    // lock is recovered (set_blocking can't panic) to keep writes best-effort.
-    let sess = self.session.lock().unwrap_or_else(|e| e.into_inner());
-    sess.set_blocking(true);
-
-    let write_result = channel.write_all(data);
-    if write_result.is_ok() {
-      let _ = channel.flush();
-    }
-
-    // Restore non-blocking before releasing the session lock.
-    sess.set_blocking(false);
-    drop(sess);
-
-    if let Err(e) = write_result {
-      if is_connection_error(&e) {
-        return Err(sc::TransportError::ConnectionLost);
-      }
-      return Err(sc::TransportError::Other("Failed to write to SSH channel"));
-    }
-
-    Ok(())
+    // Non-blocking hand-off to the async channel task; a send error means the
+    // task has exited, i.e. the connection is gone.
+    self
+      .write_tx
+      .send(Outbound::Data(data.to_vec()))
+      .map_err(|_| sc::TransportError::ConnectionLost)
   }
 
   fn resize(&self, rows: u16, cols: u16) -> Result<(), &'static str> {
-    // Set blocking for the resize request.
-    if let Ok(sess) = self.session.lock() {
-      sess.set_blocking(true);
-    }
-
-    {
-      let mut channel = self.channel.lock().map_err(|_| "Channel lock poisoned")?;
-      channel
-        .request_pty_size(cols as u32, rows as u32, None, None)
-        .map_err(|_| "Failed to resize PTY")?;
-    }
-
-    // Restore non-blocking.
-    if let Ok(sess) = self.session.lock() {
-      sess.set_blocking(false);
-    }
-
-    Ok(())
+    self
+      .write_tx
+      .send(Outbound::Resize { cols, rows })
+      .map_err(|_| "SSH channel closed")
   }
 
   fn close(&self) {
-    // Close channel gracefully.
-    if let Ok(mut channel) = self.channel.lock() {
-      let _ = channel.send_eof();
-      let _ = channel.wait_eof();
-      let _ = channel.close();
-      let _ = channel.wait_close();
-    }
-
-    // Disconnect session.
-    if let Ok(session) = self.session.lock() {
-      let _ = session.disconnect(None, "Session closed", None);
-    }
+    // Best-effort: ask the async task to eof/close/disconnect. If it already
+    // exited the send simply fails and there is nothing left to close.
+    let _ = self.write_tx.send(Outbound::Close);
   }
 }
 
@@ -313,69 +339,108 @@ impl BlockingShard for ConnectShard {
       v.max(1).min(u16::MAX as i64) as u16
     };
 
-    // Connect to SSH server
-    let addr = format!("{}:{}", host, port);
-
-    let socket_addrs: Vec<_> = addr
-      .to_socket_addrs()
-      .map_err(|_| "Failed to resolve hostname")?
-      .collect();
-
-    let socket_addr = socket_addrs
-      .first()
-      .ok_or("No address found for hostname")?;
-
-    let tcp = TcpStream::connect_timeout(socket_addr, Duration::from_secs(timeout_secs as u64))
-      .map_err(|_| "Connection failed")?;
-
-    tcp
-      .set_read_timeout(Some(Duration::from_secs(timeout_secs as u64)))
-      .map_err(|_| "Failed to set timeout")?;
-
-    let mut sess = Session::new().map_err(|_| "Failed to create SSH session")?;
-    sess.set_tcp_stream(tcp);
-    sess.handshake().map_err(|_| "SSH handshake failed")?;
-
-    // Authenticate
-    if !key_path_var.is_none() {
-      let key_path: &str = key_path_var.as_ref().try_into()?;
-      let key_path_expanded = shellexpand::tilde(key_path).to_string();
-      sess
-        .userauth_pubkey_file(user, None, Path::new(&key_path_expanded), None)
-        .map_err(|_| "Public key authentication failed")?;
-    } else if !password_var.is_none() {
-      let password: &str = password_var.as_ref().try_into()?;
-      sess
-        .userauth_password(user, password)
-        .map_err(|_| "Password authentication failed")?;
+    // Extract auth material before entering async. Public key takes precedence
+    // over password, matching the previous behavior.
+    let key_path_opt: Option<String> = if key_path_var.is_none() {
+      None
     } else {
+      let kp: &str = key_path_var.as_ref().try_into()?;
+      Some(shellexpand::tilde(kp).to_string())
+    };
+    let password_opt: Option<&str> = if password_var.is_none() {
+      None
+    } else {
+      Some(password_var.as_ref().try_into()?)
+    };
+    if key_path_opt.is_none() && password_opt.is_none() {
       return Err("Either KeyPath or Password must be provided");
     }
 
-    if !sess.authenticated() {
-      return Err("Authentication failed");
-    }
+    // Shared transport state, created before connecting so the async channel
+    // task and the sync transport can share it.
+    let inbound = Arc::new(Mutex::new(VecDeque::<u8>::new()));
+    let ended = Arc::new(AtomicBool::new(false));
+    let (write_tx, write_rx) = mpsc::unbounded_channel::<Outbound>();
 
-    // Open channel and request PTY with size
-    let mut channel = sess
-      .channel_session()
-      .map_err(|_| "Failed to open channel")?;
-    channel
-      .request_pty(
-        "xterm-256color",
-        None,
-        Some((cols as u32, rows as u32, 0, 0)),
-      )
-      .map_err(|_| "Failed to request PTY")?;
-    channel.shell().map_err(|_| "Failed to start shell")?;
+    // Connect + authenticate + open the shell channel on the SSH runtime. This
+    // runs on a `run_blocking` thread, so `block_on` is safe (not the wire
+    // coroutine).
+    let (handle, channel) = SSH_RUNTIME.block_on(async {
+      let config = Arc::new(client::Config {
+        // Persistent interactive session: no inactivity disconnect.
+        inactivity_timeout: None,
+        ..Default::default()
+      });
 
-    // Set non-blocking mode for reads
-    sess.set_blocking(false);
+      let connect_fut = client::connect(config, (host, port as u16), Client);
+      let mut handle =
+        match tokio::time::timeout(Duration::from_secs(timeout_secs as u64), connect_fut).await {
+          Ok(Ok(h)) => h,
+          Ok(Err(_)) => return Err("Connection failed"),
+          Err(_) => return Err("Connection timed out"),
+        };
 
-    // Build the transport and shared session state.
-    let transport: Arc<dyn sc::ShellTransport> = Arc::new(SshTransport {
-      session: Arc::new(Mutex::new(sess)),
-      channel: Arc::new(Mutex::new(channel)),
+      let authenticated = if let Some(ref key_path) = key_path_opt {
+        let key_pair = load_secret_key(key_path, None).map_err(|_| "Failed to load private key")?;
+        let hash_alg = handle
+          .best_supported_rsa_hash()
+          .await
+          .map_err(|_| "SSH negotiation failed")?
+          .flatten();
+        handle
+          .authenticate_publickey(
+            user,
+            PrivateKeyWithHashAlg::new(Arc::new(key_pair), hash_alg),
+          )
+          .await
+          .map_err(|_| "Public key authentication failed")?
+          .success()
+      } else {
+        // Safe: checked above that at least one of key/password is present.
+        let password = password_opt.unwrap();
+        handle
+          .authenticate_password(user, password)
+          .await
+          .map_err(|_| "Password authentication failed")?
+          .success()
+      };
+
+      if !authenticated {
+        return Err("Authentication failed");
+      }
+
+      // Open a session channel, request a PTY, and start the login shell.
+      // request_pty takes (want_reply, term, col_width, row_height, pix_w, pix_h, modes).
+      let channel = handle
+        .channel_open_session()
+        .await
+        .map_err(|_| "Failed to open channel")?;
+      channel
+        .request_pty(false, "xterm-256color", cols as u32, rows as u32, 0, 0, &[])
+        .await
+        .map_err(|_| "Failed to request PTY")?;
+      channel
+        .request_shell(false)
+        .await
+        .map_err(|_| "Failed to start shell")?;
+
+      Ok::<_, &'static str>((handle, channel))
+    })?;
+
+    // Hand the channel + session to the single async owner task.
+    SSH_RUNTIME.spawn(run_channel(
+      handle,
+      channel,
+      write_rx,
+      Arc::clone(&inbound),
+      Arc::clone(&ended),
+    ));
+
+    // Build the transport over the shared state.
+    let transport: Arc<dyn sc::ShellTransport> = Arc::new(RusshTransport {
+      write_tx,
+      inbound,
+      ended,
     });
 
     let output_buffer = Arc::new(Mutex::new(Vec::new()));

--- a/shards/tests/CLAUDE.md
+++ b/shards/tests/CLAUDE.md
@@ -694,8 +694,8 @@ Http.Post(url Headers: headers Streaming: true FullResponse: true)
 {Take("status") = status}
 Http.Stream(stream) | BytesToString
 
-// Server
-Http.Server(Port: 8080 SSL: false Handler: handler-wire)
+// Server (plaintext only — terminate TLS at a reverse proxy)
+Http.Server(Port: 8080 Handler: handler-wire)
 Http.Response(200 Headers: {"Content-Type": "text/plain"})
 Http.Chunk(Headers: {"Content-Type": "text/event-stream"})
 ```


### PR DESCRIPTION
## Summary

Two related reductions in TLS/crypto dependencies:

1. **SSH → pure-Rust russh.** Replaces `ssh2`/`libssh2` (OpenSSL) with **russh 0.62 on the `ring` backend**. Removes libssh2 and the Rust `openssl-sys` binding from every build, with **no new C crypto lib** (russh's default `aws-lc-rs` — which needs a cc+cmake build — is avoided; `ring` is already present on every target). The async russh channel is bridged into the synchronous `shell-common` `ShellTransport`: one async task owns the Handle+Channel, the sync side talks to it via an unbounded mpsc (writes/resize/close) and a shared byte queue (reads); `block_on` only on connect. Also strips the leading echoed command in `execute()` so `SSH.Execute("pwd")` returns `/tmp` instead of `pwd\n/tmp` (benefits ssh **and** localshell).

2. **Plaintext `Http.Server`.** Removes all SSL from the C++ Boost.Beast server (`SSL`/`CertFile`/`KeyFile` params, ssl_context, embedded cert, handshake). Terminate TLS at a reverse proxy. The Rust reqwest client (`Http.Get/Post`, which overrides the C++ verbs on native) already handles `https://` via `native-tls`, so outbound HTTPS is unaffected.

## SSL/crypto lib impact (per platform)

| Platform | Before | After |
| --- | --- | --- |
| iOS / visionOS / macOS.framework | LibreSSL + ring | **ring only** |
| macOS desktop (llm) | LibreSSL + AWS-LC + ring | AWS-LC + ring |
| Windows | LibreSSL + ring | **ring only** |
| Linux | system OpenSSL + ring | system OpenSSL + ring |
| Android | LibreSSL + ring | LibreSSL + ring |

- **Apple + Windows: LibreSSL fully removed** (client TLS is Secure Transport / SChannel — no OpenSSL needed).
- Linux keeps system OpenSSL, Android keeps bundled LibreSSL — both via the reqwest client's `native-tls`, unchanged by this PR.

## Verification (macOS Release)

- `nm` on the binary: **0 OpenSSL/LibreSSL symbols** (the only `*OpenSSL*` hit is prefixed `aws_lc_…` from mistralrs).
- `ssh-test.shs`: passes end-to-end against `ssh-test-docker` (connect / password auth / exec / persistent state / interactive `read` → `SendInput`).
- `localshell.shs`: passes (shared `shell-common` change, no regression).
- `http.shs`: 4/4 passes (plaintext server + `https://` client + local POST).

## ⚠️ Breaking change

`Http.Server` no longer supports `SSL: true` / `CertFile` / `KeyFile`. Front it with a reverse proxy (nginx / Cloudflare) for HTTPS.

## Follow-ups (not in this PR)

- Gate the `libressl-3.9.2` FetchContent to Android-only — it's still built (but unlinked) on Apple/Windows; pure build-time waste now.
- Optionally flip the Linux client to BoringSSL/rustls to drop OpenSSL there too.
