### PR TITLE
feat: add ShardsBench code generation benchmark

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -188,6 +188,15 @@ jobs:
           # Eval harness for `shards check`: asserts structured-diagnostic quality
           # (phases, type-directed candidates, did-you-mean) and a repairability score.
           SHARDS="$PWD/build/shards" bash shards/tests/check/run.sh
+      - name: Test ShardsBench (dev suite)
+        env:
+          RUST_BACKTRACE: full
+        shell: bash
+        run: |
+          # Harness unit tests, then grade the reference answers so the checked-in
+          # task fixtures and graders cannot rot silently.
+          python3 -m unittest discover -s benchmarks/shardsbench -t benchmarks/shardsbench
+          python3 benchmarks/shardsbench/run.py validate --shards build/shards
       - name: Test doc samples (non-UI)
         env:
           RUST_BACKTRACE: full

--- a/benchmarks/shardsbench/README.md
+++ b/benchmarks/shardsbench/README.md
@@ -1,0 +1,152 @@
+# ShardsBench
+
+ShardsBench is a deterministic benchmark for code-producing language models and
+agents working in Shards. It grades generated programs through the same stages a
+developer sees:
+
+1. candidate extraction;
+2. parsing and wire construction;
+3. whole-program composition with `shards check --json`;
+4. semantic assertions with `shards run`.
+
+The initial `dev` suite is deliberately small. It is a vertical slice for validating
+the task format, runner, metrics, and candidate contract before building the larger
+held-out benchmark.
+
+To evaluate a model rather than the reference answers, follow the complete
+[code-generation run protocol](RUN.md). In particular, `validate` is maintainer
+tooling; it does not invoke or benchmark a model.
+
+## Candidate contract
+
+Every current task asks for a file defining this wire:
+
+```shards
+@wire(solution {
+  // The task input flows in here. Leave the result in the output flow.
+})
+```
+
+The grader copies the candidate into an isolated temporary working directory,
+includes it from `tests.shs`, calls `Do(solution)`, and checks the result with Shards
+assertions. Candidates may be raw Shards or a Markdown fenced `shards`/`shs` block.
+
+## Quick start
+
+From the repository root, benchmark maintainers can inspect/export tasks and verify
+the graders against their reference answers:
+
+```sh
+python3 benchmarks/shardsbench/run.py list
+python3 benchmarks/shardsbench/run.py export --output /tmp/shardsbench-prompts.jsonl
+python3 benchmarks/shardsbench/run.py validate
+```
+
+This is a benchmark smoke test, not a model run. An actual model run exports prompts,
+generates answers in an isolated environment, and then invokes `score` as specified in
+`RUN.md`.
+
+The opt-in extended suite contains larger application tasks and may open windows or
+require graphics hardware:
+
+```sh
+python3 benchmarks/shardsbench/run.py list --suite extended
+python3 benchmarks/shardsbench/run.py validate --suite extended
+python3 benchmarks/shardsbench/run.py export \
+  --suite extended \
+  --output /tmp/shardsbench-extended-prompts.jsonl
+```
+
+`validate` grades each task's reference answer. To grade model outputs, place one
+answer per task under a directory using the task ID as its relative path:
+
+```text
+answers/
+  core/double-int.shs
+  core/sum-int-sequence.shs
+  ...
+```
+
+Then run:
+
+```sh
+python3 benchmarks/shardsbench/run.py score answers \
+  --model example-model \
+  --output /tmp/shardsbench-results.json
+```
+
+Use `--shards /path/to/shards` to override binary discovery. By default the runner
+checks `SHARDS`, `build/Release/shards`, `build/Debug/shards`, and `PATH`, in that
+order.
+
+## Metrics
+
+The JSON report includes strict `pass_at_1` plus diagnostic rates:
+
+- `candidate_at_1`: an answer file existed and yielded source;
+- `parse_at_1`: no parse diagnostic was emitted;
+- `construct_at_1`: parsing and construction succeeded;
+- `compose_at_1`: `shards check --json` accepted the complete grader;
+- `requirements_at_1`: task-required shards occur inside the `solution` wire's AST;
+- `pass_at_1`: all runtime assertions passed.
+
+Per-task records retain structured diagnostics, exit codes, durations, and bounded
+stdout/stderr. The summary also breaks scores down by track and difficulty and counts
+diagnostics by phase and kind. Runtime correctness is the headline metric; composing
+is useful partial credit, not proof that the task was solved.
+
+## Task layout
+
+```text
+tasks/dev/<task-id>/
+  task.json       # metadata
+  prompt.md       # user-facing problem
+  starter.shs     # optional broken/starter program
+  tests*.shs      # one or more dev graders; private in a held-out suite
+  reference.shs   # maintainer reference answer
+  assets/         # optional files copied into the grading workspace
+```
+
+Task manifests conform to `schema/task.schema.json`. A manifest's `tests` field may
+name one grader or a list of graders; separate graders allow a wire to be composed
+independently against otherwise-incompatible concrete input types. The runner also
+performs dependency-free validation so it does not require a JSON Schema package.
+
+App tasks can declare `requirements.shards`. These are checked against function calls
+inside the `solution` wire in the canonical JSON AST. This prevents an empty/no-op wire
+from receiving full credit merely because its outer grader starts successfully. AST
+requirements complement runtime assertions; they are not a substitute for them.
+
+## Security and benchmark integrity
+
+The runner uses a fresh temporary directory and an external timeout, but **it is not a
+security sandbox**. `shards run` currently has no capability manifest, and generated
+code can invoke effectful shards. Only grade trusted model output locally. Official or
+third-party submissions should be evaluated inside a locked-down container or VM.
+
+The checked-in `dev` graders are public smoke tests. A leaderboard-quality suite should
+keep its grading pack private, publish only prompts and public examples, pin the Shards
+commit/catalog fingerprint, and periodically add newly authored tasks.
+
+## Suites
+
+- `dev`: deterministic, headless core-language generation and repair tasks suitable
+  for ordinary CI.
+- `extended`: opt-in application tasks with platform requirements. The first task
+  builds a bounded eight-frame dashboard containing a rotating GFX cube and composed
+  UI panels/widgets. It checks the complete render/UI pipeline, required AST surface,
+  and a live mesh observer that verifies the frame counter reaches exactly eight.
+
+Keep platform-dependent task results separate from the portable headline score. A
+machine that cannot initialize the required graphics/UI subsystem should report the
+suite as unsupported, not count its tasks as model failures.
+
+## Tests
+
+```sh
+python3 -m unittest discover \
+  -s benchmarks/shardsbench \
+  -t benchmarks/shardsbench \
+  -v
+python3 benchmarks/shardsbench/run.py validate
+```

--- a/benchmarks/shardsbench/README.md
+++ b/benchmarks/shardsbench/README.md
@@ -31,6 +31,11 @@ The grader copies the candidate into an isolated temporary working directory,
 includes it from `tests.shs`, calls `Do(solution)`, and checks the result with Shards
 assertions. Candidates may be raw Shards or a Markdown fenced `shards`/`shs` block.
 
+Because the candidate is included into the grading wire, its top-level statements
+would execute before the assertions. The scorer therefore rejects any candidate whose
+top level contains anything other than `@wire`, `@define`, and `@template` definitions
+(status `contract_violation`).
+
 ## Quick start
 
 From the repository root, benchmark maintainers can inspect/export tasks and verify
@@ -87,8 +92,9 @@ The JSON report includes strict `pass_at_1` plus diagnostic rates:
 - `parse_at_1`: no parse diagnostic was emitted;
 - `construct_at_1`: parsing and construction succeeded;
 - `compose_at_1`: `shards check --json` accepted the complete grader;
+- `contract_at_1`: the candidate's top level contains only allowed definitions;
 - `requirements_at_1`: task-required shards occur inside the `solution` wire's AST;
-- `pass_at_1`: all runtime assertions passed.
+- `pass_at_1`: all runtime assertions passed and the grader ran to completion.
 
 Per-task records retain structured diagnostics, exit codes, durations, and bounded
 stdout/stderr. The summary also breaks scores down by track and difficulty and counts
@@ -119,10 +125,27 @@ requirements complement runtime assertions; they are not a substitute for them.
 
 ## Security and benchmark integrity
 
-The runner uses a fresh temporary directory and an external timeout, but **it is not a
-security sandbox**. `shards run` currently has no capability manifest, and generated
-code can invoke effectful shards. Only grade trusted model output locally. Official or
-third-party submissions should be evaluated inside a locked-down container or VM.
+Two gates keep a candidate from short-circuiting its grader:
+
+1. **Top-level contract.** The candidate's JSON AST may contain only `@wire`,
+   `@define`, and `@template` definitions at the top level. Anything else — a stray
+   `Stop`, an `@include`, a `@schedule`/`@run`, any effectful statement — would run
+   inside the grading wire before the assertions and is rejected outright.
+2. **Grader-completion sentinel.** The scorer appends a final statement to each
+   grader that writes a secret token to a sentinel file. The token is passed as a
+   command-line define whose *name* is also randomized per run, so a frozen candidate
+   can neither read the token from any file nor reference or shadow the define. A
+   clean exit without a valid sentinel (for example a `Stop` issued inside
+   `Do(solution)` that ends the grading wire) is reported as `grader_short_circuit`,
+   not a pass.
+
+These gates defeat accidental early exits and simple cheating. They are **not a
+security sandbox**: `shards run` has no capability manifest, and a deliberately
+malicious candidate still executes with the grader's full OS privileges (it could,
+for instance, inspect its own process arguments through OS facilities). Only grade
+trusted model output locally. Official or third-party submissions should be evaluated
+inside a locked-down container or VM, and top-scoring candidates should be read by a
+human before publication.
 
 The checked-in `dev` graders are public smoke tests. A leaderboard-quality suite should
 keep its grading pack private, publish only prompts and public examples, pin the Shards

