### PR TITLE
deps: bump candle 0.10.2 -> 0.11.0, mistral.rs 0.8.1 -> 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,16 +1014,15 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+version = "0.11.0"
+source = "git+https://github.com/huggingface/candle.git?rev=27f20fea993c81ea6d32ce44018f42b68466525e#27f20fea993c81ea6d32ce44018f42b68466525e"
 dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
- "cudarc 0.19.4",
+ "cudarc 0.19.8",
  "float8",
  "gemm 0.19.0",
  "half",
@@ -1034,31 +1033,31 @@ dependencies = [
  "num_cpus",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "rayon",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "thiserror 2.0.18",
  "tokenizers 0.22.2",
  "yoke 0.8.1",
- "zip 7.2.0",
+ "zerocopy",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "candle-kernels"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742e2ac226b777134436e9e692f44e77c278b8a7abb1554dc10e44dc911b349f"
+version = "0.11.0"
+source = "git+https://github.com/huggingface/candle.git?rev=27f20fea993c81ea6d32ce44018f42b68466525e#27f20fea993c81ea6d32ce44018f42b68466525e"
 dependencies = [
  "cudaforge",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
+version = "0.11.0"
+source = "git+https://github.com/huggingface/candle.git?rev=27f20fea993c81ea6d32ce44018f42b68466525e#27f20fea993c81ea6d32ce44018f42b68466525e"
 dependencies = [
+ "block2 0.6.2",
  "half",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -1070,9 +1069,8 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+version = "0.11.0"
+source = "git+https://github.com/huggingface/candle.git?rev=27f20fea993c81ea6d32ce44018f42b68466525e#27f20fea993c81ea6d32ce44018f42b68466525e"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -1082,24 +1080,23 @@ dependencies = [
  "num-traits",
  "objc2-metal 0.3.2",
  "rayon",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "candle-transformers"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+version = "0.11.0"
+source = "git+https://github.com/huggingface/candle.git?rev=27f20fea993c81ea6d32ce44018f42b68466525e#27f20fea993c81ea6d32ce44018f42b68466525e"
 dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-core",
  "candle-nn",
- "fancy-regex 0.17.0",
+ "fancy-regex 0.18.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rayon",
  "serde",
  "serde_json",
@@ -1109,9 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "candle-ug"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
+version = "0.11.0"
+source = "git+https://github.com/huggingface/candle.git?rev=27f20fea993c81ea6d32ce44018f42b68466525e#27f20fea993c81ea6d32ce44018f42b68466525e"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -1935,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.4"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "float8",
  "half",
@@ -3034,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
@@ -3197,7 +3193,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
 ]
 
@@ -4120,7 +4116,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "zerocopy",
 ]
@@ -4255,7 +4251,7 @@ dependencies = [
  "log",
  "native-tls",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.9.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5093,6 +5089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5644,9 +5651,8 @@ dependencies = [
 
 [[package]]
 name = "mistralrs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb0a83340b4492ebba9760ba6845364de369c7e10c1f91af8733d574c7405fa"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -5658,7 +5664,7 @@ dependencies = [
  "indexmap 2.13.0",
  "mistralrs-core",
  "mistralrs-macros",
- "rand 0.9.2",
+ "rand 0.9.5",
  "reqwest 0.13.2",
  "schemars 1.2.1",
  "serde",
@@ -5672,9 +5678,8 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-audio"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5d36f634c7c20c45845bc995be3b6387ab01048410386a5b180cfeaf89c72"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "anyhow",
  "apodize",
@@ -5683,10 +5688,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mistralrs-code-exec"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "image",
+ "libc",
+ "mistralrs-mcp",
+ "mistralrs-sandbox",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "uuid 1.22.0",
+]
+
+[[package]]
 name = "mistralrs-core"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b8b9e5c94491d9ceeded3a30291cb6af6ae74810a5776dd55e3bbb8b3429d4"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "ahash",
  "akin",
@@ -5727,12 +5750,15 @@ dependencies = [
  "libc",
  "llguidance",
  "lrtable",
+ "mime_guess",
  "minijinja",
  "minijinja-contrib",
  "mistralrs-audio",
+ "mistralrs-code-exec",
  "mistralrs-mcp",
  "mistralrs-paged-attn",
  "mistralrs-quant",
+ "mistralrs-sandbox",
  "mistralrs-vision",
  "num-traits",
  "objc",
@@ -5741,7 +5767,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "radix_trie",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "rand_isaac",
  "rayon",
@@ -5752,7 +5778,7 @@ dependencies = [
  "rust-mcp-schema",
  "rustc-hash 2.1.1",
  "rustfft",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "schemars 1.2.1",
  "scraper",
  "serde",
@@ -5783,9 +5809,8 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-macros"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa9b4794322d3f89fe61d21f33f67be494c16d5bd869604b111218f32544d32"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2 1.0.106",
@@ -5795,14 +5820,14 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-mcp"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa97d4e3189ed80ebbc730b7da5b2356df0ae004ab489066249340c33c089ab"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures-util",
  "http",
+ "image",
  "reqwest 0.13.2",
  "rust-mcp-schema",
  "serde",
@@ -5815,10 +5840,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mistralrs-metal-compile"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
+dependencies = [
+ "candle-metal-kernels",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
 name = "mistralrs-paged-attn"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e53ddf1537426997b46abdadbe6ca8a7ce7668004ed2b7cf00115016558bae8"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -5827,6 +5860,7 @@ dependencies = [
  "dispatch2",
  "float8",
  "half",
+ "mistralrs-metal-compile",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
  "thiserror 2.0.18",
@@ -5834,9 +5868,8 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-quant"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980715493d252e9aaf0779c4c101576d67ef4dd9812bfd77a54987f6f17526f4"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -5845,18 +5878,23 @@ dependencies = [
  "cudaforge",
  "dispatch2",
  "float8",
+ "futures",
  "half",
  "hf-hub",
+ "indicatif 0.18.4",
  "lazy_static",
+ "libc",
  "memmap2 0.9.10",
+ "mistralrs-metal-compile",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
  "paste",
  "rayon",
  "regex",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5864,10 +5902,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mistralrs-sandbox"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
+dependencies = [
+ "anyhow",
+ "itoa",
+ "landlock",
+ "libc",
+ "nix 0.31.3",
+ "seccompiler",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "mistralrs-vision"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10046a3da2de5b702d3e829b5ddef7aa829ad454819dcc4876dea481a6cb5456"
+version = "0.9.0"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?tag=v0.9.0#54957525b8b648108000af2004a4991cf08c0e69"
 dependencies = [
  "candle-core",
  "image",
@@ -7548,7 +7602,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -7627,9 +7681,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -7707,7 +7761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -7752,7 +7806,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -8536,13 +8590,15 @@ dependencies = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -8705,6 +8761,15 @@ dependencies = [
  "hybrid-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -9367,7 +9432,7 @@ dependencies = [
  "mistralrs",
  "ndarray",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "serde_json",
  "shards",
@@ -9415,7 +9480,7 @@ version = "0.1.0"
 dependencies = [
  "compile-time-crc32",
  "lazy_static",
- "rand 0.9.2",
+ "rand 0.9.5",
  "shards",
 ]
 
@@ -10511,7 +10576,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -10544,7 +10609,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -10966,7 +11031,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -12824,6 +12889,18 @@ dependencies = [
  "memchr",
  "typed-path",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -17,6 +17,11 @@ if(NOT RUST_CARGO_TARGET)
   elseif(APPLE)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
       list(APPEND RUST_FLAGS -Ctarget-feature=+fp16,+fhm)
+      # candle >=0.11's aarch64 fp16 NEON kernel uses the unstable `float16x8_t`
+      # (stdarch_neon_f16) intrinsic type unconditionally under `+fp16`, which we
+      # enable above. candle doesn't declare the feature itself, so inject it as a
+      # crate attribute (our pinned nightly has the feature). See shards/modules/candle.
+      list(APPEND RUST_FLAGS "-Zcrate-attr=feature(stdarch_neon_f16)")
     endif()
 
     if(VISIONOS)
@@ -424,6 +429,8 @@ function(add_rust_library)
 
   if(ANDROID)
     list(APPEND RUST_FLAGS -Ctarget-feature=+fp16)
+    # See Apple arm64 note above: candle >=0.11's fp16 NEON path needs stdarch_neon_f16.
+    list(APPEND RUST_FLAGS "-Zcrate-attr=feature(stdarch_neon_f16)")
   endif()
 
   if(EMSCRIPTEN_ROOT_PATH)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -11,6 +11,10 @@ if(NOT CMAKE_PROPERTIES_TO_DUPLICATE)
     "INTERFACE_HEADER_SETS" "HEADER_SETS"
     "INTERFACE_CXX_MODULE_HEADER_UNIT_SETS" "CXX_MODULE_HEADER_UNIT_SETS"
     "INTERFACE_CXX_MODULE_SETS" "CXX_MODULE_SETS"
+    # CMake 4.4+ added SOURCE_SETS/INTERFACE_SOURCE_SETS as read-only target
+    # properties; like the other *_SETS above they can't be copied via
+    # set_target_properties, so exclude them from duplication.
+    "INTERFACE_SOURCE_SETS" "SOURCE_SETS"
     "BINARY_DIR" "IMPORTED" "SOURCE_DIR"
     "MANUALLY_ADDED_DEPENDENCIES"
     "SYMBOLIC"

--- a/shards/modules/candle/Cargo.toml
+++ b/shards/modules/candle/Cargo.toml
@@ -13,14 +13,19 @@ crate-type = ["rlib", "staticlib"]
 lazy_static = "1.5.0"
 shards = { path = "../../rust" }
 compile-time-crc32 = "0.1.2"
-tokenizers = { version = "0.21.0", default-features = false, features = [
+tokenizers = { version = "0.21.4", default-features = false, features = [
   "onig",
 ] }
 
-mistralrs = { version = "0.8.1", default-features = false, optional = true }
-candle-core = "0.10.2"
-candle-nn = "0.10.2"
-candle-transformers = "0.10.2"
+# mistral.rs has no crates.io release past 0.8.1 (which pins candle ^0.10.2);
+# candle 0.11 is only reachable via the v0.9.0 git tag. That tag pins candle to
+# a specific git rev (NOT crates.io 0.11.0), so we MUST match the exact same rev
+# below or Cargo resolves two incompatible candle copies (breaking Tensor interop
+# and the metal/cuda feature unification with mistralrs).
+mistralrs = { git = "https://github.com/EricLBuehler/mistral.rs.git", tag = "v0.9.0", default-features = false, optional = true }
+candle-core = { git = "https://github.com/huggingface/candle.git", rev = "27f20fea993c81ea6d32ce44018f42b68466525e" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", rev = "27f20fea993c81ea6d32ce44018f42b68466525e" }
+candle-transformers = { git = "https://github.com/huggingface/candle.git", rev = "27f20fea993c81ea6d32ce44018f42b68466525e" }
 
 rand = { version = "0.9", default-features = false, features = ["std_rng"] }
 anyhow = "1.0.80"


### PR DESCRIPTION
## Summary

Bumps **candle 0.10.2 → 0.11.0**. candle can't be bumped independently: mistral.rs's crates.io release is frozen at 0.8.1 (which pins candle `^0.10.2`), so candle 0.11 is only reachable through mistral.rs's **git tag v0.9.0**, which itself pins candle to a specific git rev. Our candle deps use that exact rev so Cargo resolves a **single** candle copy — otherwise `Tensor` interop and the `metal`/`cuda` feature unification with `mistralrs` break (registry vs git are distinct sources).

## Changes

- **candle-core/nn/transformers** 0.10.2 → 0.11.0 (git rev `27f20fea`, matching mistral.rs v0.9.0)
- **mistralrs** 0.8.1 (crates.io) → **v0.9.0** (git tag)
- **tokenizers** 0.21.0 → 0.21.4; `rand`/`safetensors` bumped transitively
- No module source changes — mistral.rs 0.9.0's API is compatible with `llm.rs`, and candle 0.11 needed no tensor-code changes

## candle 0.11 fp16 / nightly feature

candle ≥0.11's aarch64 fp16 NEON kernel uses the unstable `stdarch_neon_f16` intrinsic type unconditionally under `+fp16` (which the build enables) without declaring the feature. Enabled via `-Zcrate-attr=feature(stdarch_neon_f16)` at the `+fp16` sites in `Rust.cmake` (Apple arm64 + Android). Keeps the optimized path; the build is already nightly with unstable flags.

## CMake 4.4 fix (separate commit)

Independent build fix: CMake 4.4 made `SOURCE_SETS`/`INTERFACE_SOURCE_SETS` read-only target properties, which `duplicate_library_target` tripped on when reconfiguring an existing build dir. Added them to the ignore list, matching the existing `HEADER_SETS`/`CXX_MODULE_SETS` entries.

## Testing

Local — macOS, Apple M4 Max, Metal, Release:
- Full `just build-rel` — clean compile + link, `shards` binary runs
- `ml-test.shs` — real BERT forward pass via candle 0.11 on Metal ✓
- `ml.shs` — tensor ops (Transpose / Sum / Split / Stack / UMAP / ToFloatNs) ✓
- Tensor runtime smoke — `Tensor.Mul` + `Tensor.Sum` dot product = 30 ✓