--- a/benchmarks/shardsbench/RUN.md
+++ b/benchmarks/shardsbench/RUN.md
@@ -177,9 +177,12 @@ python3 benchmarks/shardsbench/run.py score \
   --output /tmp/shardsbench-run/extended-results.json
 ```
 
-Scoring performs candidate extraction, `shards check --json`, AST requirements, and
-runtime assertions. It records the benchmark commit, Shards binary metadata, live shard
-catalog count/hash, platform, diagnostics, durations, and per-task outcomes.
+Scoring performs candidate extraction, `shards check --json`, the top-level candidate
+contract (definitions only — see the README's integrity section), AST requirements,
+runtime assertions, and a grader-completion sentinel that detects candidates ending
+the grading wire before its assertions run. It records the benchmark commit, Shards
+binary metadata, live shard catalog count/hash, platform, diagnostics, durations, and
+per-task outcomes.
 
 Do not send scoring diagnostics back to the model unless the declared track is an
 interactive repair benchmark. One-shot code generation ends at the first response.

--- a/benchmarks/shardsbench/RUN.md
+++ b/benchmarks/shardsbench/RUN.md
@@ -1,0 +1,257 @@
+# Running an honest ShardsBench code-generation evaluation
+
+This document defines a **model run**. A run is a batch of independent code-generation
+requests followed by one grading pass. It is not `shardsbench validate`: `validate`
+only proves that maintainers' `reference.shs` files pass their graders.
+
+The current runner intentionally separates generation from scoring. This keeps the
+task/grader format provider-neutral and makes the isolation boundary explicit.
+
+## 1. Choose and record one evaluation policy
+
+Results are comparable only when they use the same suite, context policy, tool policy,
+sampling settings, and number of samples.
+
+Recommended policy names:
+
+| Policy | Context given to the model | Tools during generation |
+|---|---|---|
+| `direct-none` | Task prompt only | None |
+| `direct-skill` | `skills/shards/SKILL.md` plus task prompt | None |
+| `direct-guide` | `SKILL.md`, `GUIDE.md`, plus task prompt | None |
+| `agent-cli` | Shards skill plus task prompt | Clean `shards` CLI: `search`, `enumerate`, `docs`, `check`, and optionally `run` |
+
+Do not mix these policies into one score. In particular, `agent-cli` measures an agent
+and its repair loop, while the direct policies measure one-shot model generation.
+
+Before generation, create a run manifest outside the model's workspace. At minimum,
+record:
+
+```json
+{
+  "run_id": "2026-07-11-example-model-dev-direct-skill-s01",
+  "benchmark_commit": "full git commit SHA",
+  "suite": "dev",
+  "model": "provider/model-version",
+  "model_revision": "exact revision or deployment ID when available",
+  "context_policy": "direct-skill",
+  "tool_policy": "none",
+  "temperature": 0.0,
+  "top_p": 1.0,
+  "max_output_tokens": 4096,
+  "samples_per_task": 1,
+  "fresh_context_per_task": true,
+  "system_prompt_sha256": "hash of the exact system/context text",
+  "notes": "Any provider options or deviations"
+}
+```
+
+Also retain the exact system prompt/context text. Model names such as “latest” are not
+reproducible; resolve them to a dated or immutable model version where possible.
+
+## 2. Freeze and export the prompt set
+
+Run this from the Shards repository, before creating the model environment:
+
+```sh
+git rev-parse HEAD
+
+python3 benchmarks/shardsbench/run.py export \
+  --suite dev \
+  --output /tmp/shardsbench-run/prompts.jsonl
+```
+
+For the opt-in UI/GFX application suite:
+
+```sh
+python3 benchmarks/shardsbench/run.py export \
+  --suite extended \
+  --output /tmp/shardsbench-run/extended-prompts.jsonl
+```
+
+Do not edit individual prompts after export. Hash and archive the exported JSONL with
+the run manifest. Each line contains a stable task `id`, metadata, and the complete
+user-facing `prompt`; repair tasks already include their starter source.
+
+The checked-in `dev` and `extended` suites are public development fixtures. They can
+support honest local experiments only if the evaluated model/agent is denied access to
+this repository. They are not contamination-resistant leaderboard sets. An official
+run requires a private task/grader pack.
+
+## 3. Create the generation boundary
+
+Generation must happen in a clean directory or container that does **not** contain:
+
+- the Shards repository;
+- `benchmarks/shardsbench/tasks`;
+- any `reference.shs`;
+- any `tests.shs` or private assets;
+- earlier ShardsBench results or diagnostics.
+
+Copy only these declared inputs into that environment:
+
+1. the exported prompt JSONL;
+2. the exact context files selected by the policy;
+3. for `agent-cli`, a clean Shards binary and only the allowed CLI/tool wrapper.
+
+Do not give a repository-aware coding agent the prompt while its working directory is
+this checkout. It could read the public answers and graders even without being
+explicitly instructed to do so.
+
+For `agent-cli`, start every task in a fresh empty workspace. The model may create its
+candidate and use the declared CLI commands, but the CLI must not be able to resolve
+includes into the benchmark repository. Record every tool call and its output.
+
+## 4. Generate answers
+
+Process every JSONL record using the same fixed procedure:
+
+1. Start a fresh conversation with no memory of previous tasks.
+2. Install the selected system/context text.
+3. Send exactly the record's `prompt` as the user message.
+4. Apply the same model and sampling settings.
+5. Capture the complete raw response and provider metadata.
+6. Do not inspect grader results or retry based on hidden-test feedback.
+
+The output contract asks for one complete Shards file defining:
+
+```shards
+@wire(solution {
+  // generated implementation
+})
+```
+
+Save one raw response per task using the task ID as its relative path:
+
+```text
+/tmp/shardsbench-run/answers/
+  core/classify-sign.shs
+  core/double-int.shs
+  core/running-total.shs
+  core/sum-int-sequence.shs
+  core/uppercase-name.shs
+  repair/parse-and-increment.shs
+  repair/uppercase-shard.shs
+```
+
+For the extended task:
+
+```text
+/tmp/shardsbench-run/extended-answers/
+  apps/ui-gfx-dashboard.shs
+```
+
+The files may contain raw Shards or the model's complete Markdown response. The scorer
+extracts a labelled `shards`/`shs` fence, a single unlabelled fence, or otherwise treats
+the entire file as source. Preserve the unmodified API response separately if the
+provider returns reasoning, token counts, finish reasons, or other metadata that would
+be lost in the answer file.
+
+A missing answer, refusal, truncation, or empty response is a benchmark failure. Do not
+repair it manually. If the protocol permits automatic retries for infrastructure
+errors, define the retry rule before the run and apply it uniformly to every task.
+
+## 5. End generation, then score once
+
+The model or agent must no longer have access when graders are introduced. Copy the
+answer directory to the scoring machine/environment and run:
+
+```sh
+python3 benchmarks/shardsbench/run.py score \
+  /tmp/shardsbench-run/answers \
+  --suite dev \
+  --model provider/model-version \
+  --run-name 2026-07-11-example-model-dev-direct-skill-s01 \
+  --output /tmp/shardsbench-run/results.json
+```
+
+Score the UI/GFX suite separately because it has platform requirements and opens a
+bounded test window:
+
+```sh
+python3 benchmarks/shardsbench/run.py score \
+  /tmp/shardsbench-run/extended-answers \
+  --suite extended \
+  --model provider/model-version \
+  --run-name 2026-07-11-example-model-extended-direct-skill-s01 \
+  --output /tmp/shardsbench-run/extended-results.json
+```
+
+Scoring performs candidate extraction, `shards check --json`, AST requirements, and
+runtime assertions. It records the benchmark commit, Shards binary metadata, live shard
+catalog count/hash, platform, diagnostics, durations, and per-task outcomes.
+
+Do not send scoring diagnostics back to the model unless the declared track is an
+interactive repair benchmark. One-shot code generation ends at the first response.
+
+## 6. Multiple samples and `pass@k`
+
+The current scorer accepts one candidate per task. For multiple samples, generate each
+sample independently into a separate answer directory and score it as a separate run:
+
+```text
+runs/<run-id>/sample-001/answers/...
+runs/<run-id>/sample-002/answers/...
+runs/<run-id>/sample-003/answers/...
+```
+
+Do not score several candidates and report only the best one as `pass@1`. Report each
+sample's `pass@1`; a future aggregation command will compute formal `pass@k` across the
+saved runs. Use deterministic sample IDs and retain all unsuccessful generations.
+
+## 7. Archive and report
+
+An auditable run archive contains:
+
+```text
+run-directory/
+  manifest.json
+  system-prompt.txt
+  prompts.jsonl
+  answers/                 # exact responses consumed by the scorer
+  raw-responses/           # provider-native response records
+  transcripts/             # required for tool-assisted agents
+  results.json
+  stdout.log
+  stderr.log
+```
+
+Publish or compare at least:
+
+- strict `pass_at_1`;
+- `parse_at_1`, `construct_at_1`, `compose_at_1`, and `requirements_at_1`;
+- per-track and per-difficulty results;
+- diagnostic histogram;
+- model/context/tool policy;
+- task and catalog fingerprints;
+- token usage, latency, and cost when available;
+- every deviation from this protocol.
+
+Keep `dev` and `extended` results separate. A graphics initialization failure caused by
+an unsupported evaluation host is an infrastructure result, not evidence about model
+quality.
+
+## Disallowed shortcuts
+
+An honest code-generation run does not allow:
+
+- model access to task references, graders, or the benchmark checkout;
+- human edits to generated code;
+- task-specific prompt changes;
+- hidden-test feedback during one-shot generation;
+- selecting among candidates using private grader results;
+- carrying conversation state or learned solutions between tasks;
+- undeclared tools, web searches, retrieval sources, or repair attempts;
+- reporting maintainer `validate` results as model results.
+
+For public fixtures, disclose possible training contamination. For official comparison,
+use a private, versioned task pack and reveal its graders only after submissions are
+frozen.
+
+## What is still manual
+
+ShardsBench currently exports prompts and deterministically scores answers, but it does
+not call model-provider APIs. Provider adapters, automatic transcript capture, run
+manifest generation, formal `pass@k` aggregation, and a private held-out task service
+are the next orchestration layer. Until then, the procedure above is the normative way
+to produce model outputs without exposing the graders.

--- a/benchmarks/shardsbench/run.py
+++ b/benchmarks/shardsbench/run.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Repository entry point for ShardsBench."""
+
+from shardsbench.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/shardsbench/schema/task.schema.json
+++ b/benchmarks/shardsbench/schema/task.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shards.dev/shardsbench/task.schema.json",
+  "title": "ShardsBench task",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "track",
+    "difficulty",
+    "tags"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9./-]*$"},
+    "title": {"type": "string", "minLength": 1},
+    "track": {"enum": ["generation", "repair", "agent", "app"]},
+    "difficulty": {"enum": ["easy", "medium", "hard"]},
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+    "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "shards": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        }
+      }
+    },
+    "prompt": {"type": "string"},
+    "starter": {"type": "string"},
+    "tests": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "reference": {"type": "string"}
+  }
+}

--- a/benchmarks/shardsbench/shardsbench/__init__.py
+++ b/benchmarks/shardsbench/shardsbench/__init__.py
@@ -1,0 +1,11 @@
+"""ShardsBench's dependency-free task loader and evaluator."""
+
+from .core import BenchmarkError, Task, discover_tasks, extract_candidate, score_tasks
+
+__all__ = [
+    "BenchmarkError",
+    "Task",
+    "discover_tasks",
+    "extract_candidate",
+    "score_tasks",
+]

--- a/benchmarks/shardsbench/shardsbench/cli.py
+++ b/benchmarks/shardsbench/shardsbench/cli.py
@@ -40,6 +40,8 @@ def _render_task_prompt(task: Task) -> str:
         parts.extend(["\nStarter program:\n", f"```shards\n{task.starter}\n```"])
     parts.append(
         "\nReturn only a complete Shards source file defining `@wire(solution { ... })`."
+        " Top-level statements other than `@wire`, `@define`, and `@template`"
+        " definitions are rejected by the grader."
     )
     return "\n".join(parts).strip()
 
@@ -64,10 +66,11 @@ def _print_summary(report: dict[str, Any]) -> None:
         "parse_at_1",
         "construct_at_1",
         "compose_at_1",
+        "contract_at_1",
         "requirements_at_1",
         "pass_at_1",
     ):
-        print(f"  {key:16} {summary[key]:.3f}")
+        print(f"  {key:18} {summary[key]:.3f}")
     failures = [result for result in report["tasks"] if not result["pass_at_1"]]
     for result in failures:
         print(f"  FAIL {result['id']}: {result['status']}")

--- a/benchmarks/shardsbench/shardsbench/cli.py
+++ b/benchmarks/shardsbench/shardsbench/cli.py
@@ -1,0 +1,167 @@
+"""Command-line interface for ShardsBench."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .core import BenchmarkError, Task, discover_tasks, resolve_shards, score_tasks
+
+
+BENCH_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BENCH_ROOT.parents[1]
+DEFAULT_SUITE = "dev"
+
+
+def _tasks_root(args: argparse.Namespace) -> Path:
+    if args.tasks_root:
+        return Path(args.tasks_root).expanduser().resolve()
+    return BENCH_ROOT / "tasks" / args.suite
+
+
+def _task_record(task: Task) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "title": task.title,
+        "track": task.track,
+        "difficulty": task.difficulty,
+        "tags": list(task.tags),
+        "required_shards": list(task.required_shards),
+        "timeout_seconds": task.timeout_seconds,
+    }
+
+
+def _render_task_prompt(task: Task) -> str:
+    parts = [task.prompt]
+    if task.starter is not None:
+        parts.extend(["\nStarter program:\n", f"```shards\n{task.starter}\n```"])
+    parts.append(
+        "\nReturn only a complete Shards source file defining `@wire(solution { ... })`."
+    )
+    return "\n".join(parts).strip()
+
+
+def _write_json(payload: dict[str, Any], output: str | None) -> None:
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output and output != "-":
+        Path(output).expanduser().write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+
+
+def _print_summary(report: dict[str, Any]) -> None:
+    summary = report["summary"]
+    print(
+        "ShardsBench "
+        f"{report['benchmark']['suite']}: {summary['status_counts'].get('passed', 0)}"
+        f"/{summary['task_count']} passed"
+    )
+    for key in (
+        "candidate_at_1",
+        "parse_at_1",
+        "construct_at_1",
+        "compose_at_1",
+        "requirements_at_1",
+        "pass_at_1",
+    ):
+        print(f"  {key:16} {summary[key]:.3f}")
+    failures = [result for result in report["tasks"] if not result["pass_at_1"]]
+    for result in failures:
+        print(f"  FAIL {result['id']}: {result['status']}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="shardsbench",
+        description="Deterministically grade model-generated Shards programs.",
+    )
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--suite", default=DEFAULT_SUITE)
+    common.add_argument("--tasks-root")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", parents=[common])
+    list_parser.add_argument("--json", action="store_true")
+
+    export_parser = subparsers.add_parser("export", parents=[common])
+    export_parser.add_argument("--output", default="-")
+
+    validate_parser = subparsers.add_parser("validate", parents=[common])
+    validate_parser.add_argument("--shards")
+    validate_parser.add_argument("--output")
+
+    score_parser = subparsers.add_parser("score", parents=[common])
+    score_parser.add_argument("answers")
+    score_parser.add_argument("--shards")
+    score_parser.add_argument("--model")
+    score_parser.add_argument("--run-name")
+    score_parser.add_argument("--output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        tasks = discover_tasks(_tasks_root(args))
+
+        if args.command == "list":
+            records = [_task_record(task) for task in tasks]
+            if args.json:
+                print(json.dumps(records, indent=2, sort_keys=True))
+            else:
+                for task in tasks:
+                    print(
+                        f"{task.id:28} {task.track:10} {task.difficulty:8} {task.title}"
+                    )
+            return 0
+
+        if args.command == "export":
+            lines = [
+                json.dumps(
+                    {**_task_record(task), "prompt": _render_task_prompt(task)},
+                    sort_keys=True,
+                )
+                for task in tasks
+            ]
+            rendered = "\n".join(lines) + "\n"
+            if args.output == "-":
+                sys.stdout.write(rendered)
+            else:
+                Path(args.output).expanduser().write_text(rendered, encoding="utf-8")
+            return 0
+
+        shards = resolve_shards(REPO_ROOT, args.shards)
+        if args.command == "validate":
+            report = score_tasks(
+                tasks,
+                lambda task: task.reference_path,
+                shards,
+                REPO_ROOT,
+                args.suite,
+                model="reference",
+                run_name="suite-validation",
+            )
+        else:
+            answers = Path(args.answers).expanduser().resolve()
+            report = score_tasks(
+                tasks,
+                lambda task: answers / f"{task.id}.shs",
+                shards,
+                REPO_ROOT,
+                args.suite,
+                model=args.model,
+                run_name=args.run_name,
+            )
+
+        if args.output:
+            _write_json(report, args.output)
+        _print_summary(report)
+        return 0 if report["summary"]["pass_at_1"] == 1.0 else 1
+    except BenchmarkError as error:
+        parser.error(str(error))
+    return 2

--- a/benchmarks/shardsbench/shardsbench/core.py
+++ b/benchmarks/shardsbench/shardsbench/core.py
@@ -1,0 +1,561 @@
+"""Core task loading, Shards execution, and metric aggregation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+SCHEMA_VERSION = 1
+MAX_CAPTURE_CHARS = 20_000
+FENCE_RE = re.compile(
+    r"```(?P<label>[^\n`]*)\n(?P<body>.*?)```", re.DOTALL | re.IGNORECASE
+)
+
+
+class BenchmarkError(RuntimeError):
+    """Raised for benchmark configuration or infrastructure failures."""
+
+
+@dataclass(frozen=True)
+class Task:
+    id: str
+    title: str
+    track: str
+    difficulty: str
+    tags: tuple[str, ...]
+    required_shards: tuple[str, ...]
+    timeout_seconds: float
+    directory: Path
+    prompt_path: Path
+    tests_paths: tuple[Path, ...]
+    reference_path: Path
+    starter_path: Path | None
+
+    @property
+    def prompt(self) -> str:
+        return self.prompt_path.read_text(encoding="utf-8").strip()
+
+    @property
+    def starter(self) -> str | None:
+        if self.starter_path is None:
+            return None
+        return self.starter_path.read_text(encoding="utf-8").rstrip()
+
+
+def _require_string(data: dict[str, Any], key: str, manifest: Path) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise BenchmarkError(f"{manifest}: {key!r} must be a non-empty string")
+    return value
+
+
+def load_task(manifest: Path) -> Task:
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise BenchmarkError(f"could not read {manifest}: {error}") from error
+
+    if not isinstance(data, dict):
+        raise BenchmarkError(f"{manifest}: manifest must be a JSON object")
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise BenchmarkError(
+            f"{manifest}: schema_version must be {SCHEMA_VERSION}"
+        )
+
+    task_id = _require_string(data, "id", manifest)
+    if task_id.startswith("/") or ".." in Path(task_id).parts:
+        raise BenchmarkError(f"{manifest}: id must be a safe relative path")
+
+    tags = data.get("tags", [])
+    if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+        raise BenchmarkError(f"{manifest}: tags must be an array of strings")
+
+    requirements = data.get("requirements", {})
+    if not isinstance(requirements, dict):
+        raise BenchmarkError(f"{manifest}: requirements must be an object")
+    required_shards = requirements.get("shards", [])
+    if not isinstance(required_shards, list) or not all(
+        isinstance(name, str) and name for name in required_shards
+    ):
+        raise BenchmarkError(
+            f"{manifest}: requirements.shards must be an array of non-empty strings"
+        )
+
+    timeout_seconds = data.get("timeout_seconds", 5)
+    if not isinstance(timeout_seconds, (int, float)) or timeout_seconds <= 0:
+        raise BenchmarkError(f"{manifest}: timeout_seconds must be positive")
+
+    directory = manifest.parent
+    prompt_path = directory / data.get("prompt", "prompt.md")
+    tests_value = data.get("tests", "tests.shs")
+    if isinstance(tests_value, str):
+        tests_names = [tests_value]
+    elif (
+        isinstance(tests_value, list)
+        and tests_value
+        and all(isinstance(name, str) for name in tests_value)
+    ):
+        tests_names = tests_value
+    else:
+        raise BenchmarkError(f"{manifest}: tests must be a string or non-empty string array")
+    tests_paths = tuple(directory / name for name in tests_names)
+    reference_path = directory / data.get("reference", "reference.shs")
+    starter_name = data.get("starter")
+    starter_path = directory / starter_name if isinstance(starter_name, str) else None
+
+    for label, path in (("prompt", prompt_path), ("reference", reference_path)):
+        if not path.is_file():
+            raise BenchmarkError(f"{manifest}: {label} file does not exist: {path}")
+    for path in tests_paths:
+        if not path.is_file():
+            raise BenchmarkError(f"{manifest}: tests file does not exist: {path}")
+    if starter_path is not None and not starter_path.is_file():
+        raise BenchmarkError(f"{manifest}: starter file does not exist: {starter_path}")
+
+    return Task(
+        id=task_id,
+        title=_require_string(data, "title", manifest),
+        track=_require_string(data, "track", manifest),
+        difficulty=_require_string(data, "difficulty", manifest),
+        tags=tuple(tags),
+        required_shards=tuple(required_shards),
+        timeout_seconds=float(timeout_seconds),
+        directory=directory,
+        prompt_path=prompt_path,
+        tests_paths=tests_paths,
+        reference_path=reference_path,
+        starter_path=starter_path,
+    )
+
+
+def discover_tasks(tasks_root: Path) -> list[Task]:
+    if not tasks_root.is_dir():
+        raise BenchmarkError(f"task root does not exist: {tasks_root}")
+    tasks = [load_task(path) for path in sorted(tasks_root.rglob("task.json"))]
+    if not tasks:
+        raise BenchmarkError(f"no task.json manifests found under {tasks_root}")
+    ids = [task.id for task in tasks]
+    duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+    if duplicates:
+        raise BenchmarkError(f"duplicate task IDs: {', '.join(duplicates)}")
+    return sorted(tasks, key=lambda task: task.id)
+
+
+def extract_candidate(raw: str) -> tuple[str, str]:
+    """Extract Shards from a raw answer and return (source, extraction mode)."""
+    matches = list(FENCE_RE.finditer(raw))
+    for match in matches:
+        label = match.group("label").strip().lower()
+        if label in {"shards", "shs"}:
+            return match.group("body").strip() + "\n", f"{label}_fence"
+    if len(matches) == 1:
+        return matches[0].group("body").strip() + "\n", "single_fence"
+    source = raw.strip()
+    return (source + "\n" if source else ""), "raw"
+
+
+def resolve_shards(repo_root: Path, override: str | None = None) -> Path:
+    candidates: list[Path] = []
+    if override:
+        candidates.append(Path(override).expanduser())
+    if os.environ.get("SHARDS"):
+        candidates.append(Path(os.environ["SHARDS"]).expanduser())
+    candidates.extend(
+        [repo_root / "build/Release/shards", repo_root / "build/Debug/shards"]
+    )
+    on_path = shutil.which("shards")
+    if on_path:
+        candidates.append(Path(on_path))
+
+    for candidate in candidates:
+        candidate = candidate.resolve()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    attempted = ", ".join(str(path) for path in candidates) or "(none)"
+    raise BenchmarkError(f"could not find an executable shards binary; tried {attempted}")
+
+
+def _bounded(text: str) -> tuple[str, bool]:
+    if len(text) <= MAX_CAPTURE_CHARS:
+        return text, False
+    return text[:MAX_CAPTURE_CHARS], True
+
+
+def _run(
+    command: list[str], cwd: Path, timeout_seconds: float
+) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        stdout, stdout_truncated = _bounded(completed.stdout)
+        stderr, stderr_truncated = _bounded(completed.stderr)
+        return {
+            "exit_code": completed.returncode,
+            "timed_out": False,
+            "duration_seconds": round(time.monotonic() - started, 6),
+            "stdout": stdout,
+            "stderr": stderr,
+            "stdout_truncated": stdout_truncated,
+            "stderr_truncated": stderr_truncated,
+        }
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout or ""
+        stderr = error.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        stdout, stdout_truncated = _bounded(stdout)
+        stderr, stderr_truncated = _bounded(stderr)
+        return {
+            "exit_code": None,
+            "timed_out": True,
+            "duration_seconds": round(time.monotonic() - started, 6),
+            "stdout": stdout,
+            "stderr": stderr,
+            "stdout_truncated": stdout_truncated,
+            "stderr_truncated": stderr_truncated,
+        }
+
+
+def _diagnostics(check_result: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        payload = json.loads(check_result["stdout"])
+    except (json.JSONDecodeError, TypeError):
+        return []
+    diagnostics = payload.get("diagnostics", []) if isinstance(payload, dict) else []
+    return diagnostics if isinstance(diagnostics, list) else []
+
+
+def _copy_task_assets(task: Task, tests_path: Path, workspace: Path) -> None:
+    shutil.copy2(tests_path, workspace / "tests.shs")
+    assets = task.directory / "assets"
+    if assets.is_dir():
+        shutil.copytree(assets, workspace / "assets")
+
+
+def _solution_function_names(ast: Any) -> list[str]:
+    """Return function names contained by the `solution` wire in a Shards AST."""
+
+    def visit(node: Any) -> list[str] | None:
+        if isinstance(node, dict):
+            function = node.get("func")
+            if isinstance(function, dict) and function.get("name") == "wire":
+                params = function.get("params", [])
+                if (
+                    isinstance(params, list)
+                    and len(params) >= 2
+                    and isinstance(params[0], dict)
+                    and params[0].get("id", {}).get("name") == "solution"
+                ):
+                    names: list[str] = []
+
+                    def collect(value: Any) -> None:
+                        if isinstance(value, dict):
+                            for key in ("sh", "func"):
+                                nested = value.get(key)
+                                if isinstance(nested, dict) and isinstance(
+                                    nested.get("name"), str
+                                ):
+                                    names.append(nested["name"])
+                            for child in value.values():
+                                collect(child)
+                        elif isinstance(value, list):
+                            for child in value:
+                                collect(child)
+
+                    collect(params[1])
+                    return names
+            for child in node.values():
+                found = visit(child)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for child in node:
+                found = visit(child)
+                if found is not None:
+                    return found
+        return None
+
+    return visit(ast) or []
+
+
+def _check_requirements(
+    task: Task, workspace: Path, shards: Path
+) -> tuple[bool, dict[str, Any]]:
+    if not task.required_shards:
+        return True, {"required_shards": [], "missing_shards": []}
+
+    ast_path = workspace / "candidate.ast.json"
+    command = _run(
+        [str(shards), "ast", "candidate.shs", "-o", str(ast_path)],
+        workspace,
+        task.timeout_seconds,
+    )
+    if command["timed_out"] or command["exit_code"] != 0 or not ast_path.is_file():
+        return False, {
+            "required_shards": list(task.required_shards),
+            "missing_shards": list(task.required_shards),
+            "ast_command": command,
+        }
+    try:
+        ast = json.loads(ast_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return False, {
+            "required_shards": list(task.required_shards),
+            "missing_shards": list(task.required_shards),
+            "error": str(error),
+            "ast_command": command,
+        }
+    found = _solution_function_names(ast)
+    found_set = set(found)
+    missing = [name for name in task.required_shards if name not in found_set]
+    return not missing, {
+        "required_shards": list(task.required_shards),
+        "found_shards": sorted(found_set),
+        "missing_shards": missing,
+        "ast_command": command,
+    }
+
+
+def score_task(task: Task, candidate: Path | None, shards: Path) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": task.id,
+        "title": task.title,
+        "track": task.track,
+        "difficulty": task.difficulty,
+        "tags": list(task.tags),
+        "candidate_at_1": False,
+        "parse_at_1": False,
+        "construct_at_1": False,
+        "compose_at_1": False,
+        "requirements_at_1": False,
+        "pass_at_1": False,
+    }
+    if candidate is None or not candidate.is_file():
+        return {**base, "status": "missing_candidate"}
+
+    try:
+        raw = candidate.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        return {**base, "status": "unreadable_candidate", "error": str(error)}
+    source, extraction_mode = extract_candidate(raw)
+    if not source.strip():
+        return {
+            **base,
+            "status": "empty_candidate",
+            "extraction_mode": extraction_mode,
+        }
+    base["candidate_at_1"] = True
+    base["extraction_mode"] = extraction_mode
+
+    with tempfile.TemporaryDirectory(prefix="shardsbench-") as temp:
+        workspaces: list[tuple[Path, Path]] = []
+        checks: list[dict[str, Any]] = []
+        all_phases: set[Any] = set()
+        for index, tests_path in enumerate(task.tests_paths):
+            workspace = Path(temp) / f"case-{index:03d}-{tests_path.stem}"
+            workspace.mkdir()
+            _copy_task_assets(task, tests_path, workspace)
+            (workspace / "candidate.shs").write_text(source, encoding="utf-8")
+            workspaces.append((tests_path, workspace))
+
+            check = _run(
+                [str(shards), "check", "--json", "tests.shs"],
+                workspace,
+                task.timeout_seconds,
+            )
+            diagnostics = _diagnostics(check)
+            all_phases.update(
+                diagnostic.get("phase")
+                for diagnostic in diagnostics
+                if isinstance(diagnostic, dict)
+            )
+            checks.append(
+                {"case": tests_path.name, **check, "diagnostics": diagnostics}
+            )
+
+        base["parse_at_1"] = not any(check["timed_out"] for check in checks) and (
+            "parse" not in all_phases
+        )
+        base["construct_at_1"] = base["parse_at_1"] and "construct" not in all_phases
+        base["compose_at_1"] = all(check["exit_code"] == 0 for check in checks)
+        base["checks"] = checks
+
+        if any(check["timed_out"] for check in checks):
+            return {**base, "status": "check_timeout"}
+        if any(check["exit_code"] == 2 for check in checks):
+            return {**base, "status": "check_infrastructure_error"}
+        if not base["compose_at_1"]:
+            return {**base, "status": "check_failed"}
+
+        requirements_ok, requirements = _check_requirements(
+            task, workspaces[0][1], shards
+        )
+        base["requirements_at_1"] = requirements_ok
+        base["requirements"] = requirements
+        if not requirements_ok:
+            if requirements.get("ast_command", {}).get("timed_out"):
+                return {**base, "status": "requirements_timeout"}
+            if requirements.get("missing_shards"):
+                return {**base, "status": "requirements_failed"}
+            return {**base, "status": "requirements_infrastructure_error"}
+
+        runs: list[dict[str, Any]] = []
+        for tests_path, workspace in workspaces:
+            run = _run(
+                [str(shards), "run", "tests.shs"],
+                workspace,
+                task.timeout_seconds,
+            )
+            runs.append({"case": tests_path.name, **run})
+        base["runs"] = runs
+        if any(run["timed_out"] for run in runs):
+            return {**base, "status": "run_timeout"}
+        if any(run["exit_code"] != 0 for run in runs):
+            return {**base, "status": "tests_failed"}
+        base["pass_at_1"] = True
+        return {**base, "status": "passed"}
+
+
+def _rate(results: list[dict[str, Any]], key: str) -> float:
+    if not results:
+        return 0.0
+    return round(sum(bool(result[key]) for result in results) / len(results), 6)
+
+
+def _aggregate_rates(results: list[dict[str, Any]]) -> dict[str, Any]:
+    status_counts: dict[str, int] = {}
+    for result in results:
+        status = str(result["status"])
+        status_counts[status] = status_counts.get(status, 0) + 1
+    return {
+        "task_count": len(results),
+        "candidate_at_1": _rate(results, "candidate_at_1"),
+        "parse_at_1": _rate(results, "parse_at_1"),
+        "construct_at_1": _rate(results, "construct_at_1"),
+        "compose_at_1": _rate(results, "compose_at_1"),
+        "requirements_at_1": _rate(results, "requirements_at_1"),
+        "pass_at_1": _rate(results, "pass_at_1"),
+        "status_counts": dict(sorted(status_counts.items())),
+    }
+
+
+def aggregate(results: list[dict[str, Any]]) -> dict[str, Any]:
+    diagnostic_phases: dict[str, int] = {}
+    diagnostic_kinds: dict[str, int] = {}
+    for result in results:
+        for check in result.get("checks", []):
+            for diagnostic in check.get("diagnostics", []):
+                if not isinstance(diagnostic, dict):
+                    continue
+                phase = str(diagnostic.get("phase", "unknown"))
+                kind = str(diagnostic.get("kind", "unknown"))
+                diagnostic_phases[phase] = diagnostic_phases.get(phase, 0) + 1
+                diagnostic_kinds[kind] = diagnostic_kinds.get(kind, 0) + 1
+
+    def grouped(field: str) -> dict[str, dict[str, Any]]:
+        values = sorted({str(result.get(field, "unknown")) for result in results})
+        return {
+            value: _aggregate_rates(
+                [result for result in results if str(result.get(field, "unknown")) == value]
+            )
+            for value in values
+        }
+
+    return {
+        **_aggregate_rates(results),
+        "diagnostics": {
+            "by_phase": dict(sorted(diagnostic_phases.items())),
+            "by_kind": dict(sorted(diagnostic_kinds.items())),
+        },
+        "by_track": grouped("track"),
+        "by_difficulty": grouped("difficulty"),
+    }
+
+
+def _git_commit(repo_root: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+def _catalog_fingerprint(shards: Path, repo_root: Path) -> dict[str, Any] | None:
+    completed = subprocess.run(
+        [str(shards), "enumerate", "--json"],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    try:
+        catalog = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return None
+    return {
+        "count": len(catalog) if isinstance(catalog, list) else None,
+        "sha256": hashlib.sha256(completed.stdout).hexdigest(),
+    }
+
+
+def score_tasks(
+    tasks: Iterable[Task],
+    candidate_for: Callable[[Task], Path | None],
+    shards: Path,
+    repo_root: Path,
+    suite: str,
+    model: str | None = None,
+    run_name: str | None = None,
+) -> dict[str, Any]:
+    task_list = list(tasks)
+    results = [score_task(task, candidate_for(task), shards) for task in task_list]
+    stat = shards.stat()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "benchmark": {
+            "name": "ShardsBench",
+            "suite": suite,
+            "git_commit": _git_commit(repo_root),
+            "shards_binary": str(shards),
+            "shards_binary_size": stat.st_size,
+            "shards_binary_mtime_ns": stat.st_mtime_ns,
+            "catalog": _catalog_fingerprint(shards, repo_root),
+        },
+        "run": {
+            "name": run_name,
+            "model": model,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+        },
+        "summary": aggregate(results),
+        "tasks": results,
+    }

--- a/benchmarks/shardsbench/shardsbench/core.py
+++ b/benchmarks/shardsbench/shardsbench/core.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import re
+import secrets
 import shutil
 import subprocess
 import tempfile
@@ -19,6 +20,14 @@ from typing import Any, Callable, Iterable
 
 SCHEMA_VERSION = 1
 MAX_CAPTURE_CHARS = 20_000
+SUBPROCESS_TIMEOUT_SECONDS = 30
+SENTINEL_FILE = "__shardsbench_sentinel__"
+SENTINEL_DEFINE_PREFIX = "shardsbench-sentinel-"
+# Top-level statements a candidate may contain. Everything else (shard
+# applications, constants, `@schedule`, `@run`, `@include`, ...) executes inside
+# the grading wire before its assertions, so it could stop the wire or fake a
+# clean exit; only inert definitions are allowed.
+ALLOWED_TOPLEVEL_FUNCS = frozenset({"wire", "define", "template"})
 FENCE_RE = re.compile(
     r"```(?P<label>[^\n`]*)\n(?P<body>.*?)```", re.DOTALL | re.IGNORECASE
 )
@@ -193,48 +202,60 @@ def _bounded(text: str) -> tuple[str, bool]:
     return text[:MAX_CAPTURE_CHARS], True
 
 
+def _bounded_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Bound captured stdout/stderr for storage in the report."""
+    stdout, stdout_truncated = _bounded(result["stdout"])
+    stderr, stderr_truncated = _bounded(result["stderr"])
+    return {
+        **result,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+    }
+
+
 def _run(
     command: list[str], cwd: Path, timeout_seconds: float
 ) -> dict[str, Any]:
+    """Run a command, capturing full (unbounded) output.
+
+    Model-generated programs can print arbitrary bytes, so decoding must never
+    raise; callers pass results through `_bounded_result` before storing them.
+    """
     started = time.monotonic()
     try:
         completed = subprocess.run(
             command,
             cwd=cwd,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout_seconds,
             check=False,
         )
-        stdout, stdout_truncated = _bounded(completed.stdout)
-        stderr, stderr_truncated = _bounded(completed.stderr)
         return {
             "exit_code": completed.returncode,
             "timed_out": False,
             "duration_seconds": round(time.monotonic() - started, 6),
-            "stdout": stdout,
-            "stderr": stderr,
-            "stdout_truncated": stdout_truncated,
-            "stderr_truncated": stderr_truncated,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
         }
     except subprocess.TimeoutExpired as error:
         stdout = error.stdout or ""
         stderr = error.stderr or ""
         if isinstance(stdout, bytes):
-            stdout = stdout.decode(errors="replace")
+            stdout = stdout.decode("utf-8", errors="replace")
         if isinstance(stderr, bytes):
-            stderr = stderr.decode(errors="replace")
-        stdout, stdout_truncated = _bounded(stdout)
-        stderr, stderr_truncated = _bounded(stderr)
+            stderr = stderr.decode("utf-8", errors="replace")
         return {
             "exit_code": None,
             "timed_out": True,
             "duration_seconds": round(time.monotonic() - started, 6),
             "stdout": stdout,
             "stderr": stderr,
-            "stdout_truncated": stdout_truncated,
-            "stderr_truncated": stderr_truncated,
         }
 
 
@@ -247,11 +268,63 @@ def _diagnostics(check_result: dict[str, Any]) -> list[dict[str, Any]]:
     return diagnostics if isinstance(diagnostics, list) else []
 
 
-def _copy_task_assets(task: Task, tests_path: Path, workspace: Path) -> None:
-    shutil.copy2(tests_path, workspace / "tests.shs")
+def _sentinel_lines(sentinel_define: str) -> str:
+    # The sentinel is the grader's last statement. A candidate that halts the
+    # grading wire early (`Stop` at top level or inside `Do(solution)`) exits
+    # cleanly without running the assertions; the sentinel file proves the
+    # grader actually reached its end. The token arrives as a command-line
+    # define so it never exists in any file the candidate can read at runtime,
+    # and both the token AND the define's name are random per run: define
+    # references resolve syntactically at eval time, so a frozen candidate
+    # cannot reference (or shadow) a name that did not exist when it was
+    # generated.
+    return (
+        f'@define({sentinel_define} "unset" IgnoreRedefined: true)\n'
+        f'"{SENTINEL_FILE}" | FS.Write(Contents: @{sentinel_define} Overwrite: true)'
+    )
+
+
+def _copy_task_assets(
+    task: Task, tests_path: Path, workspace: Path, sentinel_define: str
+) -> None:
+    tests_source = tests_path.read_text(encoding="utf-8").rstrip()
+    tests_source += f"\n\n{_sentinel_lines(sentinel_define)}\n"
+    (workspace / "tests.shs").write_text(tests_source, encoding="utf-8")
     assets = task.directory / "assets"
     if assets.is_dir():
         shutil.copytree(assets, workspace / "assets")
+
+
+def _sentinel_reached(workspace: Path, sentinel_token: str) -> bool:
+    sentinel = workspace / SENTINEL_FILE
+    try:
+        return sentinel.read_text(encoding="utf-8") == sentinel_token
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _toplevel_violations(ast: Any) -> list[dict[str, Any]]:
+    """Return candidate top-level statements that are not inert definitions."""
+    sequence = ast.get("sequence") if isinstance(ast, dict) else None
+    if not isinstance(sequence, list):
+        return [{"kind": "malformed", "name": None, "line": None}]
+    violations: list[dict[str, Any]] = []
+    for pipeline in sequence:
+        blocks = pipeline if isinstance(pipeline, list) else [pipeline]
+        for block in blocks:
+            if isinstance(block, dict):
+                function = block.get("func")
+                name = function.get("name") if isinstance(function, dict) else None
+                if name in ALLOWED_TOPLEVEL_FUNCS:
+                    continue
+                kind = next(
+                    (key for key in block if key != "line_info"), "unknown"
+                )
+                line = block.get("line_info", {}).get("line")
+                violations.append({"kind": kind, "name": name, "line": line})
+            else:
+                violations.append({"kind": "unknown", "name": None, "line": None})
+    return violations
 
 
 def _solution_function_names(ast: Any) -> list[str]:
@@ -300,41 +373,35 @@ def _solution_function_names(ast: Any) -> list[str]:
     return visit(ast) or []
 
 
-def _check_requirements(
-    task: Task, workspace: Path, shards: Path
-) -> tuple[bool, dict[str, Any]]:
-    if not task.required_shards:
-        return True, {"required_shards": [], "missing_shards": []}
-
+def _candidate_ast(
+    workspace: Path, shards: Path, timeout_seconds: float
+) -> tuple[Any | None, dict[str, Any]]:
+    """Generate the candidate's JSON AST; return (ast or None, command record)."""
     ast_path = workspace / "candidate.ast.json"
-    command = _run(
-        [str(shards), "ast", "candidate.shs", "-o", str(ast_path)],
-        workspace,
-        task.timeout_seconds,
+    command = _bounded_result(
+        _run(
+            [str(shards), "ast", "candidate.shs", "-o", str(ast_path)],
+            workspace,
+            timeout_seconds,
+        )
     )
     if command["timed_out"] or command["exit_code"] != 0 or not ast_path.is_file():
-        return False, {
-            "required_shards": list(task.required_shards),
-            "missing_shards": list(task.required_shards),
-            "ast_command": command,
-        }
+        return None, command
     try:
-        ast = json.loads(ast_path.read_text(encoding="utf-8"))
+        return json.loads(ast_path.read_text(encoding="utf-8")), command
     except (OSError, json.JSONDecodeError) as error:
-        return False, {
-            "required_shards": list(task.required_shards),
-            "missing_shards": list(task.required_shards),
-            "error": str(error),
-            "ast_command": command,
-        }
-    found = _solution_function_names(ast)
-    found_set = set(found)
+        return None, {**command, "error": str(error)}
+
+
+def _check_requirements(task: Task, ast: Any) -> tuple[bool, dict[str, Any]]:
+    if not task.required_shards:
+        return True, {"required_shards": [], "missing_shards": []}
+    found_set = set(_solution_function_names(ast))
     missing = [name for name in task.required_shards if name not in found_set]
     return not missing, {
         "required_shards": list(task.required_shards),
         "found_shards": sorted(found_set),
         "missing_shards": missing,
-        "ast_command": command,
     }
 
 
@@ -349,6 +416,7 @@ def score_task(task: Task, candidate: Path | None, shards: Path) -> dict[str, An
         "parse_at_1": False,
         "construct_at_1": False,
         "compose_at_1": False,
+        "contract_at_1": False,
         "requirements_at_1": False,
         "pass_at_1": False,
     }
@@ -369,6 +437,8 @@ def score_task(task: Task, candidate: Path | None, shards: Path) -> dict[str, An
     base["candidate_at_1"] = True
     base["extraction_mode"] = extraction_mode
 
+    sentinel_define = f"{SENTINEL_DEFINE_PREFIX}{secrets.token_hex(8)}"
+    sentinel_token = secrets.token_hex(16)
     with tempfile.TemporaryDirectory(prefix="shardsbench-") as temp:
         workspaces: list[tuple[Path, Path]] = []
         checks: list[dict[str, Any]] = []
@@ -376,7 +446,7 @@ def score_task(task: Task, candidate: Path | None, shards: Path) -> dict[str, An
         for index, tests_path in enumerate(task.tests_paths):
             workspace = Path(temp) / f"case-{index:03d}-{tests_path.stem}"
             workspace.mkdir()
-            _copy_task_assets(task, tests_path, workspace)
+            _copy_task_assets(task, tests_path, workspace, sentinel_define)
             (workspace / "candidate.shs").write_text(source, encoding="utf-8")
             workspaces.append((tests_path, workspace))
 
@@ -392,7 +462,11 @@ def score_task(task: Task, candidate: Path | None, shards: Path) -> dict[str, An
                 if isinstance(diagnostic, dict)
             )
             checks.append(
-                {"case": tests_path.name, **check, "diagnostics": diagnostics}
+                {
+                    "case": tests_path.name,
+                    **_bounded_result(check),
+                    "diagnostics": diagnostics,
+                }
             )
 
         base["parse_at_1"] = not any(check["timed_out"] for check in checks) and (
@@ -409,31 +483,59 @@ def score_task(task: Task, candidate: Path | None, shards: Path) -> dict[str, An
         if not base["compose_at_1"]:
             return {**base, "status": "check_failed"}
 
-        requirements_ok, requirements = _check_requirements(
-            task, workspaces[0][1], shards
+        ast, ast_command = _candidate_ast(
+            workspaces[0][1], shards, task.timeout_seconds
         )
+        base["ast_command"] = ast_command
+        if ast is None:
+            if ast_command["timed_out"]:
+                return {**base, "status": "ast_timeout"}
+            return {**base, "status": "ast_infrastructure_error"}
+
+        violations = _toplevel_violations(ast)
+        base["contract_at_1"] = not violations
+        if violations:
+            return {
+                **base,
+                "status": "contract_violation",
+                "contract_violations": violations,
+            }
+
+        requirements_ok, requirements = _check_requirements(task, ast)
         base["requirements_at_1"] = requirements_ok
         base["requirements"] = requirements
         if not requirements_ok:
-            if requirements.get("ast_command", {}).get("timed_out"):
-                return {**base, "status": "requirements_timeout"}
-            if requirements.get("missing_shards"):
-                return {**base, "status": "requirements_failed"}
-            return {**base, "status": "requirements_infrastructure_error"}
+            return {**base, "status": "requirements_failed"}
 
         runs: list[dict[str, Any]] = []
         for tests_path, workspace in workspaces:
             run = _run(
-                [str(shards), "run", "tests.shs"],
+                [
+                    str(shards),
+                    "run",
+                    "tests.shs",
+                    f"{sentinel_define}:{sentinel_token}",
+                ],
                 workspace,
                 task.timeout_seconds,
             )
-            runs.append({"case": tests_path.name, **run})
+            sentinel_ok = _sentinel_reached(workspace, sentinel_token)
+            runs.append(
+                {
+                    "case": tests_path.name,
+                    **_bounded_result(run),
+                    "sentinel_ok": sentinel_ok,
+                }
+            )
         base["runs"] = runs
         if any(run["timed_out"] for run in runs):
             return {**base, "status": "run_timeout"}
         if any(run["exit_code"] != 0 for run in runs):
             return {**base, "status": "tests_failed"}
+        if not all(run["sentinel_ok"] for run in runs):
+            # Exit was clean but the grader's final statement never executed:
+            # something ended the grading wire before the assertions completed.
+            return {**base, "status": "grader_short_circuit"}
         base["pass_at_1"] = True
         return {**base, "status": "passed"}
 
@@ -455,6 +557,7 @@ def _aggregate_rates(results: list[dict[str, Any]]) -> dict[str, Any]:
         "parse_at_1": _rate(results, "parse_at_1"),
         "construct_at_1": _rate(results, "construct_at_1"),
         "compose_at_1": _rate(results, "compose_at_1"),
+        "contract_at_1": _rate(results, "contract_at_1"),
         "requirements_at_1": _rate(results, "requirements_at_1"),
         "pass_at_1": _rate(results, "pass_at_1"),
         "status_counts": dict(sorted(status_counts.items())),
@@ -495,25 +598,35 @@ def aggregate(results: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _git_commit(repo_root: Path) -> str | None:
-    completed = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=repo_root,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return completed.stdout.strip() if completed.returncode == 0 else None
 
 
 def _catalog_fingerprint(shards: Path, repo_root: Path) -> dict[str, Any] | None:
-    completed = subprocess.run(
-        [str(shards), "enumerate", "--json"],
-        cwd=repo_root,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            [str(shards), "enumerate", "--json"],
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     if completed.returncode != 0:
         return None
     try:

--- a/benchmarks/shardsbench/tasks/dev/core/classify-sign/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/core/classify-sign/prompt.md
@@ -1,0 +1,2 @@
+Define a wire named `solution` that receives an integer and outputs exactly
+`"positive"`, `"zero"`, or `"negative"` according to its sign.

--- a/benchmarks/shardsbench/tasks/dev/core/classify-sign/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/classify-sign/reference.shs
@@ -1,0 +1,7 @@
+@wire(solution {
+  If({IsMore(0)} {
+    "positive"
+  } {
+    If({Is(0)} {"zero"} {"negative"})
+  })
+})

--- a/benchmarks/shardsbench/tasks/dev/core/classify-sign/task.json
+++ b/benchmarks/shardsbench/tasks/dev/core/classify-sign/task.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "core/classify-sign",
+  "title": "Classify an integer's sign",
+  "track": "generation",
+  "difficulty": "medium",
+  "tags": ["core", "integer", "if", "predicate"],
+  "timeout_seconds": 5
+}

--- a/benchmarks/shardsbench/tasks/dev/core/classify-sign/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/classify-sign/tests.shs
@@ -1,0 +1,7 @@
+@include("candidate.shs" Once: true)
+
+-100 | Do(solution) | Assert.Is("negative")
+-1 | Do(solution) | Assert.Is("negative")
+0 | Do(solution) | Assert.Is("zero")
+1 | Do(solution) | Assert.Is("positive")
+99 | Do(solution) | Assert.Is("positive")

--- a/benchmarks/shardsbench/tasks/dev/core/double-int/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/core/double-int/prompt.md
@@ -1,0 +1,2 @@
+Define a wire named `solution` that receives an integer and outputs twice that integer.
+Do not log or hard-code the grader examples.

--- a/benchmarks/shardsbench/tasks/dev/core/double-int/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/double-int/reference.shs
@@ -1,0 +1,3 @@
+@wire(solution {
+  Mul(2)
+})

--- a/benchmarks/shardsbench/tasks/dev/core/double-int/task.json
+++ b/benchmarks/shardsbench/tasks/dev/core/double-int/task.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "core/double-int",
+  "title": "Double an integer",
+  "track": "generation",
+  "difficulty": "easy",
+  "tags": ["core", "integer", "flow"],
+  "timeout_seconds": 5
+}

--- a/benchmarks/shardsbench/tasks/dev/core/double-int/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/double-int/tests.shs
@@ -1,0 +1,6 @@
+@include("candidate.shs" Once: true)
+
+0 | Do(solution) | Assert.Is(0)
+1 | Do(solution) | Assert.Is(2)
+-7 | Do(solution) | Assert.Is(-14)
+123456 | Do(solution) | Assert.Is(246912)

--- a/benchmarks/shardsbench/tasks/dev/core/running-total/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/core/running-total/prompt.md
@@ -1,0 +1,3 @@
+Define a stateful wire named `solution`. On its first activation its total is zero. Each
+integer input is added to that persistent total and the updated total is output. State
+must persist across repeated `Do(solution)` calls.

--- a/benchmarks/shardsbench/tasks/dev/core/running-total/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/running-total/reference.shs
@@ -1,0 +1,6 @@
+@wire(solution {
+  Once({
+    0 | Set(total)
+  })
+  Add(total) | Update(total)
+})

--- a/benchmarks/shardsbench/tasks/dev/core/running-total/task.json
+++ b/benchmarks/shardsbench/tasks/dev/core/running-total/task.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "core/running-total",
+  "title": "Maintain a running total",
+  "track": "generation",
+  "difficulty": "medium",
+  "tags": ["core", "wire", "once", "state", "update"],
+  "timeout_seconds": 5
+}

--- a/benchmarks/shardsbench/tasks/dev/core/running-total/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/running-total/tests.shs
@@ -1,0 +1,6 @@
+@include("candidate.shs" Once: true)
+
+1 | Do(solution) | Assert.Is(1)
+2 | Do(solution) | Assert.Is(3)
+-1 | Do(solution) | Assert.Is(2)
+10 | Do(solution) | Assert.Is(12)

--- a/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/prompt.md
@@ -1,0 +1,3 @@
+Define a wire named `solution` that receives a sequence of integers and outputs their
+sum. The empty sequence must produce `0`. Use mutable state local to the wire and leave
+the final integer in the output flow.

--- a/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/reference.shs
@@ -1,0 +1,8 @@
+@wire(solution {
+  Set(numbers)
+  0 | Set(total)
+  numbers | ForEach({
+    ExpectInt | Add(total) | Update(total)
+  })
+  total
+})

--- a/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/task.json
+++ b/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/task.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "core/sum-int-sequence",
+  "title": "Sum an integer sequence",
+  "track": "generation",
+  "difficulty": "medium",
+  "tags": ["core", "sequence", "foreach", "state"],
+  "timeout_seconds": 5,
+  "tests": ["tests.shs", "tests-empty.shs"]
+}

--- a/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/tests-empty.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/tests-empty.shs
@@ -1,0 +1,3 @@
+@include("candidate.shs" Once: true)
+
+[] | Do(solution) | Assert.Is(0)

--- a/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/sum-int-sequence/tests.shs
@@ -1,0 +1,6 @@
+@include("candidate.shs" Once: true)
+
+[1] | Do(solution) | Assert.Is(1)
+[1 2 3 4 5] | Do(solution) | Assert.Is(15)
+[-5 2 3] | Do(solution) | Assert.Is(0)
+[100 -20 7] | Do(solution) | Assert.Is(87)

--- a/benchmarks/shardsbench/tasks/dev/core/uppercase-name/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/core/uppercase-name/prompt.md
@@ -1,0 +1,3 @@
+Define a wire named `solution` that receives a table containing a string field named
+`name`. Output that name converted to uppercase. Other table fields must not affect the
+result.

--- a/benchmarks/shardsbench/tasks/dev/core/uppercase-name/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/uppercase-name/reference.shs
@@ -1,0 +1,3 @@
+@wire(solution {
+  Take("name") | String.ToUpper
+})

--- a/benchmarks/shardsbench/tasks/dev/core/uppercase-name/task.json
+++ b/benchmarks/shardsbench/tasks/dev/core/uppercase-name/task.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "core/uppercase-name",
+  "title": "Read and uppercase a table field",
+  "track": "generation",
+  "difficulty": "easy",
+  "tags": ["core", "table", "string"],
+  "timeout_seconds": 5
+}

--- a/benchmarks/shardsbench/tasks/dev/core/uppercase-name/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/core/uppercase-name/tests.shs
@@ -1,0 +1,6 @@
+@include("candidate.shs" Once: true)
+
+{name: "alice"} | Do(solution) | Assert.Is("ALICE")
+{name: "Shards" age: 12} | Do(solution) | Assert.Is("SHARDS")
+{active: true name: "mixed Case"} | Do(solution) | Assert.Is("MIXED CASE")
+{name: ""} | Do(solution) | Assert.Is("")

--- a/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/prompt.md
@@ -1,0 +1,3 @@
+Repair the starter program. The `solution` wire receives a base-10 integer encoded as a
+string and must output the parsed integer plus one. Preserve the wire name and return a
+complete corrected source file.

--- a/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/reference.shs
@@ -1,0 +1,3 @@
+@wire(solution {
+  ParseInt | Add(1)
+})

--- a/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/starter.shs
+++ b/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/starter.shs
@@ -1,0 +1,3 @@
+@wire(solution {
+  Add(1)
+})

--- a/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/task.json
+++ b/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/task.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "repair/parse-and-increment",
+  "title": "Repair a string-to-integer flow",
+  "track": "repair",
+  "difficulty": "easy",
+  "tags": ["repair", "type-mismatch", "string", "integer"],
+  "timeout_seconds": 5,
+  "starter": "starter.shs"
+}

--- a/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/repair/parse-and-increment/tests.shs
@@ -1,0 +1,6 @@
+@include("candidate.shs" Once: true)
+
+"0" | Do(solution) | Assert.Is(1)
+"41" | Do(solution) | Assert.Is(42)
+"-8" | Do(solution) | Assert.Is(-7)
+"999" | Do(solution) | Assert.Is(1000)

--- a/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/prompt.md
+++ b/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/prompt.md
@@ -1,0 +1,2 @@
+Repair the starter program. The `solution` wire receives a string and must output its
+uppercase form. Preserve the wire name and return a complete corrected source file.

--- a/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/reference.shs
+++ b/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/reference.shs
@@ -1,0 +1,3 @@
+@wire(solution {
+  String.ToUpper
+})

--- a/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/starter.shs
+++ b/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/starter.shs
@@ -1,0 +1,3 @@
+@wire(solution {
+  String.Upper
+})

--- a/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/task.json
+++ b/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/task.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "repair/uppercase-shard",
+  "title": "Repair an unknown string shard",
+  "track": "repair",
+  "difficulty": "easy",
+  "tags": ["repair", "unknown-shard", "string"],
+  "timeout_seconds": 5,
+  "starter": "starter.shs"
+}

--- a/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/tests.shs
+++ b/benchmarks/shardsbench/tasks/dev/repair/uppercase-shard/tests.shs
@@ -1,0 +1,5 @@
+@include("candidate.shs" Once: true)
+
+"hello" | Do(solution) | Assert.Is("HELLO")
+"Already Mixed" | Do(solution) | Assert.Is("ALREADY MIXED")
+"" | Do(solution) | Assert.Is("")

--- a/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/prompt.md
+++ b/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/prompt.md
@@ -1,0 +1,18 @@
+Build a small but complete dashboard application as a looped wire named `solution`.
+
+The app must:
+
+- open a 640×480 `GFX.MainWindow` titled `ShardsBench Dashboard`;
+- create and render a green built-in cube using a draw queue, transform/base-color
+  features, a drawable pass, a camera view, and a rotation that changes each frame;
+- create a UI draw queue and UI pass after the drawable pass;
+- render a top-panel title and a central panel containing the current frame label, a
+  progress bar, and a `Reset` button;
+- initialize a mutable global integer named `app-frame-count` to zero exactly once;
+- increment `app-frame-count` once per rendered frame in the outer looped `solution`
+  wire, immediately before `GFX.MainWindow`;
+- make the Reset button set `app-frame-count` back to zero when clicked;
+- render both the scene and UI every frame.
+
+Use canonical `Set`, `Update`, and `Push` word forms. Define the application only; the
+grader supplies the mesh, schedules `solution`, and runs exactly eight frames.

--- a/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/reference.shs
+++ b/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/reference.shs
@@ -1,0 +1,49 @@
+@wire(solution {
+  Once({
+    0 | Set(app-frame-count Global: true)
+
+    GFX.BuiltinMesh(Type: BuiltinMeshType::Cube) | Set(cube-mesh)
+    GFX.BuiltinFeature(Id: BuiltinFeatureId::Transform) | Push(scene-features)
+    GFX.BuiltinFeature(Id: BuiltinFeatureId::BaseColor) | Push(scene-features)
+    GFX.DrawQueue | Set(scene-queue)
+    GFX.DrawablePass(Features: scene-features Queue: scene-queue) | Push(render-steps)
+
+    GFX.DrawQueue | Set(ui-queue)
+    GFX.UIPass(ui-queue) | Push(render-steps)
+
+    {Position: @f3(0 0 8) Target: @f3(0 0 0)} | Math.LookAt | Set(view-transform)
+    GFX.View(View: view-transform) | Set(view)
+  })
+
+  none | Get(app-frame-count Global: true Default: 0)
+  Add(1) | Update(app-frame-count Global: true)
+
+  GFX.MainWindow(
+    Title: "ShardsBench Dashboard"
+    Width: 640
+    Height: 480
+    Contents: {
+      none | Get(app-frame-count Global: true Default: 0)
+      ToFloat | Mul(0.1) | Math.AxisAngleY | Math.Rotation
+      GFX.Drawable(Mesh: cube-mesh Params: {baseColor: @f4(0.1 0.8 0.2 1.0)})
+      GFX.Draw(scene-queue)
+
+      UI({
+        UI.TopPanel(Contents: {
+          "ShardsBench Dashboard" | UI.Label
+        })
+        UI.CentralPanel(Contents: {
+          none | Get(app-frame-count Global: true Default: 0) | Set(current-frame)
+          ["Frame: " current-frame] | String.Format | UI.Label
+          current-frame | ToFloat | Div(8.0) | Min(1.0)
+          UI.ProgressBar(Overlay: "Eight-frame benchmark")
+          UI.Button(Label: "Reset" Action: {
+            0 | Update(app-frame-count Global: true)
+          })
+        })
+      }) | UI.Render(ui-queue)
+
+      GFX.Render(Steps: render-steps View: view)
+    }
+  )
+} Looped: true)

--- a/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/task.json
+++ b/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/task.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "id": "apps/ui-gfx-dashboard",
+  "title": "Build a bounded UI and GFX dashboard",
+  "track": "app",
+  "difficulty": "hard",
+  "tags": ["app", "gfx", "ui", "rendering", "state", "wire"],
+  "timeout_seconds": 20,
+  "requirements": {
+    "shards": [
+      "GFX.MainWindow",
+      "GFX.BuiltinMesh",
+      "GFX.BuiltinFeature",
+      "GFX.DrawQueue",
+      "GFX.DrawablePass",
+      "GFX.Drawable",
+      "GFX.Draw",
+      "GFX.UIPass",
+      "GFX.Render",
+      "UI",
+      "UI.TopPanel",
+      "UI.CentralPanel",
+      "UI.Label",
+      "UI.ProgressBar",
+      "UI.Button",
+      "UI.Render"
+    ]
+  }
+}

--- a/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/tests.shs
+++ b/benchmarks/shardsbench/tasks/extended/apps/ui-gfx-dashboard/tests.shs
@@ -1,0 +1,17 @@
+@include("candidate.shs" Once: true)
+
+@mesh(root)
+
+@wire(observer {
+  Once({
+    0 | Set(observer-frame)
+  })
+  observer-frame | Add(1) | Update(observer-frame)
+  observer-frame | When({Is(8)} {
+    none | Get(app-frame-count Global: true Default: -1) | Assert.Is(8)
+  })
+} Looped: true)
+
+@schedule(root solution)
+@schedule(root observer)
+@run(root FPS: 60 Iterations: 8) | Assert.Is(true)

--- a/benchmarks/shardsbench/tests/__init__.py
+++ b/benchmarks/shardsbench/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for ShardsBench."""

--- a/benchmarks/shardsbench/tests/test_core.py
+++ b/benchmarks/shardsbench/tests/test_core.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 from shardsbench.core import (
     BenchmarkError,
+    SENTINEL_FILE,
+    _sentinel_lines,
+    _sentinel_reached,
     _solution_function_names,
+    _toplevel_violations,
     aggregate,
     discover_tasks,
     extract_candidate,
@@ -62,6 +66,7 @@ class AggregationTests(unittest.TestCase):
                     "parse_at_1": True,
                     "construct_at_1": True,
                     "compose_at_1": True,
+                    "contract_at_1": True,
                     "requirements_at_1": True,
                     "pass_at_1": True,
                 },
@@ -73,6 +78,7 @@ class AggregationTests(unittest.TestCase):
                     "parse_at_1": True,
                     "construct_at_1": False,
                     "compose_at_1": False,
+                    "contract_at_1": False,
                     "requirements_at_1": False,
                     "pass_at_1": False,
                 },
@@ -107,6 +113,87 @@ class AstRequirementTests(unittest.TestCase):
         self.assertEqual(
             _solution_function_names(ast), ["GFX.MainWindow", "UI.Label"]
         )
+
+
+class ContractTests(unittest.TestCase):
+    # Mirrors the real `shards ast` shape: a top-level sequence of pipelines,
+    # each pipeline a list of blocks keyed by content kind plus line_info.
+    def test_accepts_definition_only_candidates(self) -> None:
+        ast = {
+            "sequence": [
+                [
+                    {
+                        "func": {"name": "wire", "params": [{"id": {"name": "solution"}}]},
+                        "line_info": {"line": 1, "column": 1},
+                    }
+                ],
+                [
+                    {
+                        "func": {"name": "define", "params": [{"id": {"name": "x"}}]},
+                        "line_info": {"line": 4, "column": 1},
+                    }
+                ],
+            ]
+        }
+        self.assertEqual(_toplevel_violations(ast), [])
+
+    def test_flags_toplevel_shard_statements(self) -> None:
+        ast = {
+            "sequence": [
+                [
+                    {
+                        "func": {"name": "wire", "params": [{"id": {"name": "solution"}}]},
+                        "line_info": {"line": 1, "column": 1},
+                    }
+                ],
+                [
+                    {"const": {"num": {"int": 0}}, "line_info": {"line": 5, "column": 1}},
+                    {"sh": {"name": "Stop"}, "line_info": {"line": 5, "column": 5}},
+                ],
+            ]
+        }
+        violations = _toplevel_violations(ast)
+        self.assertEqual(
+            [(v["kind"], v["line"]) for v in violations],
+            [("const", 5), ("sh", 5)],
+        )
+
+    def test_flags_disallowed_funcs_and_malformed_input(self) -> None:
+        ast = {
+            "sequence": [
+                [
+                    {
+                        "func": {"name": "schedule", "params": []},
+                        "line_info": {"line": 2, "column": 1},
+                    }
+                ]
+            ]
+        }
+        self.assertEqual(
+            _toplevel_violations(ast),
+            [{"kind": "func", "name": "schedule", "line": 2}],
+        )
+        self.assertTrue(_toplevel_violations("not an ast"))
+        self.assertTrue(_toplevel_violations({"sequence": "bogus"}))
+
+
+class SentinelTests(unittest.TestCase):
+    def test_sentinel_lines_never_embed_a_token(self) -> None:
+        lines = _sentinel_lines("shardsbench-sentinel-cafe0123")
+        self.assertIn(SENTINEL_FILE, lines)
+        self.assertIn("@define(shardsbench-sentinel-cafe0123", lines)
+        self.assertIn("IgnoreRedefined: true", lines)
+        self.assertIn("Contents: @shardsbench-sentinel-cafe0123", lines)
+        self.assertIn("FS.Write", lines)
+
+    def test_sentinel_reached_requires_exact_token(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            self.assertFalse(_sentinel_reached(workspace, "token"))
+            (workspace / SENTINEL_FILE).write_text("other", encoding="utf-8")
+            self.assertFalse(_sentinel_reached(workspace, "token"))
+            (workspace / SENTINEL_FILE).write_text("token", encoding="utf-8")
+            self.assertTrue(_sentinel_reached(workspace, "token"))
 
 
 if __name__ == "__main__":

--- a/benchmarks/shardsbench/tests/test_core.py
+++ b/benchmarks/shardsbench/tests/test_core.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from shardsbench.core import (
+    BenchmarkError,
+    _solution_function_names,
+    aggregate,
+    discover_tasks,
+    extract_candidate,
+)
+
+
+class CandidateExtractionTests(unittest.TestCase):
+    def test_prefers_labeled_shards_fence(self) -> None:
+        source, mode = extract_candidate(
+            "Explanation\n```text\nignore\n```\n```shards\n@wire(solution {Mul(2)})\n```"
+        )
+        self.assertEqual(source, "@wire(solution {Mul(2)})\n")
+        self.assertEqual(mode, "shards_fence")
+
+    def test_accepts_raw_source(self) -> None:
+        source, mode = extract_candidate("  @wire(solution {Add(1)})  ")
+        self.assertEqual(source, "@wire(solution {Add(1)})\n")
+        self.assertEqual(mode, "raw")
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_rejects_duplicate_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for name in ("a", "b"):
+                task = root / name
+                task.mkdir()
+                manifest = {
+                    "schema_version": 1,
+                    "id": "duplicate",
+                    "title": name,
+                    "track": "generation",
+                    "difficulty": "easy",
+                    "tags": []
+                }
+                (task / "task.json").write_text(json.dumps(manifest), encoding="utf-8")
+                for filename in ("prompt.md", "tests.shs", "reference.shs"):
+                    (task / filename).write_text("placeholder", encoding="utf-8")
+            with self.assertRaises(BenchmarkError):
+                discover_tasks(root)
+
+
+class AggregationTests(unittest.TestCase):
+    def test_aggregates_stage_rates(self) -> None:
+        result = aggregate(
+            [
+                {
+                    "status": "passed",
+                    "track": "generation",
+                    "difficulty": "easy",
+                    "candidate_at_1": True,
+                    "parse_at_1": True,
+                    "construct_at_1": True,
+                    "compose_at_1": True,
+                    "requirements_at_1": True,
+                    "pass_at_1": True,
+                },
+                {
+                    "status": "check_failed",
+                    "track": "repair",
+                    "difficulty": "easy",
+                    "candidate_at_1": True,
+                    "parse_at_1": True,
+                    "construct_at_1": False,
+                    "compose_at_1": False,
+                    "requirements_at_1": False,
+                    "pass_at_1": False,
+                },
+            ]
+        )
+        self.assertEqual(result["candidate_at_1"], 1.0)
+        self.assertEqual(result["parse_at_1"], 1.0)
+        self.assertEqual(result["construct_at_1"], 0.5)
+        self.assertEqual(result["pass_at_1"], 0.5)
+        self.assertEqual(result["by_track"]["generation"]["pass_at_1"], 1.0)
+        self.assertEqual(result["by_track"]["repair"]["pass_at_1"], 0.0)
+
+
+class AstRequirementTests(unittest.TestCase):
+    def test_collects_only_functions_inside_solution_wire(self) -> None:
+        ast = {
+            "sequence": [
+                {"func": {"name": "wire", "params": [
+                    {"id": {"name": "helper"}},
+                    {"shards": [{"func": {"name": "Wrong", "params": []}}]},
+                ]}},
+                {"func": {"name": "wire", "params": [
+                    {"id": {"name": "solution"}},
+                    {"shards": [
+                        {"sh": {"name": "GFX.MainWindow", "params": [
+                            {"sh": {"name": "UI.Label", "params": []}}
+                        ]}}
+                    ]},
+                ]}},
+            ]
+        }
+        self.assertEqual(
+            _solution_function_names(ast), ["GFX.MainWindow", "UI.Label"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dependency-free ShardsBench task loader, evaluator, schema, and reporting CLI
- add seven headless generation/repair tasks and one bounded UI/GFX dashboard app task
- grade extraction, parse, construction, composition, AST requirements, and runtime semantics
- document an isolated, auditable code-generation run protocol that keeps references and graders away from models

## Test plan
- `python3 -m unittest discover -s benchmarks/shardsbench -t benchmarks/shardsbench -v`
- `python3 benchmarks/shardsbench/run.py validate`
- `python3 benchmarks/shardsbench/run.py validate --suite extended`
- `git diff --check`

## Notes
- the checked-in suites are public development fixtures, not contamination-resistant leaderboard tasks
- the extended suite opens a bounded 640x480 UI/GFX window and should remain separate from the portable headless score